### PR TITLE
fix: Install golangci-lint with official practice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,7 @@ python-lint:
 
 r-lint:
 	@echo "==> R lint"
-	@python scripts/run_lintr.py
-	@echo "R lint: OK"
+	@python scripts/run_lintr.py && echo "R lint: OK" || (status=$$?; if [ $$status -eq 0 ]; then echo "R lint: OK"; else exit $$status; fi)
 
 go-test:
 	GOCACHE=$(GOCACHE) go test -race -covermode=$(COVERMODE) -coverprofile=$(COVERFILE) ./...


### PR DESCRIPTION
## What  
<!-- Describe the change. -->
Fix the golangci-installation

## Why  
<!-- What's the motivation. -->
The `go install` path is discouraged by the devs.

## How  
<!-- Bullet list or description of key changes. -->
Replace the `go install` with the provided `install.sh` from the provider.

## Notes  
<!-- Breaking changes or follow-ups (if any). -->

## Checklist  

- [x] I have used conventional commits (conventionalcommits.com)
- [ ] I have updated the documentation
- [ ] I have updated the relevant RFC and its linked resources
- [ ] I have added tests
- [ ] I ran manual tests