### PR TITLE
fix: Remove redundancies from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,8 +49,5 @@ jobs:
       - name: Install tooling
         run: pip install pre-commit ruff
 
-      - name: Run lint suite
-        run: make lint
-
       - name: Run pre-commit
         run: SKIP=lint-via-make pre-commit run --all-files

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,4 +50,4 @@ jobs:
         run: pip install pre-commit ruff
 
       - name: Run pre-commit
-        run: SKIP=lint-via-make pre-commit run --all-files
+        run: pre-commit run --all-files

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ COVERFILE ?= coverage.out
 COVERMODE ?= atomic
 GOLANGCI_VERSION ?= v2.5.0
 GOLANGCI_PKG := github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_VERSION)
-BIN_DIR ?= $(CURDIR)/bin
+BIN_DIR ?= $(CURDIR)/.cache/bin
 GOLANGCI_CACHE ?= $(CURDIR)/.cache/golangci-lint
 COVER_THRESHOLD ?= 90.0
 


### PR DESCRIPTION
## What  
<!-- Describe the change. -->
Remove `make lint` as a CI job

## Why  
<!-- What's the motivation. -->
`make lint` is already executed as part of pre-commit, which is also among the CI jobs

## How  
<!-- Bullet list or description of key changes. -->
Removed the responsible step for `make lint` from the `ci.yml`

## Notes  
<!-- Breaking changes or follow-ups (if any). -->

## Checklist  

- [x] I have used conventional commits (conventionalcommits.com)
- [ ] I have updated the documentation
- [ ] I have updated the relevant RFC and its linked resources
- [ ] I have added tests
- [ ] I ran manual tests