### PR TITLE
feat: Install CI APT with provider & cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
             cache-dotcache-${{ runner.os }}-
 
       - name: Install APT packages
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: r-base libcurl4-openssl-dev libxml2-dev libxslt1-dev pkg-config
           version: 1


### PR DESCRIPTION
## What  
<!-- Describe the change. -->
Remove the "manual" APT install step and replace it with a CI provider.

## Why  
<!-- What's the motivation. -->
Supports standardization and caching.

## How  
<!-- Bullet list or description of key changes. -->
Replace the `run` block of the APT task with the awalsh128/cache-apt-pkgs-action provider.

## Notes  
<!-- Breaking changes or follow-ups (if any). -->

## Checklist  

- [x] I have used conventional commits (conventionalcommits.com)
- [ ] I have updated the documentation
- [ ] I have updated the relevant RFC and its linked resources
- [ ] I have added tests
- [ ] I ran manual tests