### PR TITLE
feat(domain): Introduce `pkg/domain` package

### DIFF
--- a/internal/core/rule_housing_capacity.go
+++ b/internal/core/rule_housing_capacity.go
@@ -14,7 +14,7 @@ type housingCapacityRule struct{}
 
 func (housingCapacityRule) Name() string { return "housing_capacity" }
 
-func (housingCapacityRule) Evaluate(ctx context.Context, view TransactionView, changes []Change) (Result, error) {
+func (housingCapacityRule) Evaluate(ctx context.Context, view RuleView, changes []Change) (Result, error) {
 	occupancy := make(map[string]int)
 	for _, organism := range view.ListOrganisms() {
 		if organism.HousingID == nil {

--- a/internal/core/rule_protocol_subject_cap.go
+++ b/internal/core/rule_protocol_subject_cap.go
@@ -14,7 +14,7 @@ type protocolSubjectCapRule struct{}
 
 func (protocolSubjectCapRule) Name() string { return "protocol_subject_cap" }
 
-func (protocolSubjectCapRule) Evaluate(ctx context.Context, view TransactionView, changes []Change) (Result, error) {
+func (protocolSubjectCapRule) Evaluate(ctx context.Context, view RuleView, changes []Change) (Result, error) {
 	counts := make(map[string]int)
 	for _, organism := range view.ListOrganisms() {
 		if organism.ProtocolID == nil {

--- a/internal/core/rules.go
+++ b/internal/core/rules.go
@@ -1,21 +1,16 @@
 package core
 
-import "context"
+import "colonycore/pkg/domain"
 
-// Rule defines an evaluation executed within a transaction boundary.
-type Rule interface {
-	Name() string
-	Evaluate(ctx context.Context, view TransactionView, changes []Change) (Result, error)
-}
-
-// RulesEngine orchestrates rule evaluation.
-type RulesEngine struct {
-	rules []Rule
-}
+type (
+	Rule        = domain.Rule
+	RuleView    = domain.RuleView
+	RulesEngine = domain.RulesEngine
+)
 
 // NewRulesEngine constructs an engine instance.
 func NewRulesEngine() *RulesEngine {
-	return &RulesEngine{}
+	return domain.NewRulesEngine()
 }
 
 // NewDefaultRulesEngine builds a rules engine with the built-in policy set.
@@ -24,22 +19,4 @@ func NewDefaultRulesEngine() *RulesEngine {
 	engine.Register(NewHousingCapacityRule())
 	engine.Register(NewProtocolSubjectCapRule())
 	return engine
-}
-
-// Register appends a rule to the engine.
-func (e *RulesEngine) Register(rule Rule) {
-	e.rules = append(e.rules, rule)
-}
-
-// Evaluate executes all registered rules and aggregates their results.
-func (e *RulesEngine) Evaluate(ctx context.Context, view TransactionView, changes []Change) (Result, error) {
-	var combined Result
-	for _, rule := range e.rules {
-		res, err := rule.Evaluate(ctx, view, changes)
-		if err != nil {
-			return Result{}, err
-		}
-		combined.Merge(res)
-	}
-	return combined, nil
 }

--- a/internal/core/store_crud_test.go
+++ b/internal/core/store_crud_test.go
@@ -378,6 +378,6 @@ type staticRule struct {
 
 func (r staticRule) Name() string { return r.name }
 
-func (r staticRule) Evaluate(ctx context.Context, view TransactionView, changes []Change) (Result, error) {
+func (r staticRule) Evaluate(ctx context.Context, view RuleView, changes []Change) (Result, error) {
 	return Result{Violations: []Violation{{Rule: r.name, Severity: r.severity}}}, nil
 }

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -1,174 +1,53 @@
 package core
 
-import "time"
+import "colonycore/pkg/domain"
 
-// EntityType identifies the type of record stored in the core domain.
-type EntityType string
-
-const (
-	EntityOrganism    EntityType = "organism"
-	EntityCohort      EntityType = "cohort"
-	EntityHousingUnit EntityType = "housing_unit"
-	EntityBreeding    EntityType = "breeding_unit"
-	EntityProcedure   EntityType = "procedure"
-	EntityProtocol    EntityType = "protocol"
-	EntityProject     EntityType = "project"
+type (
+	EntityType         = domain.EntityType
+	LifecycleStage     = domain.LifecycleStage
+	Severity           = domain.Severity
+	Base               = domain.Base
+	Organism           = domain.Organism
+	Cohort             = domain.Cohort
+	HousingUnit        = domain.HousingUnit
+	BreedingUnit       = domain.BreedingUnit
+	Procedure          = domain.Procedure
+	Protocol           = domain.Protocol
+	Project            = domain.Project
+	Change             = domain.Change
+	Action             = domain.Action
+	Violation          = domain.Violation
+	Result             = domain.Result
+	RuleViolationError = domain.RuleViolationError
 )
 
-// LifecycleStage represents the canonical organism lifecycle states described in the RFC.
-type LifecycleStage string
-
 const (
-	StagePlanned  LifecycleStage = "planned"
-	StageLarva    LifecycleStage = "embryo_larva"
-	StageJuvenile LifecycleStage = "juvenile"
-	StageAdult    LifecycleStage = "adult"
-	StageRetired  LifecycleStage = "retired"
-	StageDeceased LifecycleStage = "deceased"
+	EntityOrganism    = domain.EntityOrganism
+	EntityCohort      = domain.EntityCohort
+	EntityHousingUnit = domain.EntityHousingUnit
+	EntityBreeding    = domain.EntityBreeding
+	EntityProcedure   = domain.EntityProcedure
+	EntityProtocol    = domain.EntityProtocol
+	EntityProject     = domain.EntityProject
 )
 
-// Severity captures rule outcomes.
-type Severity string
-
 const (
-	SeverityBlock Severity = "block"
-	SeverityWarn  Severity = "warn"
-	SeverityLog   Severity = "log"
+	StagePlanned  = domain.StagePlanned
+	StageLarva    = domain.StageLarva
+	StageJuvenile = domain.StageJuvenile
+	StageAdult    = domain.StageAdult
+	StageRetired  = domain.StageRetired
+	StageDeceased = domain.StageDeceased
 )
 
-// Base contains common fields for all domain records.
-type Base struct {
-	ID        string    `json:"id"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
-}
-
-// Organism represents an individual animal tracked by the system.
-type Organism struct {
-	Base
-	Name       string         `json:"name"`
-	Species    string         `json:"species"`
-	Line       string         `json:"line"`
-	Stage      LifecycleStage `json:"stage"`
-	CohortID   *string        `json:"cohort_id"`
-	HousingID  *string        `json:"housing_id"`
-	ProtocolID *string        `json:"protocol_id"`
-	ProjectID  *string        `json:"project_id"`
-	Attributes map[string]any `json:"attributes"`
-}
-
-// Cohort represents a managed group of organisms.
-type Cohort struct {
-	Base
-	Name       string  `json:"name"`
-	Purpose    string  `json:"purpose"`
-	ProjectID  *string `json:"project_id"`
-	HousingID  *string `json:"housing_id"`
-	ProtocolID *string `json:"protocol_id"`
-}
-
-// HousingUnit captures physical housing metadata.
-type HousingUnit struct {
-	Base
-	Name        string `json:"name"`
-	Facility    string `json:"facility"`
-	Capacity    int    `json:"capacity"`
-	Environment string `json:"environment"`
-}
-
-// BreedingUnit tracks configured pairings or groups intended for reproduction.
-type BreedingUnit struct {
-	Base
-	Name       string   `json:"name"`
-	Strategy   string   `json:"strategy"`
-	HousingID  *string  `json:"housing_id"`
-	ProtocolID *string  `json:"protocol_id"`
-	FemaleIDs  []string `json:"female_ids"`
-	MaleIDs    []string `json:"male_ids"`
-}
-
-// Procedure captures scheduled or completed animal procedures.
-type Procedure struct {
-	Base
-	Name        string    `json:"name"`
-	Status      string    `json:"status"`
-	ScheduledAt time.Time `json:"scheduled_at"`
-	ProtocolID  string    `json:"protocol_id"`
-	CohortID    *string   `json:"cohort_id"`
-	OrganismIDs []string  `json:"organism_ids"`
-}
-
-// Protocol represents compliance agreements.
-type Protocol struct {
-	Base
-	Code        string `json:"code"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	MaxSubjects int    `json:"max_subjects"`
-}
-
-// Project captures cost center allocations.
-type Project struct {
-	Base
-	Code        string `json:"code"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-}
-
-// Change describes a mutation applied to an entity during a transaction.
-type Change struct {
-	Entity EntityType
-	Action Action
-	Before any
-	After  any
-}
-
-// Action indicates the type of modification performed.
-type Action string
-
 const (
-	ActionCreate Action = "create"
-	ActionUpdate Action = "update"
-	ActionDelete Action = "delete"
+	SeverityBlock = domain.SeverityBlock
+	SeverityWarn  = domain.SeverityWarn
+	SeverityLog   = domain.SeverityLog
 )
 
-// Violation reports a failed rule evaluation.
-type Violation struct {
-	Rule     string
-	Severity Severity
-	Message  string
-	Entity   EntityType
-	EntityID string
-}
-
-// Result aggregates violations from the rules engine.
-type Result struct {
-	Violations []Violation
-}
-
-// Merge appends violations from another result.
-func (r *Result) Merge(other Result) {
-	if len(other.Violations) == 0 {
-		return
-	}
-	r.Violations = append(r.Violations, other.Violations...)
-}
-
-// RuleViolationError is returned when blocking violations are present.
-type RuleViolationError struct {
-	Result Result
-}
-
-func (e RuleViolationError) Error() string {
-	return "transaction blocked by rules"
-}
-
-// HasBlocking returns true if the result contains blocking violations.
-func (r Result) HasBlocking() bool {
-	for _, v := range r.Violations {
-		if v.Severity == SeverityBlock {
-			return true
-		}
-	}
-	return false
-}
+const (
+	ActionCreate = domain.ActionCreate
+	ActionUpdate = domain.ActionUpdate
+	ActionDelete = domain.ActionDelete
+)

--- a/internal/dataset/exporter_test.go
+++ b/internal/dataset/exporter_test.go
@@ -7,6 +7,7 @@ import (
 
 	"colonycore/internal/core"
 	"colonycore/internal/dataset"
+	domain "colonycore/pkg/domain"
 	"colonycore/plugins/frog"
 )
 
@@ -27,12 +28,12 @@ func TestWorkerProcessesExport(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	project, _, err := svc.CreateProject(ctx, core.Project{Code: "PRJ-WORK", Title: "Worker"})
+	project, _, err := svc.CreateProject(ctx, domain.Project{Code: "PRJ-WORK", Title: "Worker"})
 	if err != nil {
 		t.Fatalf("create project: %v", err)
 	}
 	projectID := project.ID
-	if _, _, err := svc.CreateOrganism(ctx, core.Organism{Name: "Frog", Species: "Tree Frog", Stage: core.StageAdult, ProjectID: &projectID}); err != nil {
+	if _, _, err := svc.CreateOrganism(ctx, domain.Organism{Name: "Frog", Species: "Tree Frog", Stage: domain.StageAdult, ProjectID: &projectID}); err != nil {
 		t.Fatalf("create organism: %v", err)
 	}
 

--- a/internal/dataset/handler_test.go
+++ b/internal/dataset/handler_test.go
@@ -13,6 +13,7 @@ import (
 
 	"colonycore/internal/core"
 	"colonycore/internal/dataset"
+	domain "colonycore/pkg/domain"
 	"colonycore/plugins/frog"
 )
 
@@ -117,12 +118,12 @@ func TestHandlerRunJSON(t *testing.T) {
 	svc, handler, descriptor := setupHandler(t)
 
 	ctx := context.Background()
-	project, _, err := svc.CreateProject(ctx, core.Project{Code: "PRJ-HTTP", Title: "Dataset"})
+	project, _, err := svc.CreateProject(ctx, domain.Project{Code: "PRJ-HTTP", Title: "Dataset"})
 	if err != nil {
 		t.Fatalf("create project: %v", err)
 	}
 	projectID := project.ID
-	if _, _, err := svc.CreateOrganism(ctx, core.Organism{Name: "Frog", Species: "Tree Frog", Stage: core.StageAdult, ProjectID: &projectID}); err != nil {
+	if _, _, err := svc.CreateOrganism(ctx, domain.Organism{Name: "Frog", Species: "Tree Frog", Stage: domain.StageAdult, ProjectID: &projectID}); err != nil {
 		t.Fatalf("create organism: %v", err)
 	}
 
@@ -149,12 +150,12 @@ func TestHandlerRunCSV(t *testing.T) {
 	svc, handler, descriptor := setupHandler(t)
 
 	ctx := context.Background()
-	project, _, err := svc.CreateProject(ctx, core.Project{Code: "PRJ-CSV", Title: "Dataset"})
+	project, _, err := svc.CreateProject(ctx, domain.Project{Code: "PRJ-CSV", Title: "Dataset"})
 	if err != nil {
 		t.Fatalf("create project: %v", err)
 	}
 	projectID := project.ID
-	if _, _, err := svc.CreateOrganism(ctx, core.Organism{Name: "Frog", Species: "Tree Frog", Stage: core.StageAdult, ProjectID: &projectID}); err != nil {
+	if _, _, err := svc.CreateOrganism(ctx, domain.Organism{Name: "Frog", Species: "Tree Frog", Stage: domain.StageAdult, ProjectID: &projectID}); err != nil {
 		t.Fatalf("create organism: %v", err)
 	}
 
@@ -192,12 +193,12 @@ func TestHandlerExportLifecycle(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	project, _, err := svc.CreateProject(ctx, core.Project{Code: "PRJ-EXP", Title: "Export"})
+	project, _, err := svc.CreateProject(ctx, domain.Project{Code: "PRJ-EXP", Title: "Export"})
 	if err != nil {
 		t.Fatalf("create project: %v", err)
 	}
 	projectID := project.ID
-	if _, _, err := svc.CreateOrganism(ctx, core.Organism{Name: "Frog", Species: "Tree Frog", Stage: core.StageAdult, ProjectID: &projectID}); err != nil {
+	if _, _, err := svc.CreateOrganism(ctx, domain.Organism{Name: "Frog", Species: "Tree Frog", Stage: domain.StageAdult, ProjectID: &projectID}); err != nil {
 		t.Fatalf("create organism: %v", err)
 	}
 

--- a/internal/integration/smoke_test.go
+++ b/internal/integration/smoke_test.go
@@ -9,6 +9,7 @@ import (
 
 	"colonycore/internal/blob"
 	core "colonycore/internal/core"
+	domain "colonycore/pkg/domain"
 )
 
 // TestIntegrationSmoke exercises a minimal end-to-end write/read cycle for
@@ -74,14 +75,14 @@ func TestIntegrationSmoke(t *testing.T) {
 			store := cv.open(t)
 			svc := core.NewService(store)
 			// Write one housing unit and one organism referencing it.
-			created, res, err := svc.CreateHousingUnit(ctx, core.HousingUnit{Name: "Tank", Facility: "Lab", Capacity: 1})
+			created, res, err := svc.CreateHousingUnit(ctx, domain.HousingUnit{Name: "Tank", Facility: "Lab", Capacity: 1})
 			if err != nil {
 				t.Fatalf("create housing: %v", err)
 			}
 			if res.HasBlocking() {
 				t.Fatalf("unexpected blocking violations: %+v", res.Violations)
 			}
-			org, res, err := svc.CreateOrganism(ctx, core.Organism{Name: "Specimen", Species: "Testus"})
+			org, res, err := svc.CreateOrganism(ctx, domain.Organism{Name: "Specimen", Species: "Testus"})
 			if err != nil {
 				t.Fatalf("create organism: %v", err)
 			}

--- a/pkg/domain/entities.go
+++ b/pkg/domain/entities.go
@@ -1,0 +1,174 @@
+package domain
+
+import "time"
+
+// EntityType identifies the type of record stored in the core domain.
+type EntityType string
+
+const (
+	EntityOrganism    EntityType = "organism"
+	EntityCohort      EntityType = "cohort"
+	EntityHousingUnit EntityType = "housing_unit"
+	EntityBreeding    EntityType = "breeding_unit"
+	EntityProcedure   EntityType = "procedure"
+	EntityProtocol    EntityType = "protocol"
+	EntityProject     EntityType = "project"
+)
+
+// LifecycleStage represents the canonical organism lifecycle states described in the RFC.
+type LifecycleStage string
+
+const (
+	StagePlanned  LifecycleStage = "planned"
+	StageLarva    LifecycleStage = "embryo_larva"
+	StageJuvenile LifecycleStage = "juvenile"
+	StageAdult    LifecycleStage = "adult"
+	StageRetired  LifecycleStage = "retired"
+	StageDeceased LifecycleStage = "deceased"
+)
+
+// Severity captures rule outcomes.
+type Severity string
+
+const (
+	SeverityBlock Severity = "block"
+	SeverityWarn  Severity = "warn"
+	SeverityLog   Severity = "log"
+)
+
+// Base contains common fields for all domain records.
+type Base struct {
+	ID        string    `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// Organism represents an individual animal tracked by the system.
+type Organism struct {
+	Base
+	Name       string         `json:"name"`
+	Species    string         `json:"species"`
+	Line       string         `json:"line"`
+	Stage      LifecycleStage `json:"stage"`
+	CohortID   *string        `json:"cohort_id"`
+	HousingID  *string        `json:"housing_id"`
+	ProtocolID *string        `json:"protocol_id"`
+	ProjectID  *string        `json:"project_id"`
+	Attributes map[string]any `json:"attributes"`
+}
+
+// Cohort represents a managed group of organisms.
+type Cohort struct {
+	Base
+	Name       string  `json:"name"`
+	Purpose    string  `json:"purpose"`
+	ProjectID  *string `json:"project_id"`
+	HousingID  *string `json:"housing_id"`
+	ProtocolID *string `json:"protocol_id"`
+}
+
+// HousingUnit captures physical housing metadata.
+type HousingUnit struct {
+	Base
+	Name        string `json:"name"`
+	Facility    string `json:"facility"`
+	Capacity    int    `json:"capacity"`
+	Environment string `json:"environment"`
+}
+
+// BreedingUnit tracks configured pairings or groups intended for reproduction.
+type BreedingUnit struct {
+	Base
+	Name       string   `json:"name"`
+	Strategy   string   `json:"strategy"`
+	HousingID  *string  `json:"housing_id"`
+	ProtocolID *string  `json:"protocol_id"`
+	FemaleIDs  []string `json:"female_ids"`
+	MaleIDs    []string `json:"male_ids"`
+}
+
+// Procedure captures scheduled or completed animal procedures.
+type Procedure struct {
+	Base
+	Name        string    `json:"name"`
+	Status      string    `json:"status"`
+	ScheduledAt time.Time `json:"scheduled_at"`
+	ProtocolID  string    `json:"protocol_id"`
+	CohortID    *string   `json:"cohort_id"`
+	OrganismIDs []string  `json:"organism_ids"`
+}
+
+// Protocol represents compliance agreements.
+type Protocol struct {
+	Base
+	Code        string `json:"code"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	MaxSubjects int    `json:"max_subjects"`
+}
+
+// Project captures cost center allocations.
+type Project struct {
+	Base
+	Code        string `json:"code"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+}
+
+// Change describes a mutation applied to an entity during a transaction.
+type Change struct {
+	Entity EntityType
+	Action Action
+	Before any
+	After  any
+}
+
+// Action indicates the type of modification performed.
+type Action string
+
+const (
+	ActionCreate Action = "create"
+	ActionUpdate Action = "update"
+	ActionDelete Action = "delete"
+)
+
+// Violation reports a failed rule evaluation.
+type Violation struct {
+	Rule     string
+	Severity Severity
+	Message  string
+	Entity   EntityType
+	EntityID string
+}
+
+// Result aggregates violations from the rules engine.
+type Result struct {
+	Violations []Violation
+}
+
+// Merge appends violations from another result.
+func (r *Result) Merge(other Result) {
+	if len(other.Violations) == 0 {
+		return
+	}
+	r.Violations = append(r.Violations, other.Violations...)
+}
+
+// HasBlocking returns true if the result contains blocking violations.
+func (r Result) HasBlocking() bool {
+	for _, v := range r.Violations {
+		if v.Severity == SeverityBlock {
+			return true
+		}
+	}
+	return false
+}
+
+// RuleViolationError is returned when blocking violations are present.
+type RuleViolationError struct {
+	Result Result
+}
+
+func (e RuleViolationError) Error() string {
+	return "transaction blocked by rules"
+}

--- a/pkg/domain/result_test.go
+++ b/pkg/domain/result_test.go
@@ -1,0 +1,69 @@
+package domain
+
+import "testing"
+
+func TestResultMerge(t *testing.T) {
+	r := Result{Violations: []Violation{{Rule: "a"}}}
+	other := Result{Violations: []Violation{{Rule: "b"}}}
+
+	r.Merge(other)
+
+	if len(r.Violations) != 2 {
+		t.Fatalf("expected 2 violations, got %d", len(r.Violations))
+	}
+	if r.Violations[1].Rule != "b" {
+		t.Fatalf("expected violation appended")
+	}
+}
+
+func TestResultMergeNoopEmpty(t *testing.T) {
+	r := Result{Violations: []Violation{{Rule: "existing"}}}
+	empty := Result{}
+
+	r.Merge(empty)
+
+	if len(r.Violations) != 1 {
+		t.Fatalf("expected existing violations unchanged")
+	}
+}
+
+func TestResultHasBlocking(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  Result
+		expect bool
+	}{
+		{
+			name:   "no violations",
+			input:  Result{},
+			expect: false,
+		},
+		{
+			name:   "warn only",
+			input:  Result{Violations: []Violation{{Severity: SeverityWarn}}},
+			expect: false,
+		},
+		{
+			name:   "contains block",
+			input:  Result{Violations: []Violation{{Severity: SeverityBlock}}},
+			expect: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Helper()
+			if got := tc.input.HasBlocking(); got != tc.expect {
+				t.Fatalf("HasBlocking=%v want %v", got, tc.expect)
+			}
+		})
+	}
+}
+
+func TestRuleViolationError(t *testing.T) {
+	err := RuleViolationError{Result: Result{Violations: []Violation{{Rule: "rule"}}}}
+	if err.Error() == "" {
+		t.Fatalf("expected error string")
+	}
+}

--- a/pkg/domain/rules.go
+++ b/pkg/domain/rules.go
@@ -1,0 +1,46 @@
+package domain
+
+import "context"
+
+// RuleView provides read-only access to domain entities for rule evaluation.
+type RuleView interface {
+	ListOrganisms() []Organism
+	ListHousingUnits() []HousingUnit
+	ListProtocols() []Protocol
+	FindOrganism(id string) (Organism, bool)
+	FindHousingUnit(id string) (HousingUnit, bool)
+}
+
+// Rule defines an evaluation executed within a transaction boundary.
+type Rule interface {
+	Name() string
+	Evaluate(ctx context.Context, view RuleView, changes []Change) (Result, error)
+}
+
+// RulesEngine orchestrates rule evaluation.
+type RulesEngine struct {
+	rules []Rule
+}
+
+// NewRulesEngine constructs an engine instance.
+func NewRulesEngine() *RulesEngine {
+	return &RulesEngine{}
+}
+
+// Register appends a rule to the engine.
+func (e *RulesEngine) Register(rule Rule) {
+	e.rules = append(e.rules, rule)
+}
+
+// Evaluate executes all registered rules and aggregates their results.
+func (e *RulesEngine) Evaluate(ctx context.Context, view RuleView, changes []Change) (Result, error) {
+	var combined Result
+	for _, rule := range e.rules {
+		res, err := rule.Evaluate(ctx, view, changes)
+		if err != nil {
+			return Result{}, err
+		}
+		combined.Merge(res)
+	}
+	return combined, nil
+}

--- a/plugins/frog/plugin.go
+++ b/plugins/frog/plugin.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"colonycore/internal/core"
+	domain "colonycore/pkg/domain"
 )
 
 // Plugin implements the frog reference module described in the RFC (stubbed for the PoC).
@@ -64,12 +65,12 @@ WHERE species ILIKE 'frog%'`,
 				Type:        "string",
 				Description: "Optional lifecycle stage filter using canonical stage identifiers.",
 				Enum: []string{
-					string(core.StagePlanned),
-					string(core.StageLarva),
-					string(core.StageJuvenile),
-					string(core.StageAdult),
-					string(core.StageRetired),
-					string(core.StageDeceased),
+					string(domain.StagePlanned),
+					string(domain.StageLarva),
+					string(domain.StageJuvenile),
+					string(domain.StageAdult),
+					string(domain.StageRetired),
+					string(domain.StageDeceased),
 				},
 			},
 			{
@@ -123,8 +124,8 @@ type frogHabitatRule struct{}
 
 func (frogHabitatRule) Name() string { return "frog_habitat_warning" }
 
-func (frogHabitatRule) Evaluate(ctx context.Context, view core.TransactionView, changes []core.Change) (core.Result, error) {
-	var result core.Result
+func (frogHabitatRule) Evaluate(ctx context.Context, view domain.RuleView, changes []domain.Change) (domain.Result, error) {
+	var result domain.Result
 	for _, organism := range view.ListOrganisms() {
 		specie := strings.ToLower(organism.Species)
 		if !strings.Contains(specie, "frog") {
@@ -141,11 +142,11 @@ func (frogHabitatRule) Evaluate(ctx context.Context, view core.TransactionView, 
 		if strings.Contains(env, "aquatic") || strings.Contains(env, "humid") {
 			continue
 		}
-		result.Violations = append(result.Violations, core.Violation{
+		result.Violations = append(result.Violations, domain.Violation{
 			Rule:     "frog_habitat_warning",
-			Severity: core.SeverityWarn,
+			Severity: domain.SeverityWarn,
 			Message:  "frog assigned to non-aquatic/non-humid housing",
-			Entity:   core.EntityOrganism,
+			Entity:   domain.EntityOrganism,
 			EntityID: organism.ID,
 		})
 	}
@@ -178,7 +179,7 @@ func frogPopulationBinder(env core.DatasetEnvironment) (core.DatasetRunner, erro
 				if stageFilter != "" && string(organism.Stage) != stageFilter {
 					continue
 				}
-				if stageFilter == "" && !includeRetired && organism.Stage == core.StageRetired {
+				if stageFilter == "" && !includeRetired && organism.Stage == domain.StageRetired {
 					continue
 				}
 				if asOfTime != nil && organism.UpdatedAt.After(*asOfTime) {

--- a/plugins/frog/plugin_test.go
+++ b/plugins/frog/plugin_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"colonycore/internal/core"
+	domain "colonycore/pkg/domain"
 )
 
 func TestPluginRegistration(t *testing.T) {
@@ -48,24 +49,24 @@ func TestFrogHabitatRuleOutcomes(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	humid, _, err := svc.CreateHousingUnit(ctx, core.HousingUnit{Name: "Humid", Facility: "Lab", Capacity: 2, Environment: "humid"})
+	humid, _, err := svc.CreateHousingUnit(ctx, domain.HousingUnit{Name: "Humid", Facility: "Lab", Capacity: 2, Environment: "humid"})
 	if err != nil {
 		t.Fatalf("create humid housing: %v", err)
 	}
-	dry, _, err := svc.CreateHousingUnit(ctx, core.HousingUnit{Name: "Dry", Facility: "Lab", Capacity: 2, Environment: "dry"})
+	dry, _, err := svc.CreateHousingUnit(ctx, domain.HousingUnit{Name: "Dry", Facility: "Lab", Capacity: 2, Environment: "dry"})
 	if err != nil {
 		t.Fatalf("create dry housing: %v", err)
 	}
 
-	frogA, _, err := svc.CreateOrganism(ctx, core.Organism{Name: "Water", Species: "Tree Frog"})
+	frogA, _, err := svc.CreateOrganism(ctx, domain.Organism{Name: "Water", Species: "Tree Frog"})
 	if err != nil {
 		t.Fatalf("create frogA: %v", err)
 	}
-	frogB, _, err := svc.CreateOrganism(ctx, core.Organism{Name: "Desert", Species: "Poison Frog"})
+	frogB, _, err := svc.CreateOrganism(ctx, domain.Organism{Name: "Desert", Species: "Poison Frog"})
 	if err != nil {
 		t.Fatalf("create frogB: %v", err)
 	}
-	other, _, err := svc.CreateOrganism(ctx, core.Organism{Name: "Lizard", Species: "Gecko"})
+	other, _, err := svc.CreateOrganism(ctx, domain.Organism{Name: "Lizard", Species: "Gecko"})
 	if err != nil {
 		t.Fatalf("create non-frog organism: %v", err)
 	}
@@ -85,7 +86,7 @@ func TestFrogHabitatRuleOutcomes(t *testing.T) {
 		if res.Violations[0].Rule != "frog_habitat_warning" {
 			t.Fatalf("unexpected rule: %+v", res.Violations[0])
 		}
-		if res.Violations[0].Severity != core.SeverityWarn {
+		if res.Violations[0].Severity != domain.SeverityWarn {
 			t.Fatalf("expected warning severity")
 		}
 	}
@@ -117,21 +118,21 @@ func TestFrogPopulationDataset(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	project, _, err := svc.CreateProject(ctx, core.Project{Code: "PRJ-FROG", Title: "Frog Ops"})
+	project, _, err := svc.CreateProject(ctx, domain.Project{Code: "PRJ-FROG", Title: "Frog Ops"})
 	if err != nil {
 		t.Fatalf("create project: %v", err)
 	}
 
-	organism, _, err := svc.CreateOrganism(ctx, core.Organism{
+	organism, _, err := svc.CreateOrganism(ctx, domain.Organism{
 		Name:      "Maple",
 		Species:   "Tree Frog",
-		Stage:     core.StageAdult,
+		Stage:     domain.StageAdult,
 		ProjectID: &project.ID,
 	})
 	if err != nil {
 		t.Fatalf("create frog organism: %v", err)
 	}
-	if _, _, err := svc.CreateOrganism(ctx, core.Organism{Name: "Gecko", Species: "Gecko", Stage: core.StageAdult}); err != nil {
+	if _, _, err := svc.CreateOrganism(ctx, domain.Organism{Name: "Gecko", Species: "Gecko", Stage: domain.StageAdult}); err != nil {
 		t.Fatalf("create non frog organism: %v", err)
 	}
 
@@ -153,7 +154,7 @@ func TestFrogPopulationDataset(t *testing.T) {
 		t.Fatalf("expected project scope metadata")
 	}
 
-	filtered, _, err := template.Run(ctx, map[string]any{"stage": string(core.StageLarva)}, core.DatasetScope{}, core.FormatJSON)
+	filtered, _, err := template.Run(ctx, map[string]any{"stage": string(domain.StageLarva)}, core.DatasetScope{}, core.FormatJSON)
 	if err != nil {
 		t.Fatalf("run dataset with stage filter: %v", err)
 	}
@@ -175,19 +176,19 @@ func TestFrogPopulationBinderFilters(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	projectA, _, err := svc.CreateProject(ctx, core.Project{Code: "PRJ-A", Title: "Project A"})
+	projectA, _, err := svc.CreateProject(ctx, domain.Project{Code: "PRJ-A", Title: "Project A"})
 	if err != nil {
 		t.Fatalf("create project A: %v", err)
 	}
-	projectB, _, err := svc.CreateProject(ctx, core.Project{Code: "PRJ-B", Title: "Project B"})
+	projectB, _, err := svc.CreateProject(ctx, domain.Project{Code: "PRJ-B", Title: "Project B"})
 	if err != nil {
 		t.Fatalf("create project B: %v", err)
 	}
-	protocol, _, err := svc.CreateProtocol(ctx, core.Protocol{Code: "PROTO", Title: "Protocol", MaxSubjects: 10})
+	protocol, _, err := svc.CreateProtocol(ctx, domain.Protocol{Code: "PROTO", Title: "Protocol", MaxSubjects: 10})
 	if err != nil {
 		t.Fatalf("create protocol: %v", err)
 	}
-	housing, _, err := svc.CreateHousingUnit(ctx, core.HousingUnit{Name: "Wet", Facility: "Lab", Capacity: 4, Environment: "humid"})
+	housing, _, err := svc.CreateHousingUnit(ctx, domain.HousingUnit{Name: "Wet", Facility: "Lab", Capacity: 4, Environment: "humid"})
 	if err != nil {
 		t.Fatalf("create housing: %v", err)
 	}
@@ -197,10 +198,10 @@ func TestFrogPopulationBinderFilters(t *testing.T) {
 	projectAID := projectA.ID
 	projectBID := projectB.ID
 
-	frogA, _, err := svc.CreateOrganism(ctx, core.Organism{
+	frogA, _, err := svc.CreateOrganism(ctx, domain.Organism{
 		Name:       "Alpha",
 		Species:    "Tree Frog",
-		Stage:      core.StageAdult,
+		Stage:      domain.StageAdult,
 		ProjectID:  &projectAID,
 		ProtocolID: &protocolID,
 		HousingID:  &housingID,
@@ -210,10 +211,10 @@ func TestFrogPopulationBinderFilters(t *testing.T) {
 	}
 	frogATime := frogA.UpdatedAt
 	time.Sleep(5 * time.Millisecond)
-	if _, _, err := svc.CreateOrganism(ctx, core.Organism{
+	if _, _, err := svc.CreateOrganism(ctx, domain.Organism{
 		Name:       "Bravo",
 		Species:    "Tree Frog",
-		Stage:      core.StageAdult,
+		Stage:      domain.StageAdult,
 		ProjectID:  &projectBID,
 		ProtocolID: &protocolID,
 		HousingID:  &housingID,
@@ -221,10 +222,10 @@ func TestFrogPopulationBinderFilters(t *testing.T) {
 		t.Fatalf("create frog B: %v", err)
 	}
 	time.Sleep(5 * time.Millisecond)
-	if _, _, err := svc.CreateOrganism(ctx, core.Organism{
+	if _, _, err := svc.CreateOrganism(ctx, domain.Organism{
 		Name:       "Charlie",
 		Species:    "Tree Frog",
-		Stage:      core.StageRetired,
+		Stage:      domain.StageRetired,
 		ProjectID:  &projectAID,
 		ProtocolID: &protocolID,
 	}); err != nil {


### PR DESCRIPTION
## What  
<!-- Describe the change. -->
The state of the project was missing domain entities. Domain logic and persistence were intertwined.
This issue decouples all entity structs and related pure logic into a new `pkg/domain` package.

## Why  
<!-- What's the motivation. -->

Part of #43 

## How  
<!-- Bullet list or description of key changes. -->
* Introduced new package `pgk/domain` to house all entity structs, value objects, invariants, rule errors and new `RuleView` and `RulesEngine` abstractions
* Removed any imports form `internal/*`
* Updated rule implementations and helpers to the new interface contract, so everything compiles against `domain.RuleView`
* Adopted `pkg/domain` interfaces in the frog plugin so rule registration and stage metadata stay within the public domain layer
* Rewrote tests

## Notes  
<!-- Breaking changes or follow-ups (if any). -->

## Checklist  

- [x] I have used conventional commits (conventionalcommits.com)
- [ ] I have updated the documentation
- [ ] I have updated the relevant RFC and its linked resources
- [x] I have added tests
- [x] I ran manual tests