### PR TITLE
feat: Reallocate pre-commit cache to CI cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,4 +50,7 @@ jobs:
         run: pip install pre-commit ruff
 
       - name: Run pre-commit
-        run: pre-commit run --all-files
+        run: |
+          PRE_COMMIT_HOME=$PWD/.cache/pre-commit \
+          XDG_CACHE_HOME=$PWD/.cache \
+          pre-commit run --all-files


### PR DESCRIPTION
## What  
<!-- Describe the change. -->
Move the pre-commit cache to the project `.cache` directory

## Why  
<!-- What's the motivation. -->
Because it speeds up the CI.

## How  
<!-- Bullet list or description of key changes. -->
Add environment variables `PRE_COMMIT_HOME` and `XDG_CACHE_HOME` to the CI task.

## Notes  
<!-- Breaking changes or follow-ups (if any). -->

## Checklist  

- [x] I have used conventional commits (conventionalcommits.com)
- [ ] I have updated the documentation
- [ ] I have updated the relevant RFC and its linked resources
- [ ] I have added tests
- [ ] I ran manual tests