### PR TITLE
feat(repo): Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,42 @@
+# Code of Conduct
+
+## Purpose
+A welcoming, safe, and productive community for everyone.
+
+## Scope
+This Code applies to all project spaces (repo, issues, PRs, discussions, chats) and to anyone participating.
+
+## Our Standards
+**Do:**
+- Be respectful and constructive.
+- Welcome questions and assume good intent.
+- Provide actionable, kind feedback.
+- Use inclusive language.
+
+**Do not:**
+- Harass, insult, or demean.
+- Discriminate based on personal characteristics.
+- Disrupt discussions or derail threads.
+- Share others’ private information without consent.
+
+## Reporting
+If you experience or witness unacceptable behavior:
+- Email a maintainer listed in `MAINTAINERS.md`, or
+- Open a private report via the “Report abuse” link on GitHub, or
+- If needed, contact another trusted community member.
+
+Provide: what happened, where, when, links or screenshots, and any prior context.
+
+## Enforcement
+- Maintainers may take any action they deem appropriate, including warnings, issue/PR locks, temporary bans, or removal from the community.
+- Severe or repeated violations may result in permanent ban.
+- Actions will be documented in a private moderation log.
+
+## Appeals
+If you believe an action was taken in error, contact the maintainers with context. Appeals will be reviewed by maintainers not directly involved.
+
+## Attribution
+Inspired by community norms across open source projects, tailored for this repository.
+
+## Updates
+This Code may evolve. Proposed changes should be submitted as a PR.


### PR DESCRIPTION
## What  
Add `CODE_OF_CONDUCT.md` to the repo root

Resolves: #14 
Relates to: #8 

## Why  
To provide orientation on the terms and manner of contributions.

## How  

* Added standards (DOs and DON'Ts)
* Added contact reference to `MAINTAINERS.md`
* Added different info 

## Notes  
<!-- Breaking changes or follow-ups (if any). -->

## Checklist  
[x] I have used conventional commits (conventionalcommits.com)
[ ] I have updated the documentation
[ ] I have updated the relevant RFC and its linked resources
[ ] I have added tests
[ ] I ran manual tests