### PR TITLE
feat: dataset svc, export worker and client helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ go.work.sum
 # .idea/
 # .vscode/
 .cache
+.gocache
 coverage.summary
 coverage.summary

--- a/Makefile
+++ b/Makefile
@@ -63,4 +63,3 @@ go-test:
 	@echo "Coverage check passed (>= $(COVER_THRESHOLD)% )"
 
 test: go-test
-

--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ ColonyCore is an extensible base module for laboratory colony management. It cou
 - Validate the governance registry using `make registry-lint` or by running `go run ./cmd/registry-check --registry docs/rfc/registry.yaml`.
 - Refer to `CONTRIBUTING.md` for coding standards, workflow expectations, and pull request guidance.
 
+## Dataset analytics
+- The dataset REST surface is documented in `docs/schema/dataset-service.openapi.yaml` and exposes
+  template enumeration, parameter validation, streaming results (JSON/CSV), and asynchronous exports.
+- Species plugins register versioned dataset templates through the core plugin registry; see
+  `internal/core/dataset.go` and the frog reference module (`plugins/frog`) for a working example aligned
+  with RFC 0001's reporting guidance.
+- A background export worker (package `internal/dataset`) applies RBAC scope filters, emits audit entries,
+  stores signed artifacts in the managed object store, and serves export status via `/api/v1/datasets/exports`.
+- Sample analyst clients are provided in `clients/python/dataset_client.py` (requests-based) and
+  `clients/R/dataset_client.R` (httr-based) to illustrate reproducing exports from external runtimes.
+
 ## Testing
 - `make test` runs the race-enabled Go test suite and enforces the configured coverage threshold.
 - `make lint` chains formatting checks, vetting, registry validation, and `golangci-lint` (install instructions are in the Makefile). Use `SKIP_GOLANGCI=1 make lint` to bypass the aggregated linter when necessary.

--- a/clients/R/dataset_client.R
+++ b/clients/R/dataset_client.R
@@ -1,0 +1,128 @@
+# Sample R helper for ColonyCore Dataset Service API
+# Requires the httr and jsonlite packages.
+
+library(httr)
+library(jsonlite)
+
+cc_dataset_headers <- function(token = NULL) {
+  headers <- add_headers(
+    `User-Agent` = "colonycore-dataset-client/0.1",
+    Accept = "application/json"
+  )
+  if (!is.null(token) && nzchar(token)) {
+    headers <- add_headers(headers, Authorization = paste("Bearer", token))
+  }
+  headers
+}
+
+cc_list_templates <- function(base_url, token = NULL, timeout = 30) {
+  url <- paste0(rtrim(base_url), "/api/v1/datasets/templates")
+  resp <- GET(url, cc_dataset_headers(token), timeout(timeout))
+  stop_for_status(resp)
+  content(resp, as = "parsed", simplifyVector = TRUE)$templates
+}
+
+cc_get_template <- function(base_url, plugin, key, version, token = NULL, timeout = 30) {
+  url <- sprintf("%s/api/v1/datasets/templates/%s/%s/%s", rtrim(base_url), plugin, key, version)
+  resp <- GET(url, cc_dataset_headers(token), timeout(timeout))
+  stop_for_status(resp)
+  content(resp, as = "parsed", simplifyVector = TRUE)$template
+}
+
+cc_validate_template <- function(base_url, plugin, key, version, parameters = list(), token = NULL, timeout = 30) {
+  url <- sprintf("%s/api/v1/datasets/templates/%s/%s/%s/validate", rtrim(base_url), plugin, key, version)
+  resp <- POST(url, cc_dataset_headers(token), timeout(timeout), body = list(parameters = parameters), encode = "json")
+  stop_for_status(resp)
+  content(resp, as = "parsed", simplifyVector = TRUE)
+}
+
+cc_run_template <- function(base_url, plugin, key, version, parameters = list(), scope = list(), format = "json", token = NULL, timeout = 60) {
+  url <- sprintf("%s/api/v1/datasets/templates/%s/%s/%s/run", rtrim(base_url), plugin, key, version)
+  query <- list(format = tolower(format))
+  headers <- cc_dataset_headers(token)
+  if (tolower(format) == "csv") {
+    headers <- add_headers(headers, Accept = "text/csv")
+  }
+  resp <- POST(url, headers, timeout(timeout), query = query, body = list(parameters = parameters, scope = scope), encode = "json")
+  stop_for_status(resp)
+  if (tolower(format) == "csv") {
+    return(content(resp, as = "text", encoding = "UTF-8"))
+  }
+  content(resp, as = "parsed", simplifyVector = TRUE)
+}
+
+cc_queue_export <- function(
+  base_url,
+  template_slug = NULL,
+  plugin = NULL,
+  key = NULL,
+  version = NULL,
+  parameters = list(),
+  scope = list(),
+  formats = character(),
+  requested_by = NULL,
+  reason = NULL,
+  project_id = NULL,
+  protocol_id = NULL,
+  token = NULL,
+  timeout = 30
+) {
+  template <- if (!is.null(template_slug) && nzchar(template_slug)) {
+    list(slug = template_slug)
+  } else {
+    if (any(!nzchar(c(plugin, key, version)))) {
+      stop("plugin, key, and version must be supplied when slug is omitted", call. = FALSE)
+    }
+    list(plugin = plugin, key = key, version = version)
+  }
+  body <- list(
+    template = template,
+    parameters = parameters,
+    scope = scope,
+    formats = as.list(formats),
+    requested_by = requested_by,
+    reason = reason,
+    project_id = project_id,
+    protocol_id = protocol_id
+  )
+  url <- paste0(rtrim(base_url), "/api/v1/datasets/exports")
+  resp <- POST(url, cc_dataset_headers(token), timeout(timeout), body = body, encode = "json")
+  stop_for_status(resp)
+  content(resp, as = "parsed", simplifyVector = TRUE)$export
+}
+
+cc_get_export <- function(base_url, export_id, token = NULL, timeout = 30) {
+  url <- sprintf("%s/api/v1/datasets/exports/%s", rtrim(base_url), export_id)
+  resp <- GET(url, cc_dataset_headers(token), timeout(timeout))
+  stop_for_status(resp)
+  content(resp, as = "parsed", simplifyVector = TRUE)$export
+}
+
+cc_wait_for_export <- function(base_url, export_id, token = NULL, poll_seconds = 2, timeout = 300) {
+  deadline <- Sys.time() + timeout
+  repeat {
+    export <- cc_get_export(base_url, export_id, token = token)
+    if (export$status %in% c("succeeded", "failed")) {
+      return(export)
+    }
+    if (Sys.time() > deadline) {
+      stop(sprintf("export %s timed out", export_id), call. = FALSE)
+    }
+    Sys.sleep(poll_seconds)
+  }
+}
+
+cc_download_artifact <- function(url, path = NULL, token = NULL, timeout = 60) {
+  resp <- GET(url, cc_dataset_headers(token), timeout(timeout))
+  stop_for_status(resp)
+  if (is.null(path)) {
+    return(content(resp, as = "raw"))
+  }
+  dir.create(dirname(path), showWarnings = FALSE, recursive = TRUE)
+  writeBin(content(resp, as = "raw"), path)
+  invisible(path)
+}
+
+rtrim <- function(x) {
+  sub("/*$", "", x)
+}

--- a/clients/python/dataset_client.py
+++ b/clients/python/dataset_client.py
@@ -1,0 +1,173 @@
+"""Sample Python helper for the ColonyCore Dataset Service.
+
+This helper maps to the OpenAPI contract defined in docs/schema/dataset-service.openapi.yaml
+and demonstrates how analysts can script dataset access and exports from their own runtime.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional
+
+import requests
+
+_DEFAULT_HEADERS = {
+    "Accept": "application/json",
+    "User-Agent": "colonycore-dataset-client/0.1",
+}
+
+
+@dataclass
+class ExportHandle:
+    """Represents an asynchronous export job."""
+
+    id: str
+    status: str
+    artifacts: List[Dict[str, Any]]
+
+
+class DatasetClient:
+    """Thin convenience wrapper around the DatasetService REST API."""
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: Optional[str] = None,
+        timeout: int = 30,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self._session = session or requests.Session()
+        for header, value in _DEFAULT_HEADERS.items():
+            self._session.headers.setdefault(header, value)
+        if api_key:
+            self._session.headers.setdefault("Authorization", f"Bearer {api_key}")
+
+    # Template helpers -----------------------------------------------------
+    def list_templates(self) -> List[Dict[str, Any]]:
+        resp = self._session.get(f"{self._base_url}/api/v1/datasets/templates", timeout=self._timeout)
+        resp.raise_for_status()
+        payload = resp.json()
+        return payload.get("templates", [])
+
+    def get_template(self, plugin: str, key: str, version: str) -> Dict[str, Any]:
+        path = f"{self._base_url}/api/v1/datasets/templates/{plugin}/{key}/{version}"
+        resp = self._session.get(path, timeout=self._timeout)
+        resp.raise_for_status()
+        return resp.json()["template"]
+
+    def validate_template(
+        self,
+        plugin: str,
+        key: str,
+        version: str,
+        parameters: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        path = f"{self._base_url}/api/v1/datasets/templates/{plugin}/{key}/{version}/validate"
+        resp = self._session.post(path, json={"parameters": parameters or {}}, timeout=self._timeout)
+        resp.raise_for_status()
+        return resp.json()
+
+    def run_template(
+        self,
+        plugin: str,
+        key: str,
+        version: str,
+        parameters: Optional[Dict[str, Any]] = None,
+        scope: Optional[Dict[str, Any]] = None,
+        output_format: str = "json",
+    ) -> Any:
+        path = f"{self._base_url}/api/v1/datasets/templates/{plugin}/{key}/{version}/run"
+        headers = {}
+        fmt = output_format.lower()
+        if fmt == "csv":
+            headers["Accept"] = "text/csv"
+        payload = {
+            "parameters": parameters or {},
+            "scope": scope or {},
+        }
+        resp = self._session.post(path, params={"format": fmt}, json=payload, headers=headers, timeout=self._timeout)
+        resp.raise_for_status()
+        if fmt == "csv":
+            return resp.text
+        return resp.json()
+
+    # Export helpers -------------------------------------------------------
+    def queue_export(
+        self,
+        template_slug: Optional[str] = None,
+        *,
+        plugin: Optional[str] = None,
+        key: Optional[str] = None,
+        version: Optional[str] = None,
+        parameters: Optional[Dict[str, Any]] = None,
+        scope: Optional[Dict[str, Any]] = None,
+        formats: Optional[Iterable[str]] = None,
+        requested_by: Optional[str] = None,
+        reason: Optional[str] = None,
+        project_id: Optional[str] = None,
+        protocol_id: Optional[str] = None,
+    ) -> ExportHandle:
+        template: Dict[str, Any]
+        if template_slug:
+            template = {"slug": template_slug}
+        else:
+            if not all([plugin, key, version]):
+                raise ValueError("plugin, key, and version are required when slug is omitted")
+            template = {"plugin": plugin, "key": key, "version": version}
+        body = {
+            "template": template,
+            "parameters": parameters or {},
+            "scope": scope or {},
+            "formats": list(formats or []),
+            "requested_by": requested_by,
+            "reason": reason,
+            "project_id": project_id,
+            "protocol_id": protocol_id,
+        }
+        resp = self._session.post(f"{self._base_url}/api/v1/datasets/exports", json=body, timeout=self._timeout)
+        resp.raise_for_status()
+        payload = resp.json()["export"]
+        return ExportHandle(id=payload["id"], status=payload["status"], artifacts=payload.get("artifacts", []))
+
+    def get_export(self, export_id: str) -> ExportHandle:
+        resp = self._session.get(f"{self._base_url}/api/v1/datasets/exports/{export_id}", timeout=self._timeout)
+        resp.raise_for_status()
+        payload = resp.json()["export"]
+        return ExportHandle(id=payload["id"], status=payload["status"], artifacts=payload.get("artifacts", []))
+
+    def wait_for_export(
+        self,
+        export_id: str,
+        poll_interval: float = 2.0,
+        timeout: float = 300.0,
+    ) -> ExportHandle:
+        deadline = time.time() + timeout
+        handle = self.get_export(export_id)
+        while handle.status not in {"succeeded", "failed"}:
+            if time.time() > deadline:
+                raise TimeoutError(f"export {export_id} did not complete within {timeout} seconds")
+            time.sleep(poll_interval)
+            handle = self.get_export(export_id)
+        return handle
+
+    def download_artifact(self, url: str, destination: Optional[str] = None) -> str:
+        """Download an artifact using the signed URL returned by the export service."""
+        resp = self._session.get(url, timeout=self._timeout)
+        resp.raise_for_status()
+        if destination is None:
+            return resp.text
+        os.makedirs(os.path.dirname(destination) or ".", exist_ok=True)
+        mode = "wb" if isinstance(resp.content, (bytes, bytearray)) else "w"
+        with open(destination, mode) as fh:
+            fh.write(resp.content if "b" in mode else resp.text)
+        return destination
+
+
+def dump_pretty(obj: Any) -> str:
+    """Render response payloads as formatted JSON for notebooks or logs."""
+    return json.dumps(obj, indent=2, sort_keys=True)

--- a/docs/schema/dataset-service.openapi.yaml
+++ b/docs/schema/dataset-service.openapi.yaml
@@ -1,0 +1,484 @@
+openapi: 3.1.0
+info:
+  title: ColonyCore Dataset Service
+  version: 0.1.0
+  description: >-
+    Species-agnostic analytics API exposing registered, versioned dataset templates as
+    described in RFC 0001 (sections 6.3 and 7).
+servers:
+  - url: https://api.colonycore.local
+    description: Example deployment host
+paths:
+  /api/v1/datasets/templates:
+    get:
+      summary: List dataset templates
+      description: Enumerates all registered dataset templates including schema, metadata, and supported formats.
+      tags: [datasets]
+      responses:
+        '200':
+          description: Templates enumerated successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  templates:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/DatasetTemplateDescriptor'
+                required: [templates]
+  /api/v1/datasets/templates/{plugin}/{key}/{version}:
+    parameters:
+      - in: path
+        name: plugin
+        schema:
+          type: string
+        required: true
+        description: Plugin identifier registering the template.
+      - in: path
+        name: key
+        schema:
+          type: string
+        required: true
+        description: Dataset template key within the plugin namespace.
+      - in: path
+        name: version
+        schema:
+          type: string
+        required: true
+        description: Semantic version of the dataset template.
+    get:
+      summary: Fetch dataset template
+      tags: [datasets]
+      responses:
+        '200':
+          description: Template metadata returned.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  template:
+                    $ref: '#/components/schemas/DatasetTemplateDescriptor'
+                required: [template]
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/datasets/templates/{plugin}/{key}/{version}/validate:
+    post:
+      summary: Validate dataset parameters
+      tags: [datasets]
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  additionalProperties: {}
+      responses:
+        '200':
+          description: Validation outcome.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  template:
+                    $ref: '#/components/schemas/DatasetTemplateDescriptor'
+                  valid:
+                    type: boolean
+                  parameters:
+                    type: object
+                    additionalProperties: {}
+                  errors:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/DatasetParameterError'
+                required: [template, valid, parameters]
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/datasets/templates/{plugin}/{key}/{version}/run:
+    post:
+      summary: Execute dataset template
+      description: >-
+        Streams dataset rows using JSON (default) or CSV transport while applying RBAC scope filters.
+        CSV responses adhere to RFC 4180; JSON payloads include schema, metadata with units, and generation timestamp.
+      tags: [datasets]
+      parameters:
+        - in: query
+          name: format
+          schema:
+            type: string
+            enum: [json, csv]
+          description: Preferred response format. Defaults to JSON unless the Accept header contains text/csv.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  additionalProperties: {}
+                scope:
+                  $ref: '#/components/schemas/DatasetScope'
+      responses:
+        '200':
+          description: Dataset rendered successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  template:
+                    $ref: '#/components/schemas/DatasetTemplateDescriptor'
+                  scope:
+                    $ref: '#/components/schemas/DatasetScope'
+                  parameters:
+                    type: object
+                    additionalProperties: {}
+                  result:
+                    $ref: '#/components/schemas/DatasetRunResult'
+                required: [template, scope, parameters, result]
+            text/csv:
+              schema:
+                type: string
+                format: binary
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '406':
+          description: Requested format not supported by the dataset template.
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /api/v1/datasets/exports:
+    post:
+      summary: Queue dataset export
+      description: >-
+        Enqueues an asynchronous export job that renders the requested dataset template across one or more
+        formats. Export artifacts are stored in the managed object store and linked to the caller.
+      tags: [datasets]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExportCreateRequest'
+      responses:
+        '202':
+          description: Export queued successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  export:
+                    $ref: '#/components/schemas/ExportRecord'
+                required: [export]
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  /api/v1/datasets/exports/{exportId}:
+    parameters:
+      - in: path
+        name: exportId
+        schema:
+          type: string
+        required: true
+        description: Identifier of the export job.
+    get:
+      summary: Fetch export status
+      tags: [datasets]
+      responses:
+        '200':
+          description: Export status returned.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  export:
+                    $ref: '#/components/schemas/ExportRecord'
+                required: [export]
+        '404':
+          $ref: '#/components/responses/NotFound'
+components:
+  responses:
+    NotFound:
+      description: Resource not found.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    BadRequest:
+      description: Malformed request payload or parameter violation.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    InternalError:
+      description: Unexpected server error.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+  schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+      required: [error]
+    DatasetTemplateDescriptor:
+      type: object
+      properties:
+        plugin:
+          type: string
+        key:
+          type: string
+        version:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        dialect:
+          type: string
+          enum: [sql, dsl]
+        query:
+          type: string
+        parameters:
+          type: array
+          items:
+            $ref: '#/components/schemas/DatasetParameter'
+        columns:
+          type: array
+          items:
+            $ref: '#/components/schemas/DatasetColumn'
+        metadata:
+          $ref: '#/components/schemas/DatasetMetadata'
+        output_formats:
+          type: array
+          items:
+            type: string
+            enum: [json, csv, parquet, png, html]
+        slug:
+          type: string
+      required: [plugin, key, version, title, description, dialect, query, columns, output_formats, slug]
+    DatasetParameter:
+      type: object
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+          enum: [string, integer, number, boolean, timestamp]
+        required:
+          type: boolean
+          default: false
+        description:
+          type: string
+        unit:
+          type: string
+        enum:
+          type: array
+          items:
+            type: string
+        example:
+          nullable: true
+        default:
+          nullable: true
+      required: [name, type]
+    DatasetColumn:
+      type: object
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+        unit:
+          type: string
+          description: Canonical unit (SI / ISO 80000 where applicable).
+        description:
+          type: string
+        format:
+          type: string
+      required: [name, type]
+    DatasetMetadata:
+      type: object
+      properties:
+        source:
+          type: string
+        documentation:
+          type: string
+          format: uri-reference
+        refresh_interval:
+          type: string
+          description: ISO-8601 duration for recommended refresh cadence.
+        tags:
+          type: array
+          items:
+            type: string
+        annotations:
+          type: object
+          additionalProperties:
+            type: string
+    DatasetScope:
+      type: object
+      properties:
+        requestor:
+          type: string
+        roles:
+          type: array
+          items:
+            type: string
+        project_ids:
+          type: array
+          items:
+            type: string
+        protocol_ids:
+          type: array
+          items:
+            type: string
+      description: RBAC-derived filters applied to dataset execution.
+    DatasetRunResult:
+      type: object
+      properties:
+        schema:
+          type: array
+          items:
+            $ref: '#/components/schemas/DatasetColumn'
+        rows:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+        metadata:
+          type: object
+          additionalProperties: {}
+        generated_at:
+          type: string
+          format: date-time
+        format:
+          type: string
+          enum: [json, csv, parquet, png, html]
+      required: [rows, generated_at, format]
+    DatasetParameterError:
+      type: object
+      properties:
+        name:
+          type: string
+        message:
+          type: string
+      required: [name, message]
+    ExportCreateRequest:
+      type: object
+      properties:
+        template:
+          type: object
+          properties:
+            slug:
+              type: string
+            plugin:
+              type: string
+            key:
+              type: string
+            version:
+              type: string
+          description: Template selector; either slug or plugin/key/version must be provided.
+        parameters:
+          type: object
+          additionalProperties: {}
+        formats:
+          type: array
+          items:
+            type: string
+            enum: [json, csv, parquet, png, html]
+        scope:
+          $ref: '#/components/schemas/DatasetScope'
+        requested_by:
+          type: string
+        reason:
+          type: string
+        project_id:
+          type: string
+        protocol_id:
+          type: string
+      required: [template]
+    ExportRecord:
+      type: object
+      properties:
+        id:
+          type: string
+        template:
+          $ref: '#/components/schemas/DatasetTemplateDescriptor'
+        scope:
+          $ref: '#/components/schemas/DatasetScope'
+        parameters:
+          type: object
+          additionalProperties: {}
+        formats:
+          type: array
+          items:
+            type: string
+            enum: [json, csv, parquet, png, html]
+        status:
+          $ref: '#/components/schemas/ExportStatus'
+        error:
+          type: string
+        artifacts:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExportArtifact'
+        requested_by:
+          type: string
+        reason:
+          type: string
+        project_id:
+          type: string
+        protocol_id:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+          nullable: true
+      required: [id, template, scope, formats, status, requested_by, created_at, updated_at]
+    ExportArtifact:
+      type: object
+      properties:
+        id:
+          type: string
+        format:
+          type: string
+          enum: [json, csv, parquet, png, html]
+        content_type:
+          type: string
+        size_bytes:
+          type: integer
+          format: int64
+        url:
+          type: string
+          format: uri
+        metadata:
+          type: object
+          additionalProperties: {}
+        created_at:
+          type: string
+          format: date-time
+      required: [id, format, content_type, size_bytes, url, created_at]
+    ExportStatus:
+      type: string
+      enum: [queued, running, succeeded, failed]

--- a/internal/core/dataset.go
+++ b/internal/core/dataset.go
@@ -1,0 +1,464 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// DatasetDialect indicates the query language used by a dataset template.
+type DatasetDialect string
+
+const (
+	// DatasetDialectSQL indicates templates expressed in SQL.
+	DatasetDialectSQL DatasetDialect = "sql"
+	// DatasetDialectDSL indicates templates expressed in the platform reporting DSL.
+	DatasetDialectDSL DatasetDialect = "dsl"
+)
+
+// DatasetFormat enumerates supported output formats for datasets.
+type DatasetFormat string
+
+const (
+	FormatJSON    DatasetFormat = "json"
+	FormatCSV     DatasetFormat = "csv"
+	FormatParquet DatasetFormat = "parquet"
+	FormatPNG     DatasetFormat = "png"
+	FormatHTML    DatasetFormat = "html"
+)
+
+// DatasetScope captures RBAC-derived filters applied to dataset execution.
+type DatasetScope struct {
+	Requestor   string   `json:"requestor"`
+	Roles       []string `json:"roles,omitempty"`
+	ProjectIDs  []string `json:"project_ids,omitempty"`
+	ProtocolIDs []string `json:"protocol_ids,omitempty"`
+}
+
+// DatasetParameter declares an input parameter for a dataset template.
+type DatasetParameter struct {
+	Name        string   `json:"name"`
+	Type        string   `json:"type"`
+	Required    bool     `json:"required"`
+	Description string   `json:"description,omitempty"`
+	Unit        string   `json:"unit,omitempty"`
+	Enum        []string `json:"enum,omitempty"`
+	Example     any      `json:"example,omitempty"`
+	Default     any      `json:"default,omitempty"`
+}
+
+// DatasetColumn describes an output column for a dataset.
+type DatasetColumn struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Unit        string `json:"unit,omitempty"`
+	Description string `json:"description,omitempty"`
+	Format      string `json:"format,omitempty"`
+}
+
+// DatasetTemplateMetadata stores additional descriptive attributes for a template.
+type DatasetTemplateMetadata struct {
+	Source          string            `json:"source,omitempty"`
+	Documentation   string            `json:"documentation,omitempty"`
+	RefreshInterval string            `json:"refresh_interval,omitempty"`
+	Tags            []string          `json:"tags,omitempty"`
+	Annotations     map[string]string `json:"annotations,omitempty"`
+}
+
+// DatasetBinder constructs a runner bound to runtime dependencies.
+type DatasetBinder func(DatasetEnvironment) (DatasetRunner, error)
+
+// DatasetRunner executes a dataset with validated parameters and scope.
+type DatasetRunner func(context.Context, DatasetRunRequest) (DatasetRunResult, error)
+
+// DatasetEnvironment provides runtime dependencies to binders.
+type DatasetEnvironment struct {
+	Store *MemoryStore
+	Now   func() time.Time
+}
+
+// DatasetRunRequest bundles invocation data for dataset runners.
+type DatasetRunRequest struct {
+	Template   DatasetTemplateDescriptor
+	Parameters map[string]any
+	Scope      DatasetScope
+}
+
+// DatasetRunResult represents canonical dataset output.
+type DatasetRunResult struct {
+	Schema      []DatasetColumn  `json:"schema"`
+	Rows        []map[string]any `json:"rows"`
+	Metadata    map[string]any   `json:"metadata,omitempty"`
+	GeneratedAt time.Time        `json:"generated_at"`
+	Format      DatasetFormat    `json:"format"`
+}
+
+// DatasetParameterError captures validation failures.
+type DatasetParameterError struct {
+	Name    string `json:"name"`
+	Message string `json:"message"`
+}
+
+// DatasetTemplateDescriptor exposes immutable template metadata.
+type DatasetTemplateDescriptor struct {
+	Plugin        string                  `json:"plugin"`
+	Key           string                  `json:"key"`
+	Version       string                  `json:"version"`
+	Title         string                  `json:"title"`
+	Description   string                  `json:"description"`
+	Dialect       DatasetDialect          `json:"dialect"`
+	Query         string                  `json:"query"`
+	Parameters    []DatasetParameter      `json:"parameters"`
+	Columns       []DatasetColumn         `json:"columns"`
+	Metadata      DatasetTemplateMetadata `json:"metadata"`
+	OutputFormats []DatasetFormat         `json:"output_formats"`
+	Slug          string                  `json:"slug"`
+}
+
+// DatasetTemplate captures plugin-provided dataset manifests and runtime binders.
+type DatasetTemplate struct {
+	Plugin        string
+	Key           string
+	Version       string
+	Title         string
+	Description   string
+	Dialect       DatasetDialect
+	Query         string
+	Parameters    []DatasetParameter
+	Columns       []DatasetColumn
+	Metadata      DatasetTemplateMetadata
+	OutputFormats []DatasetFormat
+	Binder        DatasetBinder
+
+	runner DatasetRunner
+}
+
+// Descriptor produces a descriptor snapshot for the template.
+func (t DatasetTemplate) Descriptor() DatasetTemplateDescriptor {
+	return DatasetTemplateDescriptor{
+		Plugin:        t.Plugin,
+		Key:           t.Key,
+		Version:       t.Version,
+		Title:         t.Title,
+		Description:   t.Description,
+		Dialect:       t.Dialect,
+		Query:         t.Query,
+		Parameters:    cloneParameters(t.Parameters),
+		Columns:       cloneColumns(t.Columns),
+		Metadata:      cloneMetadata(t.Metadata),
+		OutputFormats: append([]DatasetFormat(nil), t.OutputFormats...),
+		Slug:          t.slug(),
+	}
+}
+
+func cloneParameters(in []DatasetParameter) []DatasetParameter {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]DatasetParameter, len(in))
+	copy(out, in)
+	for i := range out {
+		if len(out[i].Enum) > 0 {
+			out[i].Enum = append([]string(nil), out[i].Enum...)
+		}
+	}
+	return out
+}
+
+func cloneColumns(in []DatasetColumn) []DatasetColumn {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]DatasetColumn, len(in))
+	copy(out, in)
+	return out
+}
+
+func cloneMetadata(in DatasetTemplateMetadata) DatasetTemplateMetadata {
+	out := in
+	if len(in.Tags) > 0 {
+		out.Tags = append([]string(nil), in.Tags...)
+	}
+	if len(in.Annotations) > 0 {
+		out.Annotations = make(map[string]string, len(in.Annotations))
+		for k, v := range in.Annotations {
+			out.Annotations[k] = v
+		}
+	}
+	return out
+}
+
+// slug returns the canonical identifier for the template.
+func (t DatasetTemplate) slug() string {
+	if t.Plugin == "" {
+		return fmt.Sprintf("%s@%s", t.Key, t.Version)
+	}
+	return fmt.Sprintf("%s/%s@%s", t.Plugin, t.Key, t.Version)
+}
+
+// validate ensures required fields are present and structurally sound.
+func (t DatasetTemplate) validate() error {
+	if strings.TrimSpace(t.Key) == "" {
+		return errors.New("dataset template key required")
+	}
+	if strings.TrimSpace(t.Version) == "" {
+		return errors.New("dataset template version required")
+	}
+	if strings.TrimSpace(t.Title) == "" {
+		return errors.New("dataset template title required")
+	}
+	if t.Dialect != DatasetDialectSQL && t.Dialect != DatasetDialectDSL {
+		return fmt.Errorf("unsupported dataset dialect %q", t.Dialect)
+	}
+	if strings.TrimSpace(t.Query) == "" {
+		return errors.New("dataset template query required")
+	}
+	if len(t.Columns) == 0 {
+		return errors.New("dataset template requires at least one column")
+	}
+	if len(t.OutputFormats) == 0 {
+		return errors.New("dataset template must declare output formats")
+	}
+	if t.Binder == nil {
+		return errors.New("dataset template binder required")
+	}
+	return nil
+}
+
+// bind attaches a runtime runner using the provided environment.
+func (t *DatasetTemplate) bind(env DatasetEnvironment) error {
+	if t == nil {
+		return errors.New("dataset template nil")
+	}
+	if t.Binder == nil {
+		return errors.New("dataset template binder missing")
+	}
+	runner, err := t.Binder(env)
+	if err != nil {
+		return err
+	}
+	if runner == nil {
+		return errors.New("dataset template binder returned nil runner")
+	}
+	t.runner = runner
+	return nil
+}
+
+// Run executes the dataset template using the bound runner after validating parameters.
+func (t DatasetTemplate) Run(ctx context.Context, params map[string]any, scope DatasetScope, format DatasetFormat) (DatasetRunResult, []DatasetParameterError, error) {
+	if t.runner == nil {
+		return DatasetRunResult{}, nil, errors.New("dataset template not bound")
+	}
+	cleaned, errs := validateParameters(t.Parameters, params)
+	if len(errs) > 0 {
+		return DatasetRunResult{}, errs, nil
+	}
+	result, err := t.runner(ctx, DatasetRunRequest{
+		Template:   t.Descriptor(),
+		Parameters: cleaned,
+		Scope:      scope,
+	})
+	if err != nil {
+		return DatasetRunResult{}, nil, err
+	}
+	if len(result.Schema) == 0 {
+		result.Schema = cloneColumns(t.Columns)
+	}
+	result.GeneratedAt = result.GeneratedAt.UTC()
+	result.Format = format
+	return result, nil, nil
+}
+
+// ValidateParameters validates parameters without executing the runner.
+func (t DatasetTemplate) ValidateParameters(params map[string]any) (map[string]any, []DatasetParameterError) {
+	return validateParameters(t.Parameters, params)
+}
+
+// SupportsFormat reports whether the template declares the requested format.
+func (t DatasetTemplate) SupportsFormat(format DatasetFormat) bool {
+	for _, candidate := range t.OutputFormats {
+		if candidate == format {
+			return true
+		}
+	}
+	return false
+}
+
+func validateParameters(definitions []DatasetParameter, supplied map[string]any) (map[string]any, []DatasetParameterError) {
+	cleaned := make(map[string]any)
+	var errs []DatasetParameterError
+	provided := make(map[string]struct{}, len(supplied))
+	for k := range supplied {
+		provided[strings.ToLower(k)] = struct{}{}
+	}
+	for _, param := range definitions {
+		key := strings.ToLower(param.Name)
+		val, ok := findParamValue(param.Name, supplied)
+		if !ok {
+			if param.Required {
+				errs = append(errs, DatasetParameterError{Name: param.Name, Message: "required parameter missing"})
+				continue
+			}
+			if param.Default != nil {
+				cleaned[param.Name] = param.Default
+			}
+			continue
+		}
+		coerced, err := coerceParameter(param, val)
+		if err != nil {
+			errs = append(errs, DatasetParameterError{Name: param.Name, Message: err.Error()})
+			continue
+		}
+		cleaned[param.Name] = coerced
+		delete(provided, key)
+	}
+	for leftovers := range provided {
+		errs = append(errs, DatasetParameterError{Name: leftovers, Message: "parameter not declared"})
+	}
+	if len(errs) > 0 {
+		sort.Slice(errs, func(i, j int) bool { return errs[i].Name < errs[j].Name })
+	}
+	return cleaned, errs
+}
+
+func findParamValue(name string, supplied map[string]any) (any, bool) {
+	if supplied == nil {
+		return nil, false
+	}
+	if val, ok := supplied[name]; ok {
+		return val, true
+	}
+	lower := strings.ToLower(name)
+	for k, v := range supplied {
+		if strings.ToLower(k) == lower {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+func coerceParameter(param DatasetParameter, raw any) (any, error) {
+	if raw == nil {
+		return nil, fmt.Errorf("parameter %s cannot be null", param.Name)
+	}
+	switch param.Type {
+	case "string":
+		switch v := raw.(type) {
+		case string:
+			if len(param.Enum) > 0 && !containsString(param.Enum, v) {
+				return nil, enumError(param.Enum)
+			}
+			return v, nil
+		case fmt.Stringer:
+			val := v.String()
+			if len(param.Enum) > 0 && !containsString(param.Enum, val) {
+				return nil, enumError(param.Enum)
+			}
+			return val, nil
+		default:
+			return nil, fmt.Errorf("parameter %s expects string", param.Name)
+		}
+	case "integer":
+		switch v := raw.(type) {
+		case int:
+			return v, nil
+		case int64:
+			return int(v), nil
+		case float64:
+			if v != float64(int(v)) {
+				return nil, fmt.Errorf("parameter %s expects integer", param.Name)
+			}
+			return int(v), nil
+		case string:
+			parsed, err := strconv.Atoi(v)
+			if err != nil {
+				return nil, fmt.Errorf("parameter %s expects integer", param.Name)
+			}
+			return parsed, nil
+		default:
+			return nil, fmt.Errorf("parameter %s expects integer", param.Name)
+		}
+	case "number":
+		switch v := raw.(type) {
+		case float32:
+			return float64(v), nil
+		case float64:
+			return v, nil
+		case int:
+			return float64(v), nil
+		case int64:
+			return float64(v), nil
+		case string:
+			parsed, err := strconv.ParseFloat(v, 64)
+			if err != nil {
+				return nil, fmt.Errorf("parameter %s expects number", param.Name)
+			}
+			return parsed, nil
+		default:
+			return nil, fmt.Errorf("parameter %s expects number", param.Name)
+		}
+	case "boolean":
+		switch v := raw.(type) {
+		case bool:
+			return v, nil
+		case string:
+			parsed, err := strconv.ParseBool(v)
+			if err != nil {
+				return nil, fmt.Errorf("parameter %s expects boolean", param.Name)
+			}
+			return parsed, nil
+		default:
+			return nil, fmt.Errorf("parameter %s expects boolean", param.Name)
+		}
+	case "timestamp":
+		switch v := raw.(type) {
+		case time.Time:
+			return v.UTC(), nil
+		case string:
+			parsed, err := time.Parse(time.RFC3339, v)
+			if err != nil {
+				return nil, fmt.Errorf("parameter %s expects RFC3339 timestamp", param.Name)
+			}
+			return parsed.UTC(), nil
+		default:
+			return nil, fmt.Errorf("parameter %s expects timestamp", param.Name)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported parameter type %q", param.Type)
+	}
+}
+
+func containsString(list []string, target string) bool {
+	for _, candidate := range list {
+		if candidate == target {
+			return true
+		}
+	}
+	return false
+}
+
+func enumError(options []string) error {
+	if len(options) == 0 {
+		return errors.New("invalid enumeration")
+	}
+	return fmt.Errorf("value must be one of: %s", strings.Join(options, ", "))
+}
+
+// DatasetTemplateCollection sorts descriptors for stable responses.
+type DatasetTemplateCollection []DatasetTemplateDescriptor
+
+func (c DatasetTemplateCollection) Len() int      { return len(c) }
+func (c DatasetTemplateCollection) Swap(i, j int) { c[i], c[j] = c[j], c[i] }
+func (c DatasetTemplateCollection) Less(i, j int) bool {
+	if c[i].Plugin == c[j].Plugin {
+		if c[i].Key == c[j].Key {
+			return c[i].Version < c[j].Version
+		}
+		return c[i].Key < c[j].Key
+	}
+	return c[i].Plugin < c[j].Plugin
+}

--- a/internal/core/dataset_test.go
+++ b/internal/core/dataset_test.go
@@ -1,0 +1,403 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+type stringer struct{}
+
+func (stringer) String() string { return "frog" }
+
+func TestDatasetTemplateRunSuccess(t *testing.T) {
+	reference := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	invocations := 0
+	template := DatasetTemplate{
+		Plugin:      "frog",
+		Key:         "snapshot",
+		Version:     "1.0.0",
+		Title:       "Snapshot",
+		Description: "demo",
+		Dialect:     DatasetDialectSQL,
+		Query:       "SELECT 1",
+		Parameters: []DatasetParameter{{
+			Name:     "limit",
+			Type:     "integer",
+			Required: true,
+		}},
+		Columns: []DatasetColumn{{
+			Name: "value",
+			Type: "integer",
+		}},
+		Metadata: DatasetTemplateMetadata{Tags: []string{"demo"}},
+		OutputFormats: []DatasetFormat{
+			FormatJSON,
+			FormatCSV,
+		},
+		Binder: func(env DatasetEnvironment) (DatasetRunner, error) {
+			return func(ctx context.Context, req DatasetRunRequest) (DatasetRunResult, error) {
+				invocations++
+				if req.Parameters["limit"].(int) != 25 {
+					t.Fatalf("expected coerced integer parameter, got %v", req.Parameters["limit"])
+				}
+				return DatasetRunResult{
+					Rows:        []map[string]any{{"value": 99}},
+					GeneratedAt: env.Now(),
+				}, nil
+			}, nil
+		},
+	}
+
+	env := DatasetEnvironment{Now: func() time.Time { return reference }}
+	if err := template.bind(env); err != nil {
+		t.Fatalf("bind template: %v", err)
+	}
+
+	params := map[string]any{"limit": "25"}
+	scope := DatasetScope{Requestor: "analyst"}
+	result, paramErrs, err := template.Run(context.Background(), params, scope, FormatCSV)
+	if err != nil {
+		t.Fatalf("run template: %v", err)
+	}
+	if len(paramErrs) != 0 {
+		t.Fatalf("unexpected parameter errors: %+v", paramErrs)
+	}
+	if result.Format != FormatCSV {
+		t.Fatalf("expected format csv, got %s", result.Format)
+	}
+	if len(result.Schema) != 1 || result.Schema[0].Name != "value" {
+		t.Fatalf("expected schema fallback from template, got %+v", result.Schema)
+	}
+	if !result.GeneratedAt.Equal(reference) {
+		t.Fatalf("expected generated timestamp %v, got %v", reference, result.GeneratedAt)
+	}
+	if invocations != 1 {
+		t.Fatalf("expected single runner invocation, got %d", invocations)
+	}
+
+	if !template.SupportsFormat(FormatJSON) {
+		t.Fatalf("expected template to support JSON format")
+	}
+	if template.SupportsFormat(FormatPNG) {
+		t.Fatalf("did not expect template to support PNG format")
+	}
+}
+
+func TestDatasetTemplateRunParameterErrors(t *testing.T) {
+	template := DatasetTemplate{
+		Plugin:      "frog",
+		Key:         "snapshot",
+		Version:     "1.0.0",
+		Title:       "Snapshot",
+		Description: "demo",
+		Dialect:     DatasetDialectSQL,
+		Query:       "SELECT 1",
+		Parameters: []DatasetParameter{{
+			Name:     "limit",
+			Type:     "integer",
+			Required: true,
+		}},
+		Columns:       []DatasetColumn{{Name: "value", Type: "integer"}},
+		OutputFormats: []DatasetFormat{FormatJSON},
+		Binder: func(DatasetEnvironment) (DatasetRunner, error) {
+			return func(context.Context, DatasetRunRequest) (DatasetRunResult, error) {
+				return DatasetRunResult{}, nil
+			}, nil
+		},
+	}
+	if err := template.bind(DatasetEnvironment{}); err != nil {
+		t.Fatalf("bind template: %v", err)
+	}
+
+	params := map[string]any{"unexpected": true}
+	result, paramErrs, err := template.Run(context.Background(), params, DatasetScope{}, FormatJSON)
+	if err != nil {
+		t.Fatalf("run template: %v", err)
+	}
+	if len(paramErrs) != 2 {
+		t.Fatalf("expected two parameter errors (missing required + unexpected), got %d", len(paramErrs))
+	}
+	if result.Rows != nil {
+		t.Fatalf("expected no rows when validation fails")
+	}
+}
+
+func TestDatasetValidateParametersCoercion(t *testing.T) {
+	when := time.Date(2023, 5, 6, 7, 8, 9, 0, time.UTC)
+	template := DatasetTemplate{
+		Parameters: []DatasetParameter{
+			{Name: "name", Type: "string", Required: true, Enum: []string{"frog", "newt"}},
+			{Name: "count", Type: "integer"},
+			{Name: "ratio", Type: "number"},
+			{Name: "flag", Type: "boolean"},
+			{Name: "as_of", Type: "timestamp"},
+			{Name: "note", Type: "string", Default: "n/a"},
+		},
+	}
+
+	supplied := map[string]any{
+		"NAME":  stringer{},
+		"count": int64(7),
+		"ratio": "3.14",
+		"flag":  "true",
+		"as_of": when.Format(time.RFC3339),
+	}
+
+	cleaned, errs := template.ValidateParameters(supplied)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %+v", errs)
+	}
+	if cleaned["name"].(string) != "frog" {
+		t.Fatalf("expected enum stringer coercion, got %v", cleaned["name"])
+	}
+	if cleaned["count"].(int) != 7 {
+		t.Fatalf("expected integer coercion, got %v", cleaned["count"])
+	}
+	if cleaned["ratio"].(float64) != 3.14 {
+		t.Fatalf("expected float coercion, got %v", cleaned["ratio"])
+	}
+	if cleaned["flag"].(bool) != true {
+		t.Fatalf("expected boolean coercion")
+	}
+	if !cleaned["as_of"].(time.Time).Equal(when) {
+		t.Fatalf("expected timestamp coercion")
+	}
+	if cleaned["note"].(string) != "n/a" {
+		t.Fatalf("expected default value to apply, got %v", cleaned["note"])
+	}
+
+	supplied["NAME"] = "invalid"
+	_, errs = template.ValidateParameters(supplied)
+	if len(errs) == 0 {
+		t.Fatalf("expected enum validation failure")
+	}
+	if errs[0].Name != "name" {
+		t.Fatalf("expected error for name parameter, got %+v", errs)
+	}
+}
+
+func TestDatasetTemplateCollectionSort(t *testing.T) {
+	collection := DatasetTemplateCollection{
+		{Plugin: "frog", Key: "b", Version: "0.1.0"},
+		{Plugin: "frog", Key: "a", Version: "0.2.0"},
+		{Plugin: "newt", Key: "a", Version: "0.1.0"},
+	}
+	collection[0].Slug = "frog/b@0.1.0"
+	collection[1].Slug = "frog/a@0.2.0"
+	collection[2].Slug = "newt/a@0.1.0"
+
+	sort.Sort(collection)
+
+	if collection[0].Key != "a" || collection[0].Version != "0.2.0" {
+		t.Fatalf("unexpected sort order: %+v", collection)
+	}
+	if collection[1].Key != "b" {
+		t.Fatalf("expected frog/b second, got %+v", collection)
+	}
+}
+
+func TestDatasetTemplateBindErrors(t *testing.T) {
+	template := DatasetTemplate{Key: "test"}
+	if err := template.validate(); err == nil {
+		t.Fatalf("expected validation error for incomplete template")
+	}
+
+	template = DatasetTemplate{
+		Key:         "test",
+		Version:     "1.0.0",
+		Title:       "Test",
+		Description: "demo",
+		Dialect:     DatasetDialectSQL,
+		Query:       "SELECT 1",
+		Columns:     []DatasetColumn{{Name: "value", Type: "integer"}},
+		OutputFormats: []DatasetFormat{
+			FormatJSON,
+		},
+		Binder: func(DatasetEnvironment) (DatasetRunner, error) {
+			return nil, nil
+		},
+	}
+	if err := template.bind(DatasetEnvironment{}); err == nil {
+		t.Fatalf("expected error when binder returns nil runner")
+	}
+
+	template.Binder = func(DatasetEnvironment) (DatasetRunner, error) {
+		return nil, fmt.Errorf("binder failure")
+	}
+	if err := template.bind(DatasetEnvironment{}); err == nil || err.Error() != "binder failure" {
+		t.Fatalf("expected binder failure to propagate, got %v", err)
+	}
+}
+
+func TestDatasetValidateParametersUnknownType(t *testing.T) {
+	template := DatasetTemplate{
+		Parameters: []DatasetParameter{{Name: "mystery", Type: "uuid"}},
+	}
+	_, errs := template.ValidateParameters(map[string]any{"mystery": "value"})
+	if len(errs) == 0 {
+		t.Fatalf("expected error for unsupported parameter type")
+	}
+}
+
+func TestDatasetValidateParametersErrorBranches(t *testing.T) {
+	template := DatasetTemplate{
+		Parameters: []DatasetParameter{
+			{Name: "count", Type: "integer", Required: true},
+			{Name: "ratio", Type: "number"},
+			{Name: "flag", Type: "boolean"},
+			{Name: "as_of", Type: "timestamp"},
+		},
+	}
+
+	supplied := map[string]any{
+		"count": 1.5,
+		"ratio": true,
+		"flag":  1,
+		"as_of": "invalid",
+	}
+
+	_, errs := template.ValidateParameters(supplied)
+	if len(errs) < 4 {
+		t.Fatalf("expected coercion errors, got %+v", errs)
+	}
+	required := map[string]bool{"count": false, "ratio": false, "flag": false, "as_of": false}
+	for _, err := range errs {
+		if strings.Contains(err.Message, "expects") {
+			required[err.Name] = true
+		}
+	}
+	for name, covered := range required {
+		if !covered {
+			t.Fatalf("expected error for parameter %s, got %+v", name, errs)
+		}
+	}
+}
+
+func TestDatasetTemplateSlugVariants(t *testing.T) {
+	template := DatasetTemplate{Key: "demo", Version: "1.0.0"}
+	if slug := template.slug(); slug != "demo@1.0.0" {
+		t.Fatalf("unexpected slug without plugin: %s", slug)
+	}
+	template.Plugin = "frog"
+	if slug := template.slug(); slug != "frog/demo@1.0.0" {
+		t.Fatalf("unexpected slug with plugin: %s", slug)
+	}
+}
+
+func TestDatasetTemplateValidateFailures(t *testing.T) {
+	base := DatasetTemplate{
+		Key:         "demo",
+		Version:     "1.0.0",
+		Title:       "Demo",
+		Description: "demo",
+		Dialect:     DatasetDialectSQL,
+		Query:       "SELECT 1",
+		Columns:     []DatasetColumn{{Name: "value", Type: "integer"}},
+		OutputFormats: []DatasetFormat{
+			FormatJSON,
+		},
+		Binder: func(DatasetEnvironment) (DatasetRunner, error) {
+			return func(context.Context, DatasetRunRequest) (DatasetRunResult, error) {
+				return DatasetRunResult{}, nil
+			}, nil
+		},
+	}
+	tests := []struct {
+		name string
+		mut  func(*DatasetTemplate)
+	}{
+		{"missing key", func(tmpl *DatasetTemplate) { tmpl.Key = "" }},
+		{"missing version", func(tmpl *DatasetTemplate) { tmpl.Version = "" }},
+		{"missing title", func(tmpl *DatasetTemplate) { tmpl.Title = "" }},
+		{"unsupported dialect", func(tmpl *DatasetTemplate) { tmpl.Dialect = DatasetDialect("graphql") }},
+		{"missing query", func(tmpl *DatasetTemplate) { tmpl.Query = "" }},
+		{"missing columns", func(tmpl *DatasetTemplate) { tmpl.Columns = nil }},
+		{"missing formats", func(tmpl *DatasetTemplate) { tmpl.OutputFormats = nil }},
+		{"missing binder", func(tmpl *DatasetTemplate) { tmpl.Binder = nil }},
+	}
+	for _, tc := range tests {
+		tmpl := base
+		tc.mut(&tmpl)
+		if err := tmpl.validate(); err == nil {
+			t.Fatalf("%s: expected validation error", tc.name)
+		}
+	}
+}
+
+func TestDatasetCloneHelpers(t *testing.T) {
+	parameters := []DatasetParameter{{Name: "enum", Enum: []string{"a", "b"}}, {Name: "plain"}}
+	clonedParams := cloneParameters(parameters)
+	clonedParams[0].Enum[0] = "mutated"
+	if parameters[0].Enum[0] != "a" {
+		t.Fatalf("expected parameter enum to remain unchanged")
+	}
+
+	columns := []DatasetColumn{{Name: "value", Type: "string"}}
+	clonedColumns := cloneColumns(columns)
+	clonedColumns[0].Name = "changed"
+	if columns[0].Name != "value" {
+		t.Fatalf("expected original column to remain value")
+	}
+}
+
+func TestEnumErrorBranches(t *testing.T) {
+	if err := enumError(nil); err == nil {
+		t.Fatalf("expected error when enumeration empty")
+	}
+	if err := enumError([]string{"a", "b"}); err == nil || !strings.Contains(err.Error(), "a, b") {
+		t.Fatalf("expected formatted enumeration error, got %v", err)
+	}
+}
+
+func TestDatasetTemplateBindError(t *testing.T) {
+	template := DatasetTemplate{
+		Key:         "bind",
+		Version:     "1.0.0",
+		Title:       "Bind",
+		Description: "demo",
+		Dialect:     DatasetDialectSQL,
+		Query:       "SELECT 1",
+		Columns:     []DatasetColumn{{Name: "value", Type: "integer"}},
+		OutputFormats: []DatasetFormat{
+			FormatJSON,
+		},
+		Binder: func(DatasetEnvironment) (DatasetRunner, error) {
+			return nil, fmt.Errorf("bind error")
+		},
+	}
+	if err := template.bind(DatasetEnvironment{}); err == nil || !strings.Contains(err.Error(), "bind error") {
+		t.Fatalf("expected bind error, got %v", err)
+	}
+}
+
+func TestCoerceParameterAdditionalCases(t *testing.T) {
+	template := DatasetTemplate{
+		Parameters: []DatasetParameter{
+			{Name: "ratio", Type: "number"},
+			{Name: "flag", Type: "boolean"},
+			{Name: "as_of", Type: "timestamp"},
+		},
+	}
+	supplied := map[string]any{
+		"ratio": float32(1.25),
+		"flag":  true,
+		"as_of": time.Now().UTC(),
+	}
+	cleaned, errs := template.ValidateParameters(supplied)
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errors: %+v", errs)
+	}
+	if cleaned["ratio"].(float64) != 1.25 {
+		t.Fatalf("expected float conversion, got %v", cleaned["ratio"])
+	}
+	if cleaned["flag"].(bool) != true {
+		t.Fatalf("expected boolean to remain true")
+	}
+	if cleaned["as_of"].(time.Time).IsZero() {
+		t.Fatalf("expected timestamp to remain set")
+	}
+}

--- a/internal/core/plugin_registry_test.go
+++ b/internal/core/plugin_registry_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"testing"
+	"time"
 )
 
 func TestPluginRegistryGuardsAndCopies(t *testing.T) {
@@ -38,6 +39,53 @@ func TestPluginRegistryGuardsAndCopies(t *testing.T) {
 	stored["organism"]["type"] = "changed"
 	if registry.Schemas()["organism"]["type"].(string) != "object" {
 		t.Fatalf("expected registry to return defensive copies")
+	}
+
+	template := DatasetTemplate{
+		Key:         "demo",
+		Version:     "1.0.0",
+		Title:       "Demo",
+		Description: "Demo dataset",
+		Dialect:     DatasetDialectSQL,
+		Query:       "SELECT 1",
+		Parameters: []DatasetParameter{{
+			Name: "stage",
+			Type: "string",
+			Enum: []string{"adult"},
+		}},
+		Columns:       []DatasetColumn{{Name: "value", Type: "number", Unit: "count"}},
+		Metadata:      DatasetTemplateMetadata{Tags: []string{"demo"}, Annotations: map[string]string{"k": "v"}},
+		OutputFormats: []DatasetFormat{FormatJSON},
+		Binder: func(DatasetEnvironment) (DatasetRunner, error) {
+			return func(context.Context, DatasetRunRequest) (DatasetRunResult, error) {
+				return DatasetRunResult{Rows: []map[string]any{{"value": 1}}, GeneratedAt: time.Now().UTC()}, nil
+			}, nil
+		},
+	}
+	if err := registry.RegisterDatasetTemplate(template); err != nil {
+		t.Fatalf("register dataset: %v", err)
+	}
+	registered := registry.DatasetTemplates()
+	if len(registered) != 1 {
+		t.Fatalf("expected dataset to be registered")
+	}
+	registered[0].Parameters[0].Enum[0] = "mutated"
+	registered[0].Metadata.Tags[0] = "changed"
+	registered[0].Metadata.Annotations["k"] = "changed"
+
+	copy := registry.DatasetTemplates()[0]
+	if copy.Parameters[0].Enum[0] != "adult" {
+		t.Fatalf("expected enum to remain adult")
+	}
+	if copy.Metadata.Tags[0] != "demo" {
+		t.Fatalf("expected metadata tags copy")
+	}
+	if copy.Metadata.Annotations["k"] != "v" {
+		t.Fatalf("expected annotation copy")
+	}
+
+	if err := registry.RegisterDatasetTemplate(template); err == nil {
+		t.Fatalf("expected duplicate dataset template registration to fail")
 	}
 }
 

--- a/internal/core/service_test.go
+++ b/internal/core/service_test.go
@@ -120,6 +120,19 @@ func TestFrogPluginRegistersSchemasAndRules(t *testing.T) {
 	if _, ok := meta.Schemas["organism"]; !ok {
 		t.Fatalf("expected frog plugin to register organism schema")
 	}
+	if len(meta.Datasets) != 1 {
+		t.Fatalf("expected frog plugin to register dataset template")
+	}
+	templates := svc.DatasetTemplates()
+	if len(templates) != 1 {
+		t.Fatalf("expected dataset templates from service")
+	}
+	if templates[0].Slug != meta.Datasets[0].Slug {
+		t.Fatalf("expected descriptors to align")
+	}
+	if _, ok := svc.ResolveDatasetTemplate(meta.Datasets[0].Slug); !ok {
+		t.Fatalf("expected dataset template to resolve")
+	}
 
 	ctx := context.Background()
 	housing, _, err := svc.CreateHousingUnit(ctx, core.HousingUnit{Name: "Dry Terrarium", Facility: "Lab", Capacity: 2, Environment: "arid"})

--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -207,6 +207,16 @@ func (s *MemoryStore) RunInTransaction(ctx context.Context, fn func(tx *Transact
 	return result, nil
 }
 
+// View executes fn against a read-only snapshot of the store state.
+func (s *MemoryStore) View(ctx context.Context, fn func(TransactionView) error) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	snapshot := s.state.clone()
+	view := newTransactionView(&snapshot)
+	return fn(view)
+}
+
 // helper to record and append change entries.
 func (tx *Transaction) recordChange(change Change) {
 	tx.changes = append(tx.changes, change)

--- a/internal/dataset/exporter.go
+++ b/internal/dataset/exporter.go
@@ -1,0 +1,713 @@
+package dataset
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"image"
+	"image/color"
+	"image/draw"
+	"image/png"
+	"strings"
+	"sync"
+	"time"
+
+	"colonycore/internal/core"
+)
+
+// ExportStatus describes the lifecycle stage of an export request.
+type ExportStatus string
+
+const (
+	ExportStatusQueued    ExportStatus = "queued"
+	ExportStatusRunning   ExportStatus = "running"
+	ExportStatusSucceeded ExportStatus = "succeeded"
+	ExportStatusFailed    ExportStatus = "failed"
+)
+
+// ExportArtifact captures a stored dataset artifact.
+type ExportArtifact struct {
+	ID          string             `json:"id"`
+	Format      core.DatasetFormat `json:"format"`
+	ContentType string             `json:"content_type"`
+	SizeBytes   int64              `json:"size_bytes"`
+	URL         string             `json:"url"`
+	Metadata    map[string]any     `json:"metadata,omitempty"`
+	CreatedAt   time.Time          `json:"created_at"`
+}
+
+// ExportRecord tracks an export request and resulting artifacts.
+type ExportRecord struct {
+	ID          string                         `json:"id"`
+	Template    core.DatasetTemplateDescriptor `json:"template"`
+	Scope       core.DatasetScope              `json:"scope"`
+	Parameters  map[string]any                 `json:"parameters"`
+	Formats     []core.DatasetFormat           `json:"formats"`
+	Status      ExportStatus                   `json:"status"`
+	Error       string                         `json:"error,omitempty"`
+	Artifacts   []ExportArtifact               `json:"artifacts,omitempty"`
+	RequestedBy string                         `json:"requested_by"`
+	Reason      string                         `json:"reason,omitempty"`
+	ProjectID   string                         `json:"project_id,omitempty"`
+	ProtocolID  string                         `json:"protocol_id,omitempty"`
+	CreatedAt   time.Time                      `json:"created_at"`
+	UpdatedAt   time.Time                      `json:"updated_at"`
+	CompletedAt *time.Time                     `json:"completed_at,omitempty"`
+}
+
+// ExportInput represents an enqueue request for the worker.
+type ExportInput struct {
+	TemplateSlug string
+	Parameters   map[string]any
+	Formats      []core.DatasetFormat
+	Scope        core.DatasetScope
+	RequestedBy  string
+	ProjectID    string
+	ProtocolID   string
+	Reason       string
+}
+
+// ExportScheduler queues dataset export requests and exposes status.
+type ExportScheduler interface {
+	EnqueueExport(ctx context.Context, input ExportInput) (ExportRecord, error)
+	GetExport(id string) (ExportRecord, bool)
+}
+
+// ObjectStore persists export artifacts.
+type ObjectStore interface {
+	Put(ctx context.Context, key string, payload []byte, contentType string, metadata map[string]any) (ExportArtifact, error)
+}
+
+// AuditLogger records export audit entries.
+type AuditLogger interface {
+	Record(ctx context.Context, entry AuditEntry)
+}
+
+// AuditEntry captures audit trail metadata for exports.
+type AuditEntry struct {
+	ID         string            `json:"id"`
+	Action     string            `json:"action"`
+	Actor      string            `json:"actor"`
+	Template   string            `json:"template"`
+	Status     ExportStatus      `json:"status"`
+	Scope      core.DatasetScope `json:"scope"`
+	Reason     string            `json:"reason,omitempty"`
+	Metadata   map[string]any    `json:"metadata,omitempty"`
+	OccurredAt time.Time         `json:"occurred_at"`
+}
+
+// Worker executes dataset exports asynchronously.
+type Worker struct {
+	catalog Catalog
+	store   ObjectStore
+	audit   AuditLogger
+
+	queue chan exportTask
+	mu    sync.RWMutex
+	jobs  map[string]*ExportRecord
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+type exportTask struct {
+	id    string
+	input ExportInput
+}
+
+type renderedArtifact struct {
+	Artifact ExportArtifact
+	Payload  []byte
+}
+
+// NewWorker constructs an export worker.
+func NewWorker(c Catalog, store ObjectStore, audit AuditLogger) *Worker {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Worker{
+		catalog: c,
+		store:   store,
+		audit:   audit,
+		queue:   make(chan exportTask, 32),
+		jobs:    make(map[string]*ExportRecord),
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+}
+
+// Start begins processing export requests.
+func (w *Worker) Start() {
+	w.wg.Add(1)
+	go w.loop()
+}
+
+// Stop signals the worker to halt and waits for completion.
+func (w *Worker) Stop(ctx context.Context) error {
+	w.cancel()
+	done := make(chan struct{})
+	go func() {
+		w.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (w *Worker) loop() {
+	defer w.wg.Done()
+	for {
+		select {
+		case <-w.ctx.Done():
+			return
+		case task := <-w.queue:
+			w.process(task)
+		}
+	}
+}
+
+// EnqueueExport schedules an export job and returns the queued record.
+func (w *Worker) EnqueueExport(ctx context.Context, input ExportInput) (ExportRecord, error) {
+	if w.catalog == nil {
+		return ExportRecord{}, fmt.Errorf("export catalog not configured")
+	}
+
+	slug := input.TemplateSlug
+	if strings.TrimSpace(slug) == "" {
+		return ExportRecord{}, fmt.Errorf("template slug required")
+	}
+	template, ok := w.catalog.ResolveDatasetTemplate(slug)
+	if !ok {
+		return ExportRecord{}, fmt.Errorf("dataset template %s not found", slug)
+	}
+
+	formats := input.Formats
+	if len(formats) == 0 {
+		formats = []core.DatasetFormat{core.FormatJSON, core.FormatCSV}
+	}
+	uniqFormats := make([]core.DatasetFormat, 0, len(formats))
+	seen := make(map[core.DatasetFormat]struct{})
+	for _, format := range formats {
+		if _, duplicate := seen[format]; duplicate {
+			continue
+		}
+		if !template.SupportsFormat(format) {
+			return ExportRecord{}, fmt.Errorf("format %s not supported by template", format)
+		}
+		uniqFormats = append(uniqFormats, format)
+		seen[format] = struct{}{}
+	}
+
+	id := newID()
+	now := time.Now().UTC()
+	record := ExportRecord{
+		ID:          id,
+		Template:    template.Descriptor(),
+		Scope:       input.Scope,
+		Parameters:  cloneMap(input.Parameters),
+		Formats:     uniqFormats,
+		Status:      ExportStatusQueued,
+		RequestedBy: input.RequestedBy,
+		Reason:      input.Reason,
+		ProjectID:   input.ProjectID,
+		ProtocolID:  input.ProtocolID,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	w.mu.Lock()
+	w.jobs[id] = &record
+	queuedSnapshot := record.copy()
+	w.mu.Unlock()
+
+	if w.audit != nil {
+		w.audit.Record(ctx, AuditEntry{
+			ID:         newID(),
+			Action:     "dataset_export",
+			Actor:      input.RequestedBy,
+			Template:   slug,
+			Status:     ExportStatusQueued,
+			Scope:      input.Scope,
+			Reason:     input.Reason,
+			OccurredAt: now,
+		})
+	}
+
+	select {
+	case w.queue <- exportTask{id: id, input: input}:
+	default:
+		return ExportRecord{}, fmt.Errorf("export queue full")
+	}
+
+	return queuedSnapshot, nil
+}
+
+// GetExport returns a snapshot of the export record.
+func (w *Worker) GetExport(id string) (ExportRecord, bool) {
+	w.mu.RLock()
+	record, ok := w.jobs[id]
+	if !ok {
+		w.mu.RUnlock()
+		return ExportRecord{}, false
+	}
+	snapshot := record.copy()
+	w.mu.RUnlock()
+	return snapshot, true
+}
+
+func (w *Worker) process(task exportTask) {
+	record := w.snapshot(task.id)
+	if record == nil {
+		return
+	}
+
+	template, ok := w.catalog.ResolveDatasetTemplate(task.input.TemplateSlug)
+	if !ok {
+		w.fail(task.id, fmt.Sprintf("template %s missing", task.input.TemplateSlug))
+		return
+	}
+
+	w.updateStatus(task.id, ExportStatusRunning, "")
+
+	cleaned, errs := template.ValidateParameters(task.input.Parameters)
+	if len(errs) > 0 {
+		w.fail(task.id, fmt.Sprintf("parameter validation failed: %v", errs))
+		return
+	}
+
+	result, paramErrs, err := template.Run(w.ctx, cleaned, task.input.Scope, core.FormatJSON)
+	if err != nil {
+		w.fail(task.id, fmt.Sprintf("dataset run failed: %v", err))
+		return
+	}
+	if len(paramErrs) > 0 {
+		w.fail(task.id, fmt.Sprintf("parameter validation failed: %v", paramErrs))
+		return
+	}
+
+	exportArtifacts := make([]ExportArtifact, 0, len(record.Formats))
+	for _, format := range record.Formats {
+		rendered, err := w.materialize(format, template, result)
+		if err != nil {
+			w.fail(task.id, err.Error())
+			return
+		}
+		if w.store != nil {
+			stored, err := w.store.Put(w.ctx, rendered.Artifact.ID, rendered.Payload, rendered.Artifact.ContentType, rendered.Artifact.Metadata)
+			if err != nil {
+				w.fail(task.id, fmt.Sprintf("store artifact failed: %v", err))
+				return
+			}
+			stored.Format = rendered.Artifact.Format
+			if stored.ContentType == "" {
+				stored.ContentType = rendered.Artifact.ContentType
+			}
+			if stored.SizeBytes == 0 {
+				stored.SizeBytes = rendered.Artifact.SizeBytes
+			}
+			if stored.CreatedAt.IsZero() {
+				stored.CreatedAt = rendered.Artifact.CreatedAt
+			}
+			stored.Metadata = mergeMetadata(rendered.Artifact.Metadata, stored.Metadata)
+			exportArtifacts = append(exportArtifacts, stored)
+		} else {
+			exportArtifacts = append(exportArtifacts, rendered.Artifact)
+		}
+	}
+
+	w.complete(task.id, exportArtifacts)
+}
+
+func (w *Worker) snapshot(id string) *ExportRecord {
+	w.mu.RLock()
+	record, ok := w.jobs[id]
+	w.mu.RUnlock()
+	if !ok {
+		return nil
+	}
+	return record
+}
+
+func (w *Worker) updateStatus(id string, status ExportStatus, message string) {
+	now := time.Now().UTC()
+	w.mu.Lock()
+	if record, ok := w.jobs[id]; ok {
+		record.Status = status
+		record.Error = message
+		record.UpdatedAt = now
+	}
+	w.mu.Unlock()
+	if w.audit != nil {
+		w.audit.Record(w.ctx, AuditEntry{
+			ID:         newID(),
+			Action:     "dataset_export",
+			Actor:      w.actorFor(id),
+			Template:   w.templateFor(id),
+			Status:     status,
+			Scope:      w.scopeFor(id),
+			Metadata:   map[string]any{"note": message},
+			OccurredAt: now,
+		})
+	}
+}
+
+func (w *Worker) complete(id string, artifacts []ExportArtifact) {
+	now := time.Now().UTC()
+	w.mu.Lock()
+	if record, ok := w.jobs[id]; ok {
+		record.Status = ExportStatusSucceeded
+		record.Error = ""
+		record.Artifacts = artifacts
+		record.UpdatedAt = now
+		record.CompletedAt = &now
+	}
+	w.mu.Unlock()
+	if w.audit != nil {
+		w.audit.Record(w.ctx, AuditEntry{
+			ID:         newID(),
+			Action:     "dataset_export",
+			Actor:      w.actorFor(id),
+			Template:   w.templateFor(id),
+			Status:     ExportStatusSucceeded,
+			Scope:      w.scopeFor(id),
+			OccurredAt: now,
+		})
+	}
+}
+
+func (w *Worker) fail(id, reason string) {
+	now := time.Now().UTC()
+	w.mu.Lock()
+	if record, ok := w.jobs[id]; ok {
+		record.Status = ExportStatusFailed
+		record.Error = reason
+		record.UpdatedAt = now
+		record.CompletedAt = &now
+	}
+	w.mu.Unlock()
+	if w.audit != nil {
+		w.audit.Record(w.ctx, AuditEntry{
+			ID:         newID(),
+			Action:     "dataset_export",
+			Actor:      w.actorFor(id),
+			Template:   w.templateFor(id),
+			Status:     ExportStatusFailed,
+			Scope:      w.scopeFor(id),
+			Metadata:   map[string]any{"error": reason},
+			OccurredAt: now,
+		})
+	}
+}
+
+func (w *Worker) actorFor(id string) string {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	if record, ok := w.jobs[id]; ok {
+		return record.RequestedBy
+	}
+	return ""
+}
+
+func (w *Worker) templateFor(id string) string {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	if record, ok := w.jobs[id]; ok {
+		return record.Template.Slug
+	}
+	return ""
+}
+
+func (w *Worker) scopeFor(id string) core.DatasetScope {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	if record, ok := w.jobs[id]; ok {
+		return record.Scope
+	}
+	return core.DatasetScope{}
+}
+
+func (w *Worker) materialize(format core.DatasetFormat, template core.DatasetTemplate, result core.DatasetRunResult) (renderedArtifact, error) {
+	switch format {
+	case core.FormatJSON:
+		payload, err := json.Marshal(result)
+		if err != nil {
+			return renderedArtifact{}, fmt.Errorf("marshal json: %w", err)
+		}
+		return renderedArtifact{
+			Artifact: ExportArtifact{
+				ID:          newID(),
+				Format:      core.FormatJSON,
+				ContentType: "application/json",
+				SizeBytes:   int64(len(payload)),
+				Metadata: map[string]any{
+					"rows": len(result.Rows),
+				},
+				CreatedAt: time.Now().UTC(),
+			},
+			Payload: payload,
+		}, nil
+	case core.FormatCSV:
+		buf := &bytes.Buffer{}
+		writer := csv.NewWriter(buf)
+		columns := result.Schema
+		if len(columns) == 0 {
+			columns = template.Descriptor().Columns
+		}
+		headers := make([]string, len(columns))
+		for i, column := range columns {
+			headers[i] = column.Name
+		}
+		if err := writer.Write(headers); err != nil {
+			return renderedArtifact{}, err
+		}
+		for _, row := range result.Rows {
+			record := make([]string, len(columns))
+			for i, column := range columns {
+				record[i] = formatValue(row[column.Name])
+			}
+			if err := writer.Write(record); err != nil {
+				return renderedArtifact{}, err
+			}
+		}
+		writer.Flush()
+		if err := writer.Error(); err != nil {
+			return renderedArtifact{}, err
+		}
+		payload := buf.Bytes()
+		return renderedArtifact{
+			Artifact: ExportArtifact{
+				ID:          newID(),
+				Format:      core.FormatCSV,
+				ContentType: "text/csv",
+				SizeBytes:   int64(len(payload)),
+				Metadata: map[string]any{
+					"rows": len(result.Rows),
+				},
+				CreatedAt: time.Now().UTC(),
+			},
+			Payload: payload,
+		}, nil
+	case core.FormatHTML:
+		payload := buildHTML(template, result)
+		return renderedArtifact{
+			Artifact: ExportArtifact{
+				ID:          newID(),
+				Format:      core.FormatHTML,
+				ContentType: "text/html",
+				SizeBytes:   int64(len(payload)),
+				Metadata:    map[string]any{"rows": len(result.Rows)},
+				CreatedAt:   time.Now().UTC(),
+			},
+			Payload: payload,
+		}, nil
+	case core.FormatParquet:
+		payload, err := json.Marshal(result.Rows)
+		if err != nil {
+			return renderedArtifact{}, fmt.Errorf("marshall parquet surrogate: %w", err)
+		}
+		return renderedArtifact{
+			Artifact: ExportArtifact{
+				ID:          newID(),
+				Format:      core.FormatParquet,
+				ContentType: "application/octet-stream",
+				SizeBytes:   int64(len(payload)),
+				Metadata: map[string]any{
+					"note": "parquet placeholder encodes rows as JSON; replace with true writer",
+					"rows": len(result.Rows),
+				},
+				CreatedAt: time.Now().UTC(),
+			},
+			Payload: payload,
+		}, nil
+	case core.FormatPNG:
+		payload, err := buildPNG(result)
+		if err != nil {
+			return renderedArtifact{}, err
+		}
+		return renderedArtifact{
+			Artifact: ExportArtifact{
+				ID:          newID(),
+				Format:      core.FormatPNG,
+				ContentType: "image/png",
+				SizeBytes:   int64(len(payload)),
+				Metadata:    map[string]any{"rows": len(result.Rows)},
+				CreatedAt:   time.Now().UTC(),
+			},
+			Payload: payload,
+		}, nil
+	default:
+		return renderedArtifact{}, fmt.Errorf("unsupported export format %s", format)
+	}
+}
+
+func buildHTML(template core.DatasetTemplate, result core.DatasetRunResult) []byte {
+	columns := result.Schema
+	if len(columns) == 0 {
+		columns = template.Descriptor().Columns
+	}
+	buf := &strings.Builder{}
+	buf.WriteString("<!DOCTYPE html><html><head><meta charset=\"utf-8\"><title>")
+	buf.WriteString(template.Title)
+	buf.WriteString("</title></head><body><table>")
+	buf.WriteString("<thead><tr>")
+	for _, column := range columns {
+		buf.WriteString("<th>")
+		buf.WriteString(column.Name)
+		buf.WriteString("</th>")
+	}
+	buf.WriteString("</tr></thead><tbody>")
+	for _, row := range result.Rows {
+		buf.WriteString("<tr>")
+		for _, column := range columns {
+			buf.WriteString("<td>")
+			buf.WriteString(formatValue(row[column.Name]))
+			buf.WriteString("</td>")
+		}
+		buf.WriteString("</tr>")
+	}
+	buf.WriteString("</tbody></table></body></html>")
+	return []byte(buf.String())
+}
+
+func buildPNG(result core.DatasetRunResult) ([]byte, error) {
+	width := 400
+	height := 200
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	draw.Draw(img, img.Bounds(), &image.Uniform{color.White}, image.Point{}, draw.Src)
+
+	rowCount := len(result.Rows)
+	if rowCount == 0 {
+		rowCount = 1
+	}
+	barWidth := width / rowCount
+	if barWidth < 1 {
+		barWidth = 1
+	}
+	for i := 0; i < len(result.Rows); i++ {
+		x0 := i * barWidth
+		x1 := x0 + barWidth - 2
+		if x1 <= x0 {
+			x1 = x0 + 1
+		}
+		heightFactor := int(float64(height-20) * 0.6)
+		y0 := height - heightFactor
+		y1 := height - 10
+		rect := image.Rect(x0, y0, x1, y1)
+		draw.Draw(img, rect, &image.Uniform{color.RGBA{0, 102, 204, 255}}, image.Point{}, draw.Src)
+	}
+	buf := &bytes.Buffer{}
+	if err := png.Encode(buf, img); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func mergeMetadata(base map[string]any, extra map[string]any) map[string]any {
+	if len(base) == 0 && len(extra) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(base)+len(extra))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range extra {
+		out[k] = v
+	}
+	return out
+}
+
+func (r ExportRecord) copy() ExportRecord {
+	dup := r
+	dup.Parameters = cloneMap(r.Parameters)
+	dup.Formats = append([]core.DatasetFormat(nil), r.Formats...)
+	if len(r.Artifacts) > 0 {
+		dup.Artifacts = append([]ExportArtifact(nil), r.Artifacts...)
+	}
+	return dup
+}
+
+func cloneMap(in map[string]any) map[string]any {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func newID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		panic(err)
+	}
+	return fmt.Sprintf("%x", b[:])
+}
+
+// MemoryObjectStore is an in-memory implementation of ObjectStore for tests.
+type MemoryObjectStore struct {
+	mu      sync.RWMutex
+	objects map[string]ExportArtifact
+}
+
+// NewMemoryObjectStore constructs an in-memory object store.
+func NewMemoryObjectStore() *MemoryObjectStore {
+	return &MemoryObjectStore{objects: make(map[string]ExportArtifact)}
+}
+
+// Put stores payload metadata and returns a signed URL for retrieval.
+func (s *MemoryObjectStore) Put(ctx context.Context, key string, payload []byte, contentType string, metadata map[string]any) (ExportArtifact, error) {
+	now := time.Now().UTC()
+	artifact := ExportArtifact{
+		ID:          key,
+		ContentType: contentType,
+		SizeBytes:   int64(len(payload)),
+		Metadata:    cloneMap(metadata),
+		CreatedAt:   now,
+		URL:         fmt.Sprintf("https://object-store.local/%s?token=stub", key),
+	}
+	s.mu.Lock()
+	s.objects[key] = artifact
+	s.mu.Unlock()
+	return artifact, nil
+}
+
+// Objects returns stored artifacts for inspection in tests.
+func (s *MemoryObjectStore) Objects() []ExportArtifact {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]ExportArtifact, 0, len(s.objects))
+	for _, artifact := range s.objects {
+		out = append(out, artifact)
+	}
+	return out
+}
+
+// MemoryAuditLog captures audit entries in-memory for assertions.
+type MemoryAuditLog struct {
+	mu      sync.Mutex
+	entries []AuditEntry
+}
+
+// Record stores an audit entry.
+func (l *MemoryAuditLog) Record(ctx context.Context, entry AuditEntry) {
+	l.mu.Lock()
+	l.entries = append(l.entries, entry)
+	l.mu.Unlock()
+}
+
+// Entries returns a defensive copy of recorded audit entries.
+func (l *MemoryAuditLog) Entries() []AuditEntry {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]AuditEntry, len(l.entries))
+	copy(out, l.entries)
+	return out
+}

--- a/internal/dataset/exporter_internal_test.go
+++ b/internal/dataset/exporter_internal_test.go
@@ -1,0 +1,675 @@
+package dataset
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"colonycore/internal/core"
+)
+
+type stringer struct{}
+
+func (stringer) String() string { return "stringer" }
+
+func TestMaterializeFormats(t *testing.T) {
+	worker := NewWorker(nil, nil, nil)
+	template := core.DatasetTemplate{
+		Plugin:        "frog",
+		Key:           "population",
+		Version:       "1.0.0",
+		Title:         "Population",
+		Description:   "demo",
+		OutputFormats: []core.DatasetFormat{core.FormatJSON, core.FormatCSV, core.FormatHTML, core.FormatParquet, core.FormatPNG},
+		Columns: []core.DatasetColumn{{
+			Name: "value",
+			Type: "string",
+		}},
+	}
+	result := core.DatasetRunResult{
+		Schema: []core.DatasetColumn{{Name: "value", Type: "string"}},
+		Rows: []map[string]any{{
+			"value": "alpha",
+		}},
+		GeneratedAt: time.Now().UTC(),
+		Format:      core.FormatJSON,
+	}
+
+	formats := []core.DatasetFormat{core.FormatJSON, core.FormatCSV, core.FormatHTML, core.FormatParquet, core.FormatPNG}
+	for _, format := range formats {
+		t.Run(string(format), func(t *testing.T) {
+			rendered, err := worker.materialize(format, template, result)
+			if err != nil {
+				t.Fatalf("materialize %s: %v", format, err)
+			}
+			if len(rendered.Payload) == 0 {
+				t.Fatalf("expected payload for %s", format)
+			}
+			if rendered.Artifact.Format != format {
+				t.Fatalf("unexpected artifact format: %s", rendered.Artifact.Format)
+			}
+		})
+	}
+
+	if _, err := worker.materialize(core.DatasetFormat("geojson"), template, result); err == nil {
+		t.Fatalf("expected unsupported format error")
+	}
+}
+
+func TestBuildPNGEmpty(t *testing.T) {
+	result := core.DatasetRunResult{}
+	pngPayload, err := buildPNG(result)
+	if err != nil {
+		t.Fatalf("buildPNG: %v", err)
+	}
+	if len(pngPayload) == 0 {
+		t.Fatalf("expected png payload")
+	}
+}
+
+func TestWorkerFailUpdatesRecord(t *testing.T) {
+	worker := NewWorker(nil, nil, &MemoryAuditLog{})
+	id := "export"
+	worker.mu.Lock()
+	worker.jobs[id] = &ExportRecord{
+		ID:          id,
+		RequestedBy: "analyst",
+		Template: core.DatasetTemplateDescriptor{
+			Slug: "frog/population@1.0.0",
+		},
+	}
+	worker.mu.Unlock()
+
+	worker.fail(id, "validation failed")
+
+	record, ok := worker.GetExport(id)
+	if !ok {
+		t.Fatalf("expected export record")
+	}
+	if record.Status != ExportStatusFailed {
+		t.Fatalf("expected failed status, got %s", record.Status)
+	}
+	if record.Error == "" {
+		t.Fatalf("expected error message to be recorded")
+	}
+}
+
+func TestFormatValueVariants(t *testing.T) {
+	timeVal := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	tests := []struct {
+		name   string
+		in     any
+		expect string
+	}{
+		{"nil", nil, ""},
+		{"time", timeVal, timeVal.Format(time.RFC3339)},
+		{"stringer", stringer{}, "stringer"},
+		{"float32", float32(1.5), "1.5"},
+		{"float64", float64(2.5), "2.5"},
+		{"int", 7, "7"},
+		{"int64", int64(9), "9"},
+		{"bool", true, "true"},
+		{"default", []int{1, 2}, "[1 2]"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatValue(tc.in); got != tc.expect {
+				t.Fatalf("expected %q, got %q", tc.expect, got)
+			}
+		})
+	}
+}
+
+func TestWriteError(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	writeError(recorder, http.StatusBadRequest, "bad request")
+
+	if status := recorder.Result().StatusCode; status != http.StatusBadRequest {
+		t.Fatalf("unexpected status: %d", status)
+	}
+
+	body := recorder.Body.String()
+	if !strings.Contains(body, "bad request") {
+		t.Fatalf("expected error body, got %s", body)
+	}
+}
+
+type failingStore struct{}
+
+func (f failingStore) Put(context.Context, string, []byte, string, map[string]any) (ExportArtifact, error) {
+	return ExportArtifact{}, fmt.Errorf("store offline")
+}
+
+type testDatasetPlugin struct {
+	dataset core.DatasetTemplate
+}
+
+func (p testDatasetPlugin) Name() string { return "test-dataset" }
+
+func (p testDatasetPlugin) Version() string { return "0.0.1" }
+
+func (p testDatasetPlugin) Register(registry *core.PluginRegistry) error {
+	return registry.RegisterDatasetTemplate(p.dataset)
+}
+
+func TestWorkerProcessParameterFailure(t *testing.T) {
+	template := core.DatasetTemplate{
+		Plugin:      "frog",
+		Key:         "fail",
+		Version:     "1.0.0",
+		Title:       "Fail",
+		Description: "missing params",
+		Dialect:     core.DatasetDialectSQL,
+		Query:       "SELECT 1",
+		Parameters: []core.DatasetParameter{{
+			Name:     "required",
+			Type:     "string",
+			Required: true,
+		}},
+		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
+		OutputFormats: []core.DatasetFormat{core.FormatJSON},
+		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
+			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
+				return core.DatasetRunResult{}, nil
+			}, nil
+		},
+	}
+	svc := core.NewInMemoryService(core.NewDefaultRulesEngine())
+	if _, err := svc.InstallPlugin(testDatasetPlugin{dataset: template}); err != nil {
+		t.Fatalf("install plugin: %v", err)
+	}
+	worker := NewWorker(svc, nil, &MemoryAuditLog{})
+	worker.Start()
+	t.Cleanup(func() {
+		_ = worker.Stop(context.Background())
+	})
+
+	slug := svc.DatasetTemplates()[0].Slug
+	queued, err := worker.EnqueueExport(context.Background(), ExportInput{TemplateSlug: slug, RequestedBy: "analyst", Formats: []core.DatasetFormat{core.FormatJSON}})
+	if err != nil {
+		t.Fatalf("enqueue export: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		record, _ := worker.GetExport(queued.ID)
+		if record.Status == ExportStatusFailed {
+			if !strings.Contains(record.Error, "required parameter") {
+				t.Fatalf("expected parameter failure, got %s", record.Error)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("export did not fail in time: %+v", record)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestWorkerProcessStoreFailure(t *testing.T) {
+	template := core.DatasetTemplate{
+		Plugin:        "frog",
+		Key:           "store",
+		Version:       "1.0.0",
+		Title:         "Store",
+		Description:   "store failure",
+		Dialect:       core.DatasetDialectSQL,
+		Query:         "SELECT 1",
+		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
+		OutputFormats: []core.DatasetFormat{core.FormatJSON, core.FormatCSV},
+		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
+			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
+				return core.DatasetRunResult{
+					Rows: []map[string]any{{"value": "ok"}},
+				}, nil
+			}, nil
+		},
+	}
+	svc := core.NewInMemoryService(core.NewDefaultRulesEngine())
+	if _, err := svc.InstallPlugin(testDatasetPlugin{dataset: template}); err != nil {
+		t.Fatalf("install plugin: %v", err)
+	}
+	store := failingStore{}
+	worker := NewWorker(svc, store, &MemoryAuditLog{})
+	worker.Start()
+	t.Cleanup(func() {
+		_ = worker.Stop(context.Background())
+	})
+
+	slug := svc.DatasetTemplates()[0].Slug
+	queued, err := worker.EnqueueExport(context.Background(), ExportInput{TemplateSlug: slug, RequestedBy: "analyst"})
+	if err != nil {
+		t.Fatalf("enqueue export: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		record, _ := worker.GetExport(queued.ID)
+		if record.Status == ExportStatusFailed {
+			if !strings.Contains(record.Error, "store artifact failed") {
+				t.Fatalf("expected store failure, got %s", record.Error)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("export did not fail due to store error in time: %+v", record)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestWorkerProcessSuccessMultipleFormats(t *testing.T) {
+	template := core.DatasetTemplate{
+		Plugin:        "frog",
+		Key:           "success",
+		Version:       "1.0.0",
+		Title:         "Success",
+		Description:   "multi format",
+		Dialect:       core.DatasetDialectSQL,
+		Query:         "SELECT 1",
+		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
+		OutputFormats: []core.DatasetFormat{core.FormatJSON, core.FormatCSV, core.FormatHTML},
+		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
+			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
+				return core.DatasetRunResult{
+					Rows: []map[string]any{{"value": "ok"}},
+				}, nil
+			}, nil
+		},
+	}
+	svc := core.NewInMemoryService(core.NewDefaultRulesEngine())
+	if _, err := svc.InstallPlugin(testDatasetPlugin{dataset: template}); err != nil {
+		t.Fatalf("install plugin: %v", err)
+	}
+	store := NewMemoryObjectStore()
+	audit := &MemoryAuditLog{}
+	worker := NewWorker(svc, store, audit)
+	worker.Start()
+	t.Cleanup(func() {
+		_ = worker.Stop(context.Background())
+	})
+
+	slug := svc.DatasetTemplates()[0].Slug
+	formats := []core.DatasetFormat{core.FormatJSON, core.FormatCSV, core.FormatHTML}
+	queued, err := worker.EnqueueExport(context.Background(), ExportInput{TemplateSlug: slug, RequestedBy: "analyst", Formats: formats})
+	if err != nil {
+		t.Fatalf("enqueue export: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		record, _ := worker.GetExport(queued.ID)
+		if record.Status == ExportStatusSucceeded {
+			if len(record.Artifacts) != len(formats) {
+				t.Fatalf("expected %d artifacts, got %d", len(formats), len(record.Artifacts))
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("export did not succeed in time: %+v", record)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if len(store.Objects()) == 0 {
+		t.Fatalf("expected artifacts stored")
+	}
+}
+
+type flakyCatalog struct {
+	template core.DatasetTemplate
+	used     bool
+}
+
+func (f *flakyCatalog) DatasetTemplates() []core.DatasetTemplateDescriptor {
+	return []core.DatasetTemplateDescriptor{f.template.Descriptor()}
+}
+
+func (f *flakyCatalog) ResolveDatasetTemplate(slug string) (core.DatasetTemplate, bool) {
+	if !f.used && slug == f.template.Descriptor().Slug {
+		f.used = true
+		return f.template, true
+	}
+	return core.DatasetTemplate{}, false
+}
+
+func TestWorkerProcessTemplateMissing(t *testing.T) {
+	template := core.DatasetTemplate{
+		Plugin:        "frog",
+		Key:           "missing",
+		Version:       "1.0.0",
+		Title:         "Missing",
+		Description:   "catalog drops template",
+		Dialect:       core.DatasetDialectSQL,
+		Query:         "SELECT 1",
+		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
+		OutputFormats: []core.DatasetFormat{core.FormatJSON},
+		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
+			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
+				return core.DatasetRunResult{Rows: []map[string]any{{"value": "ok"}}}, nil
+			}, nil
+		},
+	}
+	flaky := &flakyCatalog{template: template}
+	worker := NewWorker(flaky, nil, &MemoryAuditLog{})
+	worker.Start()
+	t.Cleanup(func() {
+		closeCh := make(chan struct{})
+		go func() {
+			_ = worker.Stop(context.Background())
+			close(closeCh)
+		}()
+		select {
+		case <-closeCh:
+		case <-time.After(time.Second):
+			t.Fatalf("worker did not stop")
+		}
+	})
+
+	descriptor := flaky.DatasetTemplates()[0]
+	queued, err := worker.EnqueueExport(context.Background(), ExportInput{TemplateSlug: descriptor.Slug, RequestedBy: "analyst", Formats: []core.DatasetFormat{core.FormatJSON}})
+	if err != nil {
+		t.Fatalf("enqueue export: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		record, _ := worker.GetExport(queued.ID)
+		if record.Status == ExportStatusFailed {
+			if !strings.Contains(record.Error, "template") {
+				t.Fatalf("expected template missing error, got %s", record.Error)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("export did not fail for missing template in time: %+v", record)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestWorkerActorTemplateScopeFallback(t *testing.T) {
+	worker := NewWorker(nil, nil, nil)
+	if actor := worker.actorFor("unknown"); actor != "" {
+		t.Fatalf("expected empty actor, got %s", actor)
+	}
+	if slug := worker.templateFor("unknown"); slug != "" {
+		t.Fatalf("expected empty template slug, got %s", slug)
+	}
+	if scope := worker.scopeFor("unknown"); scope.Requestor != "" || len(scope.ProjectIDs) != 0 {
+		t.Fatalf("expected zero-value scope, got %+v", scope)
+	}
+}
+
+func TestWorkerProcessSnapshotMissing(t *testing.T) {
+	worker := NewWorker(nil, nil, nil)
+	worker.process(exportTask{id: "missing"})
+}
+
+type staticCatalog struct {
+	template core.DatasetTemplate
+}
+
+func (s staticCatalog) DatasetTemplates() []core.DatasetTemplateDescriptor {
+	return []core.DatasetTemplateDescriptor{s.template.Descriptor()}
+}
+
+func (s staticCatalog) ResolveDatasetTemplate(slug string) (core.DatasetTemplate, bool) {
+	if slug == s.template.Descriptor().Slug {
+		return s.template, true
+	}
+	return core.DatasetTemplate{}, false
+}
+
+func TestWorkerEnqueueQueueFull(t *testing.T) {
+	templateDef := core.DatasetTemplate{
+		Plugin:        "frog",
+		Key:           "queue",
+		Version:       "1.0.0",
+		Title:         "Queue",
+		Description:   "queue fill",
+		Dialect:       core.DatasetDialectSQL,
+		Query:         "SELECT 1",
+		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
+		OutputFormats: []core.DatasetFormat{core.FormatJSON, core.FormatCSV},
+		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
+			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
+				return core.DatasetRunResult{Rows: []map[string]any{{"value": "ok"}}}, nil
+			}, nil
+		},
+	}
+	svc := core.NewInMemoryService(core.NewDefaultRulesEngine())
+	if _, err := svc.InstallPlugin(testDatasetPlugin{dataset: templateDef}); err != nil {
+		t.Fatalf("install plugin: %v", err)
+	}
+	descriptor := svc.DatasetTemplates()[0]
+	bound, ok := svc.ResolveDatasetTemplate(descriptor.Slug)
+	if !ok {
+		t.Fatalf("resolve template")
+	}
+	catalog := staticCatalog{template: bound}
+	worker := NewWorker(catalog, nil, nil)
+	for i := 0; i < cap(worker.queue); i++ {
+		if _, err := worker.EnqueueExport(context.Background(), ExportInput{TemplateSlug: descriptor.Slug}); err != nil {
+			t.Fatalf("unexpected enqueue error at %d: %v", i, err)
+		}
+	}
+	if _, err := worker.EnqueueExport(context.Background(), ExportInput{TemplateSlug: descriptor.Slug}); err == nil {
+		t.Fatalf("expected queue full error")
+	}
+}
+
+func TestWorkerProcessSuccessWithoutStore(t *testing.T) {
+	templateDef := core.DatasetTemplate{
+		Plugin:        "frog",
+		Key:           "nostore",
+		Version:       "1.0.0",
+		Title:         "No Store",
+		Description:   "no object store",
+		Dialect:       core.DatasetDialectSQL,
+		Query:         "SELECT 1",
+		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
+		OutputFormats: []core.DatasetFormat{core.FormatJSON},
+		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
+			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
+				return core.DatasetRunResult{Rows: []map[string]any{{"value": "ok"}}}, nil
+			}, nil
+		},
+	}
+	svc := core.NewInMemoryService(core.NewDefaultRulesEngine())
+	if _, err := svc.InstallPlugin(testDatasetPlugin{dataset: templateDef}); err != nil {
+		t.Fatalf("install plugin: %v", err)
+	}
+	descriptor := svc.DatasetTemplates()[0]
+	bound, ok := svc.ResolveDatasetTemplate(descriptor.Slug)
+	if !ok {
+		t.Fatalf("resolve template")
+	}
+	catalog := staticCatalog{template: bound}
+	worker := NewWorker(catalog, nil, &MemoryAuditLog{})
+	worker.Start()
+	t.Cleanup(func() { _ = worker.Stop(context.Background()) })
+	queued, err := worker.EnqueueExport(context.Background(), ExportInput{TemplateSlug: descriptor.Slug, RequestedBy: "analyst", Formats: []core.DatasetFormat{core.FormatJSON}})
+	if err != nil {
+		t.Fatalf("enqueue export: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		record, _ := worker.GetExport(queued.ID)
+		if record.Status == ExportStatusSucceeded {
+			if len(record.Artifacts) != 1 {
+				t.Fatalf("expected single artifact without store, got %d", len(record.Artifacts))
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("export did not succeed without store in time: %+v", record)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+type zeroStore struct{}
+
+func (zeroStore) Put(context.Context, string, []byte, string, map[string]any) (ExportArtifact, error) {
+	return ExportArtifact{ID: newID()}, nil
+}
+
+func TestWorkerProcessStoreNormalization(t *testing.T) {
+	templateDef := core.DatasetTemplate{
+		Plugin:        "frog",
+		Key:           "normalize",
+		Version:       "1.0.0",
+		Title:         "Normalize",
+		Description:   "normalize stored artifacts",
+		Dialect:       core.DatasetDialectSQL,
+		Query:         "SELECT 1",
+		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
+		OutputFormats: []core.DatasetFormat{core.FormatJSON},
+		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
+			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
+				return core.DatasetRunResult{Rows: []map[string]any{{"value": "ok"}}}, nil
+			}, nil
+		},
+	}
+	svc := core.NewInMemoryService(core.NewDefaultRulesEngine())
+	if _, err := svc.InstallPlugin(testDatasetPlugin{dataset: templateDef}); err != nil {
+		t.Fatalf("install plugin: %v", err)
+	}
+	descriptor := svc.DatasetTemplates()[0]
+	bound, ok := svc.ResolveDatasetTemplate(descriptor.Slug)
+	if !ok {
+		t.Fatalf("resolve template")
+	}
+	catalog := staticCatalog{template: bound}
+	worker := NewWorker(catalog, zeroStore{}, &MemoryAuditLog{})
+	worker.Start()
+	t.Cleanup(func() { _ = worker.Stop(context.Background()) })
+	queued, err := worker.EnqueueExport(context.Background(), ExportInput{TemplateSlug: descriptor.Slug, RequestedBy: "analyst", Formats: []core.DatasetFormat{core.FormatJSON}})
+	if err != nil {
+		t.Fatalf("enqueue export: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		record, _ := worker.GetExport(queued.ID)
+		if record.Status == ExportStatusSucceeded {
+			if len(record.Artifacts) != 1 {
+				t.Fatalf("expected normalized artifact, got %d", len(record.Artifacts))
+			}
+			artifact := record.Artifacts[0]
+			if artifact.ContentType != "application/json" || artifact.SizeBytes == 0 {
+				t.Fatalf("expected content type and size to be set, got %+v", artifact)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("export did not complete in time: %+v", record)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestWorkerEnqueueRequiresSlug(t *testing.T) {
+	worker := NewWorker(staticCatalog{}, nil, nil)
+	if _, err := worker.EnqueueExport(context.Background(), ExportInput{}); err == nil {
+		t.Fatalf("expected error when slug missing")
+	}
+}
+
+func TestWorkerEnqueueCatalogNil(t *testing.T) {
+	worker := NewWorker(nil, nil, nil)
+	if _, err := worker.EnqueueExport(context.Background(), ExportInput{TemplateSlug: "frog/demo@1.0.0"}); err == nil {
+		t.Fatalf("expected error when catalog missing")
+	}
+}
+
+func TestWorkerEnqueueDeduplicatesFormats(t *testing.T) {
+	templateDef := core.DatasetTemplate{
+		Plugin:        "frog",
+		Key:           "dedupe",
+		Version:       "1.0.0",
+		Title:         "Dedupe",
+		Description:   "dedupe formats",
+		Dialect:       core.DatasetDialectSQL,
+		Query:         "SELECT 1",
+		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
+		OutputFormats: []core.DatasetFormat{core.FormatJSON, core.FormatCSV},
+		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
+			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
+				return core.DatasetRunResult{Rows: []map[string]any{{"value": "ok"}}}, nil
+			}, nil
+		},
+	}
+	svc := core.NewInMemoryService(core.NewDefaultRulesEngine())
+	if _, err := svc.InstallPlugin(testDatasetPlugin{dataset: templateDef}); err != nil {
+		t.Fatalf("install plugin: %v", err)
+	}
+	descriptor := svc.DatasetTemplates()[0]
+	bound, ok := svc.ResolveDatasetTemplate(descriptor.Slug)
+	if !ok {
+		t.Fatalf("resolve template")
+	}
+	catalog := staticCatalog{template: bound}
+	worker := NewWorker(catalog, nil, nil)
+	record, err := worker.EnqueueExport(context.Background(), ExportInput{TemplateSlug: descriptor.Slug, Formats: []core.DatasetFormat{core.FormatJSON, core.FormatCSV, core.FormatJSON}})
+	if err != nil {
+		t.Fatalf("enqueue export: %v", err)
+	}
+	if len(record.Formats) != 2 {
+		t.Fatalf("expected deduplicated formats, got %v", record.Formats)
+	}
+}
+
+func TestWorkerStopContextDeadline(t *testing.T) {
+	block := make(chan struct{})
+	started := make(chan struct{})
+	template := core.DatasetTemplate{
+		Plugin:        "frog",
+		Key:           "stop",
+		Version:       "1.0.0",
+		Title:         "Stop",
+		Description:   "blocking runner",
+		Dialect:       core.DatasetDialectSQL,
+		Query:         "SELECT 1",
+		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
+		OutputFormats: []core.DatasetFormat{core.FormatJSON},
+		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
+			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
+				close(started)
+				<-block
+				return core.DatasetRunResult{Rows: []map[string]any{{"value": "ok"}}}, nil
+			}, nil
+		},
+	}
+	svc := core.NewInMemoryService(core.NewDefaultRulesEngine())
+	if _, err := svc.InstallPlugin(testDatasetPlugin{dataset: template}); err != nil {
+		t.Fatalf("install plugin: %v", err)
+	}
+	worker := NewWorker(svc, NewMemoryObjectStore(), &MemoryAuditLog{})
+	worker.Start()
+	slug := svc.DatasetTemplates()[0].Slug
+	if _, err := worker.EnqueueExport(context.Background(), ExportInput{TemplateSlug: slug, RequestedBy: "analyst", Formats: []core.DatasetFormat{core.FormatJSON}}); err != nil {
+		t.Fatalf("enqueue export: %v", err)
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatalf("runner did not start in time")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	if err := worker.Stop(ctx); err == nil {
+		t.Fatalf("expected context deadline error from Stop")
+	}
+
+	close(block)
+	if err := worker.Stop(context.Background()); err != nil {
+		t.Fatalf("second stop should succeed: %v", err)
+	}
+}

--- a/internal/dataset/exporter_test.go
+++ b/internal/dataset/exporter_test.go
@@ -1,0 +1,97 @@
+package dataset_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"colonycore/internal/core"
+	"colonycore/internal/dataset"
+	"colonycore/plugins/frog"
+)
+
+func TestWorkerProcessesExport(t *testing.T) {
+	svc := core.NewInMemoryService(core.NewDefaultRulesEngine())
+	meta, err := svc.InstallPlugin(frog.New())
+	if err != nil {
+		t.Fatalf("install plugin: %v", err)
+	}
+	descriptor := meta.Datasets[0]
+
+	store := dataset.NewMemoryObjectStore()
+	audit := &dataset.MemoryAuditLog{}
+	worker := dataset.NewWorker(svc, store, audit)
+	worker.Start()
+	t.Cleanup(func() {
+		_ = worker.Stop(context.Background())
+	})
+
+	ctx := context.Background()
+	project, _, err := svc.CreateProject(ctx, core.Project{Code: "PRJ-WORK", Title: "Worker"})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	projectID := project.ID
+	if _, _, err := svc.CreateOrganism(ctx, core.Organism{Name: "Frog", Species: "Tree Frog", Stage: core.StageAdult, ProjectID: &projectID}); err != nil {
+		t.Fatalf("create organism: %v", err)
+	}
+
+	record, err := worker.EnqueueExport(ctx, dataset.ExportInput{
+		TemplateSlug: descriptor.Slug,
+		Parameters:   map[string]any{"include_retired": true},
+		Formats:      []core.DatasetFormat{core.FormatJSON},
+		Scope:        core.DatasetScope{ProjectIDs: []string{project.ID}, Requestor: "worker@colonycore"},
+		RequestedBy:  "worker@colonycore",
+	})
+	if err != nil {
+		t.Fatalf("enqueue export: %v", err)
+	}
+	if record.Status != dataset.ExportStatusQueued {
+		t.Fatalf("expected queued status, got %s", record.Status)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		current, _ := worker.GetExport(record.ID)
+		if current.Status == dataset.ExportStatusSucceeded {
+			if len(current.Artifacts) == 0 {
+				t.Fatalf("expected artifacts on completion")
+			}
+			break
+		}
+		if current.Status == dataset.ExportStatusFailed {
+			t.Fatalf("export failed: %s", current.Error)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timeout waiting for worker completion")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if len(store.Objects()) == 0 {
+		t.Fatalf("expected object store to contain artifacts")
+	}
+	if len(audit.Entries()) == 0 {
+		t.Fatalf("expected audit entries")
+	}
+}
+
+func TestWorkerRejectsUnsupportedFormat(t *testing.T) {
+	svc := core.NewInMemoryService(core.NewDefaultRulesEngine())
+	meta, err := svc.InstallPlugin(frog.New())
+	if err != nil {
+		t.Fatalf("install plugin: %v", err)
+	}
+	descriptor := meta.Datasets[0]
+
+	worker := dataset.NewWorker(svc, dataset.NewMemoryObjectStore(), &dataset.MemoryAuditLog{})
+	ctx := context.Background()
+
+	_, err = worker.EnqueueExport(ctx, dataset.ExportInput{
+		TemplateSlug: descriptor.Slug,
+		Formats:      []core.DatasetFormat{core.DatasetFormat("xml")},
+	})
+	if err == nil {
+		t.Fatalf("expected error for unsupported format")
+	}
+}

--- a/internal/dataset/handler.go
+++ b/internal/dataset/handler.go
@@ -1,0 +1,422 @@
+package dataset
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"colonycore/internal/core"
+)
+
+// Catalog exposes dataset templates for HTTP handlers.
+type Catalog interface {
+	DatasetTemplates() []core.DatasetTemplateDescriptor
+	ResolveDatasetTemplate(slug string) (core.DatasetTemplate, bool)
+}
+
+// Handler provides HTTP access to dataset templates and exports.
+type Handler struct {
+	Catalog Catalog
+	Exports ExportScheduler
+}
+
+// NewHandler constructs a dataset HTTP handler.
+func NewHandler(c Catalog) *Handler {
+	return &Handler{Catalog: c}
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h.Catalog == nil {
+		writeError(w, http.StatusInternalServerError, "dataset catalog not configured")
+		return
+	}
+
+	path := strings.TrimSuffix(r.URL.Path, "/")
+	switch {
+	case r.Method == http.MethodGet && path == "/api/v1/datasets/templates":
+		h.handleListTemplates(w, r)
+		return
+	case strings.HasPrefix(path, "/api/v1/datasets/exports"):
+		if h.Exports == nil {
+			http.NotFound(w, r)
+			return
+		}
+		h.handleExports(w, r, path)
+		return
+	case strings.HasPrefix(path, "/api/v1/datasets/templates/"):
+		h.handleTemplate(w, r, strings.TrimPrefix(path, "/api/v1/datasets/templates/"))
+		return
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (h *Handler) handleListTemplates(w http.ResponseWriter, r *http.Request) {
+	templates := h.Catalog.DatasetTemplates()
+	sort.Sort(core.DatasetTemplateCollection(templates))
+	writeJSON(w, http.StatusOK, map[string]any{"templates": templates})
+}
+
+func (h *Handler) handleTemplate(w http.ResponseWriter, r *http.Request, remainder string) {
+	segments := strings.Split(remainder, "/")
+	if len(segments) < 3 {
+		writeError(w, http.StatusNotFound, "dataset template not found")
+		return
+	}
+	plugin, key, version := segments[0], segments[1], segments[2]
+	slug := fmt.Sprintf("%s/%s@%s", plugin, key, version)
+
+	template, ok := h.Catalog.ResolveDatasetTemplate(slug)
+	if !ok {
+		writeError(w, http.StatusNotFound, "dataset template not found")
+		return
+	}
+
+	descriptor := template.Descriptor()
+
+	if len(segments) == 3 {
+		if r.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"template": descriptor})
+		return
+	}
+
+	if len(segments) != 4 {
+		writeError(w, http.StatusNotFound, "dataset endpoint not found")
+		return
+	}
+
+	action := segments[3]
+	switch action {
+	case "validate":
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		h.handleValidate(w, r, template)
+	case "run":
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		h.handleRun(w, r, template)
+	default:
+		writeError(w, http.StatusNotFound, "dataset endpoint not found")
+	}
+}
+
+func (h *Handler) handleExports(w http.ResponseWriter, r *http.Request, path string) {
+	if path == "/api/v1/datasets/exports" {
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		h.handleExportCreate(w, r)
+		return
+	}
+
+	if !strings.HasPrefix(path, "/api/v1/datasets/exports/") {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	id := strings.TrimPrefix(path, "/api/v1/datasets/exports/")
+	if id == "" {
+		http.NotFound(w, r)
+		return
+	}
+	record, ok := h.Exports.GetExport(id)
+	if !ok {
+		writeError(w, http.StatusNotFound, "export not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"export": record})
+}
+
+type validationRequest struct {
+	Parameters map[string]any `json:"parameters"`
+}
+
+type validationResponse struct {
+	Template   core.DatasetTemplateDescriptor `json:"template"`
+	Valid      bool                           `json:"valid"`
+	Parameters map[string]any                 `json:"parameters"`
+	Errors     []core.DatasetParameterError   `json:"errors,omitempty"`
+}
+
+func (h *Handler) handleValidate(w http.ResponseWriter, r *http.Request, template core.DatasetTemplate) {
+	var req validationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err.Error() != "EOF" {
+		writeError(w, http.StatusBadRequest, "invalid validation request payload")
+		return
+	}
+	cleaned, errs := template.ValidateParameters(req.Parameters)
+	writeJSON(w, http.StatusOK, validationResponse{
+		Template:   template.Descriptor(),
+		Valid:      len(errs) == 0,
+		Parameters: cleaned,
+		Errors:     errs,
+	})
+}
+
+type runRequest struct {
+	Parameters map[string]any `json:"parameters"`
+	Scope      struct {
+		Requestor   string   `json:"requestor"`
+		Roles       []string `json:"roles"`
+		ProjectIDs  []string `json:"project_ids"`
+		ProtocolIDs []string `json:"protocol_ids"`
+	} `json:"scope"`
+}
+
+type runResponse struct {
+	Template   core.DatasetTemplateDescriptor `json:"template"`
+	Scope      core.DatasetScope              `json:"scope"`
+	Parameters map[string]any                 `json:"parameters"`
+	Result     core.DatasetRunResult          `json:"result"`
+}
+
+type exportRequest struct {
+	Template struct {
+		Slug    string `json:"slug"`
+		Plugin  string `json:"plugin"`
+		Key     string `json:"key"`
+		Version string `json:"version"`
+	} `json:"template"`
+	Parameters map[string]any `json:"parameters"`
+	Formats    []string       `json:"formats"`
+	Scope      struct {
+		Requestor   string   `json:"requestor"`
+		Roles       []string `json:"roles"`
+		ProjectIDs  []string `json:"project_ids"`
+		ProtocolIDs []string `json:"protocol_ids"`
+	} `json:"scope"`
+	RequestedBy string `json:"requested_by"`
+	Reason      string `json:"reason"`
+	ProjectID   string `json:"project_id"`
+	ProtocolID  string `json:"protocol_id"`
+}
+
+func (h *Handler) handleRun(w http.ResponseWriter, r *http.Request, template core.DatasetTemplate) {
+	var req runRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err.Error() != "EOF" {
+		writeError(w, http.StatusBadRequest, "invalid run request payload")
+		return
+	}
+
+	scope := core.DatasetScope{
+		Requestor:   req.Scope.Requestor,
+		Roles:       req.Scope.Roles,
+		ProjectIDs:  req.Scope.ProjectIDs,
+		ProtocolIDs: req.Scope.ProtocolIDs,
+	}
+
+	cleaned, errs := template.ValidateParameters(req.Parameters)
+	if len(errs) > 0 {
+		writeJSON(w, http.StatusBadRequest, validationResponse{
+			Template:   template.Descriptor(),
+			Valid:      false,
+			Parameters: cleaned,
+			Errors:     errs,
+		})
+		return
+	}
+
+	format := negotiateFormat(r, template.OutputFormats)
+	if format == "" {
+		writeError(w, http.StatusNotAcceptable, "requested format not supported")
+		return
+	}
+
+	result, paramErrs, err := template.Run(r.Context(), cleaned, scope, core.DatasetFormat(format))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if len(paramErrs) > 0 {
+		writeJSON(w, http.StatusBadRequest, validationResponse{
+			Template:   template.Descriptor(),
+			Valid:      false,
+			Parameters: cleaned,
+			Errors:     paramErrs,
+		})
+		return
+	}
+
+	switch core.DatasetFormat(format) {
+	case core.FormatCSV:
+		streamCSV(w, template, result)
+	default:
+		writeJSON(w, http.StatusOK, runResponse{
+			Template:   template.Descriptor(),
+			Scope:      scope,
+			Parameters: cleaned,
+			Result:     result,
+		})
+	}
+}
+
+func (h *Handler) handleExportCreate(w http.ResponseWriter, r *http.Request) {
+	var req exportRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err.Error() != "EOF" {
+		writeError(w, http.StatusBadRequest, "invalid export request payload")
+		return
+	}
+
+	slug := strings.TrimSpace(req.Template.Slug)
+	if slug == "" {
+		if req.Template.Plugin == "" || req.Template.Key == "" || req.Template.Version == "" {
+			writeError(w, http.StatusBadRequest, "template slug or plugin/key/version required")
+			return
+		}
+		slug = fmt.Sprintf("%s/%s@%s", req.Template.Plugin, req.Template.Key, req.Template.Version)
+	}
+
+	formats := make([]core.DatasetFormat, 0, len(req.Formats))
+	for _, f := range req.Formats {
+		switch strings.ToLower(strings.TrimSpace(f)) {
+		case "json":
+			formats = append(formats, core.FormatJSON)
+		case "csv":
+			formats = append(formats, core.FormatCSV)
+		case "parquet":
+			formats = append(formats, core.FormatParquet)
+		case "png":
+			formats = append(formats, core.FormatPNG)
+		case "html":
+			formats = append(formats, core.FormatHTML)
+		default:
+			writeError(w, http.StatusBadRequest, "unsupported export format")
+			return
+		}
+	}
+
+	scope := core.DatasetScope{
+		Requestor:   req.Scope.Requestor,
+		Roles:       req.Scope.Roles,
+		ProjectIDs:  req.Scope.ProjectIDs,
+		ProtocolIDs: req.Scope.ProtocolIDs,
+	}
+
+	record, err := h.Exports.EnqueueExport(r.Context(), ExportInput{
+		TemplateSlug: slug,
+		Parameters:   req.Parameters,
+		Formats:      formats,
+		Scope:        scope,
+		RequestedBy:  firstNonEmpty(req.RequestedBy, req.Scope.Requestor),
+		Reason:       req.Reason,
+		ProjectID:    req.ProjectID,
+		ProtocolID:   req.ProtocolID,
+	})
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusAccepted, map[string]any{"export": record})
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func negotiateFormat(r *http.Request, supported []core.DatasetFormat) string {
+	wanted := strings.ToLower(r.URL.Query().Get("format"))
+	if wanted == "" {
+		accept := r.Header.Get("Accept")
+		if strings.Contains(accept, "text/csv") {
+			wanted = string(core.FormatCSV)
+		} else {
+			wanted = string(core.FormatJSON)
+		}
+	}
+	switch core.DatasetFormat(wanted) {
+	case core.FormatCSV, core.FormatJSON:
+		for _, candidate := range supported {
+			if string(candidate) == wanted {
+				return wanted
+			}
+		}
+	}
+	return ""
+}
+
+func streamCSV(w http.ResponseWriter, template core.DatasetTemplate, result core.DatasetRunResult) {
+	descriptor := template.Descriptor()
+	filename := fmt.Sprintf("%s-%s.csv", descriptor.Key, time.Now().UTC().Format("20060102T150405Z"))
+
+	w.Header().Set("Content-Type", "text/csv")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filename))
+	writer := csv.NewWriter(w)
+	defer writer.Flush()
+
+	var columns []core.DatasetColumn
+	if len(result.Schema) > 0 {
+		columns = result.Schema
+	} else {
+		columns = descriptor.Columns
+	}
+
+	headers := make([]string, len(columns))
+	for i, column := range columns {
+		headers[i] = column.Name
+	}
+	if err := writer.Write(headers); err != nil {
+		return
+	}
+
+	for _, row := range result.Rows {
+		record := make([]string, len(columns))
+		for i, column := range columns {
+			record[i] = formatValue(row[column.Name])
+		}
+		if err := writer.Write(record); err != nil {
+			return
+		}
+	}
+}
+
+func formatValue(value any) string {
+	switch v := value.(type) {
+	case nil:
+		return ""
+	case time.Time:
+		return v.UTC().Format(time.RFC3339)
+	case fmt.Stringer:
+		return v.String()
+	case float32:
+		return fmt.Sprintf("%g", v)
+	case float64:
+		return fmt.Sprintf("%g", v)
+	case int:
+		return fmt.Sprintf("%d", v)
+	case int64:
+		return fmt.Sprintf("%d", v)
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]any{"error": message})
+}

--- a/internal/dataset/handler_internal_test.go
+++ b/internal/dataset/handler_internal_test.go
@@ -1,0 +1,143 @@
+package dataset
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"colonycore/internal/core"
+)
+
+func TestHandleTemplateMissingSegments(t *testing.T) {
+	svc := core.NewInMemoryService(core.NewDefaultRulesEngine())
+	handler := &Handler{Catalog: svc}
+	req := httptest.NewRequest(http.MethodGet, "/ignored", nil)
+	rec := httptest.NewRecorder()
+	handler.handleTemplate(rec, req, "frog")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestHandleTemplateMethodNotAllowedInternal(t *testing.T) {
+	template := core.DatasetTemplate{
+		Plugin:        "frog",
+		Key:           "demo",
+		Version:       "1.0.0",
+		Title:         "Demo",
+		Description:   "demo",
+		Dialect:       core.DatasetDialectSQL,
+		Query:         "SELECT 1",
+		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
+		OutputFormats: []core.DatasetFormat{core.FormatJSON},
+		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
+			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
+				return core.DatasetRunResult{Rows: []map[string]any{{"value": "ok"}}}, nil
+			}, nil
+		},
+	}
+	svc := core.NewInMemoryService(core.NewDefaultRulesEngine())
+	if _, err := svc.InstallPlugin(testDatasetPlugin{dataset: template}); err != nil {
+		t.Fatalf("install plugin: %v", err)
+	}
+	descriptor := svc.DatasetTemplates()[0]
+	handler := &Handler{Catalog: svc}
+	remainder := descriptor.Plugin + "/" + descriptor.Key + "/" + descriptor.Version
+	req := httptest.NewRequest(http.MethodPost, "/ignored", nil)
+	rec := httptest.NewRecorder()
+	handler.handleTemplate(rec, req, remainder)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rec.Code)
+	}
+}
+
+func TestServeHTTPMissingCatalog(t *testing.T) {
+	handler := &Handler{}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/datasets/templates", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 when catalog missing, got %d", rec.Code)
+	}
+}
+
+func TestHandleExportsInvalidPath(t *testing.T) {
+	handler := &Handler{Exports: NewWorker(nil, nil, nil)}
+	req := httptest.NewRequest(http.MethodGet, "/ignored", nil)
+	rec := httptest.NewRecorder()
+	handler.handleExports(rec, req, "/api/v1/datasets/exports/foo/bar")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestHandleRunRunnerError(t *testing.T) {
+	template := core.DatasetTemplate{
+		Plugin:        "frog",
+		Key:           "error",
+		Version:       "1.0.0",
+		Title:         "Error",
+		Description:   "demo",
+		Dialect:       core.DatasetDialectSQL,
+		Query:         "SELECT 1",
+		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
+		OutputFormats: []core.DatasetFormat{core.FormatJSON},
+		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
+			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
+				return core.DatasetRunResult{}, fmt.Errorf("failure")
+			}, nil
+		},
+	}
+	svc := core.NewInMemoryService(core.NewDefaultRulesEngine())
+	if _, err := svc.InstallPlugin(testDatasetPlugin{dataset: template}); err != nil {
+		t.Fatalf("install plugin: %v", err)
+	}
+	descriptor := svc.DatasetTemplates()[0]
+	bound, ok := svc.ResolveDatasetTemplate(descriptor.Slug)
+	if !ok {
+		t.Fatalf("expected dataset template to resolve")
+	}
+	handler := &Handler{Catalog: svc}
+	req := httptest.NewRequest(http.MethodPost, "/ignored", bytes.NewBufferString(`{"parameters":{}}`))
+	rec := httptest.NewRecorder()
+	handler.handleRun(rec, req, bound)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rec.Code)
+	}
+}
+
+func TestHandleExportCreateWithPluginFields(t *testing.T) {
+	template := core.DatasetTemplate{
+		Plugin:        "frog",
+		Key:           "create",
+		Version:       "1.0.0",
+		Title:         "Create",
+		Description:   "demo",
+		Dialect:       core.DatasetDialectSQL,
+		Query:         "SELECT 1",
+		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
+		OutputFormats: []core.DatasetFormat{core.FormatJSON},
+		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
+			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
+				return core.DatasetRunResult{Rows: []map[string]any{{"value": "ok"}}}, nil
+			}, nil
+		},
+	}
+	svc := core.NewInMemoryService(core.NewDefaultRulesEngine())
+	if _, err := svc.InstallPlugin(testDatasetPlugin{dataset: template}); err != nil {
+		t.Fatalf("install plugin: %v", err)
+	}
+	worker := NewWorker(svc, NewMemoryObjectStore(), &MemoryAuditLog{})
+	handler := &Handler{Catalog: svc, Exports: worker}
+	descriptor := svc.DatasetTemplates()[0]
+	payload := bytes.NewBufferString(fmt.Sprintf(`{"template":{"plugin":"%s","key":"%s","version":"%s"},"formats":["json"]}`, descriptor.Plugin, descriptor.Key, descriptor.Version))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/datasets/exports", payload)
+	rec := httptest.NewRecorder()
+	handler.handleExportCreate(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", rec.Code)
+	}
+}

--- a/internal/dataset/handler_test.go
+++ b/internal/dataset/handler_test.go
@@ -1,0 +1,369 @@
+package dataset_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"colonycore/internal/core"
+	"colonycore/internal/dataset"
+	"colonycore/plugins/frog"
+)
+
+type listResponse struct {
+	Templates []core.DatasetTemplateDescriptor `json:"templates"`
+}
+
+type templateResponse struct {
+	Template core.DatasetTemplateDescriptor `json:"template"`
+}
+
+type validateResponse struct {
+	Valid  bool                         `json:"valid"`
+	Errors []core.DatasetParameterError `json:"errors"`
+}
+
+type runResponse struct {
+	Result struct {
+		Rows []map[string]any `json:"rows"`
+	} `json:"result"`
+}
+
+func setupHandler(t *testing.T) (*core.Service, *dataset.Handler, core.DatasetTemplateDescriptor) {
+	t.Helper()
+	svc := core.NewInMemoryService(core.NewDefaultRulesEngine())
+	meta, err := svc.InstallPlugin(frog.New())
+	if err != nil {
+		t.Fatalf("install plugin: %v", err)
+	}
+	handler := dataset.NewHandler(svc)
+	return svc, handler, meta.Datasets[0]
+}
+
+func TestHandlerListTemplates(t *testing.T) {
+	_, handler, descriptor := setupHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/datasets/templates", nil)
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", resp.Code)
+	}
+
+	var body listResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(body.Templates) != 1 {
+		t.Fatalf("expected one template")
+	}
+	if body.Templates[0].Slug != descriptor.Slug {
+		t.Fatalf("unexpected slug: %s", body.Templates[0].Slug)
+	}
+}
+
+func TestHandlerGetTemplate(t *testing.T) {
+	_, handler, descriptor := setupHandler(t)
+
+	url := "/api/v1/datasets/templates/" + descriptor.Plugin + "/" + descriptor.Key + "/" + descriptor.Version
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", resp.Code)
+	}
+	var body templateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Template.Slug != descriptor.Slug {
+		t.Fatalf("unexpected slug: %s", body.Template.Slug)
+	}
+}
+
+func TestHandlerValidateErrors(t *testing.T) {
+	_, handler, descriptor := setupHandler(t)
+
+	url := "/api/v1/datasets/templates/" + descriptor.Plugin + "/" + descriptor.Key + "/" + descriptor.Version + "/validate"
+	body := bytes.NewBufferString(`{"parameters": {"unknown": "value"}}`)
+	req := httptest.NewRequest(http.MethodPost, url, body)
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", resp.Code)
+	}
+	var validation validateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&validation); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if validation.Valid {
+		t.Fatalf("expected validation to fail")
+	}
+	if len(validation.Errors) == 0 {
+		t.Fatalf("expected validation errors")
+	}
+}
+
+func TestHandlerRunJSON(t *testing.T) {
+	svc, handler, descriptor := setupHandler(t)
+
+	ctx := context.Background()
+	project, _, err := svc.CreateProject(ctx, core.Project{Code: "PRJ-HTTP", Title: "Dataset"})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	projectID := project.ID
+	if _, _, err := svc.CreateOrganism(ctx, core.Organism{Name: "Frog", Species: "Tree Frog", Stage: core.StageAdult, ProjectID: &projectID}); err != nil {
+		t.Fatalf("create organism: %v", err)
+	}
+
+	url := "/api/v1/datasets/templates/" + descriptor.Plugin + "/" + descriptor.Key + "/" + descriptor.Version + "/run"
+	payload := `{"scope": {"project_ids": ["` + project.ID + `"]}, "parameters": {"include_retired": true}}`
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewBufferString(payload))
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", resp.Code)
+	}
+
+	var result runResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(result.Result.Rows) != 1 {
+		t.Fatalf("expected single row, got %d", len(result.Result.Rows))
+	}
+}
+
+func TestHandlerRunCSV(t *testing.T) {
+	svc, handler, descriptor := setupHandler(t)
+
+	ctx := context.Background()
+	project, _, err := svc.CreateProject(ctx, core.Project{Code: "PRJ-CSV", Title: "Dataset"})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	projectID := project.ID
+	if _, _, err := svc.CreateOrganism(ctx, core.Organism{Name: "Frog", Species: "Tree Frog", Stage: core.StageAdult, ProjectID: &projectID}); err != nil {
+		t.Fatalf("create organism: %v", err)
+	}
+
+	url := "/api/v1/datasets/templates/" + descriptor.Plugin + "/" + descriptor.Key + "/" + descriptor.Version + "/run?format=csv"
+	payload := `{"scope": {"project_ids": ["` + project.ID + `"]}, "parameters": {"include_retired": true}}`
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewBufferString(payload))
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("unexpected status: %d", resp.Code)
+	}
+	if got := resp.Header().Get("Content-Type"); got != "text/csv" {
+		t.Fatalf("unexpected content type: %s", got)
+	}
+	reader := csv.NewReader(resp.Body)
+	rows, err := reader.ReadAll()
+	if err != nil {
+		t.Fatalf("read csv: %v", err)
+	}
+	if len(rows) != 2 { // header + single row
+		t.Fatalf("expected 2 csv rows, got %d", len(rows))
+	}
+}
+
+func TestHandlerExportLifecycle(t *testing.T) {
+	svc, handler, descriptor := setupHandler(t)
+	store := dataset.NewMemoryObjectStore()
+	audit := &dataset.MemoryAuditLog{}
+	worker := dataset.NewWorker(svc, store, audit)
+	handler.Exports = worker
+	worker.Start()
+	t.Cleanup(func() {
+		_ = worker.Stop(context.Background())
+	})
+
+	ctx := context.Background()
+	project, _, err := svc.CreateProject(ctx, core.Project{Code: "PRJ-EXP", Title: "Export"})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+	projectID := project.ID
+	if _, _, err := svc.CreateOrganism(ctx, core.Organism{Name: "Frog", Species: "Tree Frog", Stage: core.StageAdult, ProjectID: &projectID}); err != nil {
+		t.Fatalf("create organism: %v", err)
+	}
+
+	payload := fmt.Sprintf(`{"template":{"slug":"%s"},"scope":{"project_ids":["%s"],"requestor":"analyst@colonycore"},"parameters":{"include_retired":true},"formats":["json","csv","html","png","parquet"],"requested_by":"analyst@colonycore"}`, descriptor.Slug, project.ID)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/datasets/exports", bytes.NewBufferString(payload))
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusAccepted {
+		t.Fatalf("unexpected status: %d", resp.Code)
+	}
+
+	var created struct {
+		Export dataset.ExportRecord `json:"export"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode export create: %v", err)
+	}
+	if created.Export.ID == "" {
+		t.Fatalf("expected export id")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		record, _ := handler.Exports.GetExport(created.Export.ID)
+		if record.Status == dataset.ExportStatusSucceeded {
+			break
+		}
+		if record.Status == dataset.ExportStatusFailed {
+			t.Fatalf("export failed: %s", record.Error)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timeout waiting for export completion (status=%s)", record.Status)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	statusReq := httptest.NewRequest(http.MethodGet, "/api/v1/datasets/exports/"+created.Export.ID, nil)
+	statusResp := httptest.NewRecorder()
+	handler.ServeHTTP(statusResp, statusReq)
+	if statusResp.Code != http.StatusOK {
+		t.Fatalf("unexpected status response: %d", statusResp.Code)
+	}
+
+	objects := store.Objects()
+	if len(objects) == 0 {
+		t.Fatalf("expected stored artifacts")
+	}
+}
+
+func TestHandlerTemplateNotFound(t *testing.T) {
+	_, handler, _ := setupHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/datasets/templates/frog/unknown/1.0.0", nil)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.Code)
+	}
+}
+
+func TestHandlerRunUnsupportedFormat(t *testing.T) {
+	_, handler, descriptor := setupHandler(t)
+	url := "/api/v1/datasets/templates/" + descriptor.Plugin + "/" + descriptor.Key + "/" + descriptor.Version + "/run?format=parquet"
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewBufferString(`{"parameters":{}}`))
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusNotAcceptable {
+		t.Fatalf("expected 406 for unsupported format, got %d", resp.Code)
+	}
+}
+
+func TestHandlerValidateInvalidJSON(t *testing.T) {
+	_, handler, descriptor := setupHandler(t)
+	url := "/api/v1/datasets/templates/" + descriptor.Plugin + "/" + descriptor.Key + "/" + descriptor.Version + "/validate"
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewBufferString("{invalid"))
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.Code)
+	}
+}
+
+func TestHandlerExportCreateMissingTemplate(t *testing.T) {
+	_, handler, _ := setupHandler(t)
+	handler.Exports = dataset.NewWorker(nil, nil, nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/datasets/exports", bytes.NewBufferString(`{}`))
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing template, got %d", resp.Code)
+	}
+}
+
+func TestHandlerExportGetNotFound(t *testing.T) {
+	_, handler, _ := setupHandler(t)
+	handler.Exports = dataset.NewWorker(nil, nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/datasets/exports/missing", nil)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing export, got %d", resp.Code)
+	}
+}
+
+func TestHandlerTemplateMethodNotAllowed(t *testing.T) {
+	_, handler, descriptor := setupHandler(t)
+	url := "/api/v1/datasets/templates/" + descriptor.Plugin + "/" + descriptor.Key + "/" + descriptor.Version
+	req := httptest.NewRequest(http.MethodPost, url, nil)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", resp.Code)
+	}
+}
+
+func TestHandlerExportsMethodNotAllowed(t *testing.T) {
+	_, handler, _ := setupHandler(t)
+	handler.Exports = dataset.NewWorker(nil, nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/datasets/exports", nil)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", resp.Code)
+	}
+}
+
+func TestHandlerRunParameterErrors(t *testing.T) {
+	_, handler, descriptor := setupHandler(t)
+	url := "/api/v1/datasets/templates/" + descriptor.Plugin + "/" + descriptor.Key + "/" + descriptor.Version + "/run"
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewBufferString(`{"parameters":{"unknown":true}}`))
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for parameter validation, got %d", resp.Code)
+	}
+}
+
+func TestHandlerExportCreateUnsupportedFormat(t *testing.T) {
+	_, handler, descriptor := setupHandler(t)
+	handler.Exports = dataset.NewWorker(nil, nil, nil)
+	payload := fmt.Sprintf(`{"template":{"plugin":"%s","key":"%s","version":"%s"},"formats":["xml"]}`, descriptor.Plugin, descriptor.Key, descriptor.Version)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/datasets/exports", bytes.NewBufferString(payload))
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unsupported export format, got %d", resp.Code)
+	}
+}
+
+func TestHandlerServeHTTPUnknownPath(t *testing.T) {
+	_, handler, _ := setupHandler(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/datasets/ping", nil)
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown path, got %d", resp.Code)
+	}
+}
+
+func TestHandlerExportsPathMethodNotAllowed(t *testing.T) {
+	_, handler, _ := setupHandler(t)
+	handler.Exports = dataset.NewWorker(nil, nil, nil)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/datasets/exports/identifier", bytes.NewBufferString(`{}`))
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	if resp.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405 for exports PUT, got %d", resp.Code)
+	}
+}

--- a/plugins/frog/plugin_test.go
+++ b/plugins/frog/plugin_test.go
@@ -3,6 +3,7 @@ package frog
 import (
 	"context"
 	"testing"
+	"time"
 
 	"colonycore/internal/core"
 )
@@ -26,6 +27,17 @@ func TestPluginRegistration(t *testing.T) {
 	rules := registry.Rules()
 	if len(rules) != 1 {
 		t.Fatalf("expected frog plugin to register one rule, got %d", len(rules))
+	}
+
+	datasets := registry.DatasetTemplates()
+	if len(datasets) != 1 {
+		t.Fatalf("expected one dataset template, got %d", len(datasets))
+	}
+	if datasets[0].Key != "frog_population_snapshot" {
+		t.Fatalf("unexpected dataset key: %s", datasets[0].Key)
+	}
+	if datasets[0].Binder == nil {
+		t.Fatalf("dataset binder should be registered")
 	}
 }
 
@@ -86,5 +98,188 @@ func TestFrogHabitatRuleOutcomes(t *testing.T) {
 				t.Fatalf("unexpected violation for non-frog species: %+v", violation)
 			}
 		}
+	}
+}
+
+func TestFrogPopulationDataset(t *testing.T) {
+	svc := core.NewInMemoryService(core.NewRulesEngine())
+	meta, err := svc.InstallPlugin(New())
+	if err != nil {
+		t.Fatalf("install frog plugin: %v", err)
+	}
+	if len(meta.Datasets) != 1 {
+		t.Fatalf("expected dataset descriptor to be registered")
+	}
+
+	template, ok := svc.ResolveDatasetTemplate(meta.Datasets[0].Slug)
+	if !ok {
+		t.Fatalf("dataset template not resolved: %s", meta.Datasets[0].Slug)
+	}
+
+	ctx := context.Background()
+	project, _, err := svc.CreateProject(ctx, core.Project{Code: "PRJ-FROG", Title: "Frog Ops"})
+	if err != nil {
+		t.Fatalf("create project: %v", err)
+	}
+
+	organism, _, err := svc.CreateOrganism(ctx, core.Organism{
+		Name:      "Maple",
+		Species:   "Tree Frog",
+		Stage:     core.StageAdult,
+		ProjectID: &project.ID,
+	})
+	if err != nil {
+		t.Fatalf("create frog organism: %v", err)
+	}
+	if _, _, err := svc.CreateOrganism(ctx, core.Organism{Name: "Gecko", Species: "Gecko", Stage: core.StageAdult}); err != nil {
+		t.Fatalf("create non frog organism: %v", err)
+	}
+
+	result, paramErrs, err := template.Run(ctx, map[string]any{"include_retired": true}, core.DatasetScope{ProjectIDs: []string{project.ID}}, core.FormatJSON)
+	if err != nil {
+		t.Fatalf("run dataset: %v", err)
+	}
+	if len(paramErrs) > 0 {
+		t.Fatalf("unexpected parameter errors: %+v", paramErrs)
+	}
+	if len(result.Rows) != 1 {
+		t.Fatalf("expected one row, got %d", len(result.Rows))
+	}
+	row := result.Rows[0]
+	if row["organism_id"].(string) != organism.ID {
+		t.Fatalf("unexpected organism in dataset: %+v", row)
+	}
+	if _, ok := result.Metadata["project_scope"]; !ok {
+		t.Fatalf("expected project scope metadata")
+	}
+
+	filtered, _, err := template.Run(ctx, map[string]any{"stage": string(core.StageLarva)}, core.DatasetScope{}, core.FormatJSON)
+	if err != nil {
+		t.Fatalf("run dataset with stage filter: %v", err)
+	}
+	if len(filtered.Rows) != 0 {
+		t.Fatalf("expected no larva rows, got %d", len(filtered.Rows))
+	}
+}
+
+func TestFrogHabitatRuleName(t *testing.T) {
+	if name := (frogHabitatRule{}).Name(); name == "" {
+		t.Fatalf("expected frog habitat rule name")
+	}
+}
+
+func TestFrogPopulationBinderFilters(t *testing.T) {
+	svc := core.NewInMemoryService(core.NewDefaultRulesEngine())
+	if _, err := svc.InstallPlugin(New()); err != nil {
+		t.Fatalf("install frog plugin: %v", err)
+	}
+	ctx := context.Background()
+
+	projectA, _, err := svc.CreateProject(ctx, core.Project{Code: "PRJ-A", Title: "Project A"})
+	if err != nil {
+		t.Fatalf("create project A: %v", err)
+	}
+	projectB, _, err := svc.CreateProject(ctx, core.Project{Code: "PRJ-B", Title: "Project B"})
+	if err != nil {
+		t.Fatalf("create project B: %v", err)
+	}
+	protocol, _, err := svc.CreateProtocol(ctx, core.Protocol{Code: "PROTO", Title: "Protocol", MaxSubjects: 10})
+	if err != nil {
+		t.Fatalf("create protocol: %v", err)
+	}
+	housing, _, err := svc.CreateHousingUnit(ctx, core.HousingUnit{Name: "Wet", Facility: "Lab", Capacity: 4, Environment: "humid"})
+	if err != nil {
+		t.Fatalf("create housing: %v", err)
+	}
+	housingID := housing.ID
+
+	protocolID := protocol.ID
+	projectAID := projectA.ID
+	projectBID := projectB.ID
+
+	frogA, _, err := svc.CreateOrganism(ctx, core.Organism{
+		Name:       "Alpha",
+		Species:    "Tree Frog",
+		Stage:      core.StageAdult,
+		ProjectID:  &projectAID,
+		ProtocolID: &protocolID,
+		HousingID:  &housingID,
+	})
+	if err != nil {
+		t.Fatalf("create frog A: %v", err)
+	}
+	frogATime := frogA.UpdatedAt
+	time.Sleep(5 * time.Millisecond)
+	if _, _, err := svc.CreateOrganism(ctx, core.Organism{
+		Name:       "Bravo",
+		Species:    "Tree Frog",
+		Stage:      core.StageAdult,
+		ProjectID:  &projectBID,
+		ProtocolID: &protocolID,
+		HousingID:  &housingID,
+	}); err != nil {
+		t.Fatalf("create frog B: %v", err)
+	}
+	time.Sleep(5 * time.Millisecond)
+	if _, _, err := svc.CreateOrganism(ctx, core.Organism{
+		Name:       "Charlie",
+		Species:    "Tree Frog",
+		Stage:      core.StageRetired,
+		ProjectID:  &projectAID,
+		ProtocolID: &protocolID,
+	}); err != nil {
+		t.Fatalf("create frog C: %v", err)
+	}
+
+	descriptor := svc.DatasetTemplates()[0]
+	template, ok := svc.ResolveDatasetTemplate(descriptor.Slug)
+	if !ok {
+		t.Fatalf("resolve dataset template")
+	}
+
+	params := map[string]any{
+		"as_of": frogATime.Add(time.Second).Format(time.RFC3339),
+	}
+	scope := core.DatasetScope{Requestor: "analyst", ProjectIDs: []string{projectAID}, ProtocolIDs: []string{protocolID}}
+	result, paramErrs, err := template.Run(ctx, params, scope, core.FormatJSON)
+	if err != nil {
+		t.Fatalf("run dataset: %v", err)
+	}
+	if len(paramErrs) != 0 {
+		t.Fatalf("unexpected parameter errors: %+v", paramErrs)
+	}
+	if len(result.Rows) != 1 {
+		t.Fatalf("expected single row after filters, got %d", len(result.Rows))
+	}
+	if result.Rows[0]["organism_id"].(string) != frogA.ID {
+		t.Fatalf("expected frog A row, got %+v", result.Rows[0])
+	}
+
+	paramsRetired := map[string]any{
+		"include_retired": true,
+		"as_of":           time.Now().Add(time.Hour).Format(time.RFC3339),
+	}
+	result, _, err = template.Run(ctx, paramsRetired, scope, core.FormatJSON)
+	if err != nil {
+		t.Fatalf("run dataset include retired: %v", err)
+	}
+	if len(result.Rows) != 2 {
+		t.Fatalf("expected two rows with retired included, got %d", len(result.Rows))
+	}
+
+	blankScope := core.DatasetScope{ProjectIDs: []string{"nonexistent"}}
+	result, _, err = template.Run(ctx, params, blankScope, core.FormatJSON)
+	if err != nil {
+		t.Fatalf("run dataset with mismatched scope: %v", err)
+	}
+	if len(result.Rows) != 0 {
+		t.Fatalf("expected no rows for unmatched scope, got %d", len(result.Rows))
+	}
+
+	if contains([]string{"a", "b"}, "z") {
+		t.Fatalf("expected contains helper to return false")
+	}
+	if value := valueOrNil(nil); value != nil {
+		t.Fatalf("expected valueOrNil to return nil")
 	}
 }


### PR DESCRIPTION
* Allow plugins to register dataset templates with validation and metadata
* Expose dataset REST API, OpenAPI spec and Python/R client examples
* Add asynchronous export worker with RBAC scopes, audit logging and artifact storage
* Expand tests and docs to satisfy RFC requirements

## What  
<!-- Describe the change. -->
Added a species-agnostic analytics layer so datasets are registered, discoverable, and exportable through ColonyCore.

## Why  
<!-- What's the motivation. -->
Species plugins needed a uniform way to publish reusable analytics datasets that analysts can run across projects without bespoke wiring.

Resolves: #5 

## How  
<!-- Bullet list or description of key changes. -->
* Let each species plugin ship versioned DatasetTemplate manifests with SQL/DSL, schema, units, and metadata.
* Extended the DatasetService OpenAPI surface with template listing, parameter validation, and result streaming endpoints (JSON/CSV per RFC).
* Introduced an async export worker honoring RBAC filters, persisting audit trails, and storing parquet/csv/png/html artifacts in the managed object store with protocol/project linkbacks.
* Published Python and R helper packages that call the REST API, handle signed download URLs, and reproduce exports locally—no embedded runtimes.
* Updated RFC 0001-colonycore-base-module.ml sections 107-110, 131-136, and 168-191 to capture the new analytics layer contract and service obligations.

## Notes  
<!-- Breaking changes or follow-ups (if any). -->
No breaking changes; existing reports keep working and may opt into templates incrementally.

## Checklist  

- [x] I have used conventional commits (conventionalcommits.com)
- [x] I have updated the documentation
- [x] I have updated the relevant RFC and its linked resources
- [x] I have added tests
- [x] I ran manual tests