### PR TITLE
feat(core): Refactor service layer

### DIFF
--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -8,27 +8,109 @@ import (
 	"time"
 )
 
-// Service exposes higher-level transactional CRUD operations for the core schema.
+// Clock exposes time retrieval used by the service for deterministic binding.
+type Clock interface {
+	Now() time.Time
+}
+
+// ClockFunc adapts a function into a Clock.
+type ClockFunc func() time.Time
+
+// Now returns the current time for the function-based clock.
+func (fn ClockFunc) Now() time.Time {
+	if fn == nil {
+		return time.Now().UTC()
+	}
+	return fn().UTC()
+}
+
+// Logger abstracts structured logging used by the service layer.
+type Logger interface {
+	Debug(msg string, args ...any)
+	Info(msg string, args ...any)
+	Warn(msg string, args ...any)
+	Error(msg string, args ...any)
+}
+
+type noopLogger struct{}
+
+func (noopLogger) Debug(string, ...any) {}
+func (noopLogger) Info(string, ...any)  {}
+func (noopLogger) Warn(string, ...any)  {}
+func (noopLogger) Error(string, ...any) {}
+
+// ServiceOption configures optional dependencies for the Service constructor.
+type ServiceOption func(*serviceOptions)
+
+type serviceOptions struct {
+	clock  Clock
+	logger Logger
+}
+
+// WithClock overrides the default clock used by the service.
+func WithClock(clock Clock) ServiceOption {
+	return func(opts *serviceOptions) {
+		if clock != nil {
+			opts.clock = clock
+		}
+	}
+}
+
+// WithLogger injects a logger used by the service.
+func WithLogger(logger Logger) ServiceOption {
+	return func(opts *serviceOptions) {
+		if logger != nil {
+			opts.logger = logger
+		}
+	}
+}
+
+func defaultServiceOptions() serviceOptions {
+	return serviceOptions{
+		clock:  ClockFunc(func() time.Time { return time.Now().UTC() }),
+		logger: noopLogger{},
+	}
+}
+
+// Service orchestrates transactional operations, plugin registration, and dataset binding.
 type Service struct {
 	store    PersistentStore
+	engine   *RulesEngine
+	clock    Clock
+	now      func() time.Time
+	logger   Logger
 	plugins  map[string]PluginMetadata
 	datasets map[string]DatasetTemplate
 	mu       sync.RWMutex
 }
 
 // NewService constructs a service backed by the supplied store.
-func NewService(store PersistentStore) *Service {
-	return &Service{
+func NewService(store PersistentStore, opts ...ServiceOption) *Service {
+	if store == nil {
+		panic("core: service requires a persistent store")
+	}
+	options := defaultServiceOptions()
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&options)
+		}
+	}
+	svc := &Service{
 		store:    store,
+		clock:    options.clock,
+		logger:   options.logger,
 		plugins:  make(map[string]PluginMetadata),
 		datasets: make(map[string]DatasetTemplate),
 	}
+	svc.engine = extractRulesEngine(store)
+	svc.now = selectNowFunc(store, svc.clock)
+	return svc
 }
 
 // NewInMemoryService creates a service and in-memory store with the given rules engine.
-func NewInMemoryService(engine *RulesEngine) *Service {
+func NewInMemoryService(engine *RulesEngine, opts ...ServiceOption) *Service {
 	store := NewMemoryStore(engine)
-	return NewService(store)
+	return NewService(store, opts...)
 }
 
 // Store returns the underlying storage implementation.
@@ -37,13 +119,12 @@ func (s *Service) Store() PersistentStore {
 }
 
 // CreateProject persists a new project.
-
 func (s *Service) CreateProject(ctx context.Context, project Project) (Project, Result, error) {
 	var created Project
-	res, err := s.store.RunInTransaction(ctx, func(tx Transaction) error {
-		var err error
-		created, err = tx.CreateProject(project)
-		return err
+	res, err := s.run(ctx, "create_project", func(tx Transaction) error {
+		var innerErr error
+		created, innerErr = tx.CreateProject(project)
+		return innerErr
 	})
 	return created, res, err
 }
@@ -51,10 +132,10 @@ func (s *Service) CreateProject(ctx context.Context, project Project) (Project, 
 // CreateProtocol persists a new protocol.
 func (s *Service) CreateProtocol(ctx context.Context, protocol Protocol) (Protocol, Result, error) {
 	var created Protocol
-	res, err := s.store.RunInTransaction(ctx, func(tx Transaction) error {
-		var err error
-		created, err = tx.CreateProtocol(protocol)
-		return err
+	res, err := s.run(ctx, "create_protocol", func(tx Transaction) error {
+		var innerErr error
+		created, innerErr = tx.CreateProtocol(protocol)
+		return innerErr
 	})
 	return created, res, err
 }
@@ -62,10 +143,10 @@ func (s *Service) CreateProtocol(ctx context.Context, protocol Protocol) (Protoc
 // CreateHousingUnit persists housing metadata.
 func (s *Service) CreateHousingUnit(ctx context.Context, housing HousingUnit) (HousingUnit, Result, error) {
 	var created HousingUnit
-	res, err := s.store.RunInTransaction(ctx, func(tx Transaction) error {
-		var err error
-		created, err = tx.CreateHousingUnit(housing)
-		return err
+	res, err := s.run(ctx, "create_housing_unit", func(tx Transaction) error {
+		var innerErr error
+		created, innerErr = tx.CreateHousingUnit(housing)
+		return innerErr
 	})
 	return created, res, err
 }
@@ -73,10 +154,10 @@ func (s *Service) CreateHousingUnit(ctx context.Context, housing HousingUnit) (H
 // CreateCohort persists a new cohort.
 func (s *Service) CreateCohort(ctx context.Context, cohort Cohort) (Cohort, Result, error) {
 	var created Cohort
-	res, err := s.store.RunInTransaction(ctx, func(tx Transaction) error {
-		var err error
-		created, err = tx.CreateCohort(cohort)
-		return err
+	res, err := s.run(ctx, "create_cohort", func(tx Transaction) error {
+		var innerErr error
+		created, innerErr = tx.CreateCohort(cohort)
+		return innerErr
 	})
 	return created, res, err
 }
@@ -84,10 +165,10 @@ func (s *Service) CreateCohort(ctx context.Context, cohort Cohort) (Cohort, Resu
 // CreateOrganism persists a new organism.
 func (s *Service) CreateOrganism(ctx context.Context, organism Organism) (Organism, Result, error) {
 	var created Organism
-	res, err := s.store.RunInTransaction(ctx, func(tx Transaction) error {
-		var err error
-		created, err = tx.CreateOrganism(organism)
-		return err
+	res, err := s.run(ctx, "create_organism", func(tx Transaction) error {
+		var innerErr error
+		created, innerErr = tx.CreateOrganism(organism)
+		return innerErr
 	})
 	return created, res, err
 }
@@ -95,35 +176,34 @@ func (s *Service) CreateOrganism(ctx context.Context, organism Organism) (Organi
 // UpdateOrganism mutates an organism using the provided mutator.
 func (s *Service) UpdateOrganism(ctx context.Context, id string, mutator func(*Organism) error) (Organism, Result, error) {
 	var updated Organism
-	res, err := s.store.RunInTransaction(ctx, func(tx Transaction) error {
-		var err error
-		updated, err = tx.UpdateOrganism(id, mutator)
-		return err
+	res, err := s.run(ctx, "update_organism", func(tx Transaction) error {
+		var innerErr error
+		updated, innerErr = tx.UpdateOrganism(id, mutator)
+		return innerErr
 	})
 	return updated, res, err
 }
 
 // DeleteOrganism removes an organism record.
 func (s *Service) DeleteOrganism(ctx context.Context, id string) (Result, error) {
-	res, err := s.store.RunInTransaction(ctx, func(tx Transaction) error {
+	return s.run(ctx, "delete_organism", func(tx Transaction) error {
 		return tx.DeleteOrganism(id)
 	})
-	return res, err
 }
 
 // AssignOrganismHousing updates an organism's housing reference within a transaction that validates dependencies.
 func (s *Service) AssignOrganismHousing(ctx context.Context, organismID, housingID string) (Organism, Result, error) {
 	var updated Organism
-	res, err := s.store.RunInTransaction(ctx, func(tx Transaction) error {
+	res, err := s.run(ctx, "assign_organism_housing", func(tx Transaction) error {
 		if _, ok := tx.FindHousingUnit(housingID); !ok {
 			return ErrNotFound{Entity: EntityHousingUnit, ID: housingID}
 		}
-		var err error
-		updated, err = tx.UpdateOrganism(organismID, func(o *Organism) error {
+		var innerErr error
+		updated, innerErr = tx.UpdateOrganism(organismID, func(o *Organism) error {
 			o.HousingID = &housingID
 			return nil
 		})
-		return err
+		return innerErr
 	})
 	return updated, res, err
 }
@@ -131,16 +211,16 @@ func (s *Service) AssignOrganismHousing(ctx context.Context, organismID, housing
 // AssignOrganismProtocol links an organism to a protocol within the same transactional scope.
 func (s *Service) AssignOrganismProtocol(ctx context.Context, organismID, protocolID string) (Organism, Result, error) {
 	var updated Organism
-	res, err := s.store.RunInTransaction(ctx, func(tx Transaction) error {
+	res, err := s.run(ctx, "assign_organism_protocol", func(tx Transaction) error {
 		if _, ok := tx.FindProtocol(protocolID); !ok {
 			return ErrNotFound{Entity: EntityProtocol, ID: protocolID}
 		}
-		var err error
-		updated, err = tx.UpdateOrganism(organismID, func(o *Organism) error {
+		var innerErr error
+		updated, innerErr = tx.UpdateOrganism(organismID, func(o *Organism) error {
 			o.ProtocolID = &protocolID
 			return nil
 		})
-		return err
+		return innerErr
 	})
 	return updated, res, err
 }
@@ -148,10 +228,10 @@ func (s *Service) AssignOrganismProtocol(ctx context.Context, organismID, protoc
 // CreateBreedingUnit persists a breeding configuration.
 func (s *Service) CreateBreedingUnit(ctx context.Context, unit BreedingUnit) (BreedingUnit, Result, error) {
 	var created BreedingUnit
-	res, err := s.store.RunInTransaction(ctx, func(tx Transaction) error {
-		var err error
-		created, err = tx.CreateBreedingUnit(unit)
-		return err
+	res, err := s.run(ctx, "create_breeding_unit", func(tx Transaction) error {
+		var innerErr error
+		created, innerErr = tx.CreateBreedingUnit(unit)
+		return innerErr
 	})
 	return created, res, err
 }
@@ -159,10 +239,10 @@ func (s *Service) CreateBreedingUnit(ctx context.Context, unit BreedingUnit) (Br
 // CreateProcedure persists a procedure record.
 func (s *Service) CreateProcedure(ctx context.Context, procedure Procedure) (Procedure, Result, error) {
 	var created Procedure
-	res, err := s.store.RunInTransaction(ctx, func(tx Transaction) error {
-		var err error
-		created, err = tx.CreateProcedure(procedure)
-		return err
+	res, err := s.run(ctx, "create_procedure", func(tx Transaction) error {
+		var innerErr error
+		created, innerErr = tx.CreateProcedure(procedure)
+		return innerErr
 	})
 	return created, res, err
 }
@@ -170,20 +250,19 @@ func (s *Service) CreateProcedure(ctx context.Context, procedure Procedure) (Pro
 // UpdateProcedure mutates a procedure.
 func (s *Service) UpdateProcedure(ctx context.Context, id string, mutator func(*Procedure) error) (Procedure, Result, error) {
 	var updated Procedure
-	res, err := s.store.RunInTransaction(ctx, func(tx Transaction) error {
-		var err error
-		updated, err = tx.UpdateProcedure(id, mutator)
-		return err
+	res, err := s.run(ctx, "update_procedure", func(tx Transaction) error {
+		var innerErr error
+		updated, innerErr = tx.UpdateProcedure(id, mutator)
+		return innerErr
 	})
 	return updated, res, err
 }
 
 // DeleteProcedure removes a procedure record.
 func (s *Service) DeleteProcedure(ctx context.Context, id string) (Result, error) {
-	res, err := s.store.RunInTransaction(ctx, func(tx Transaction) error {
+	return s.run(ctx, "delete_procedure", func(tx Transaction) error {
 		return tx.DeleteProcedure(id)
 	})
-	return res, err
 }
 
 // ErrNotFound is returned when reference validation fails within transactional helpers.
@@ -205,9 +284,6 @@ func (s *Service) InstallPlugin(plugin Plugin) (PluginMetadata, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.plugins == nil {
-		s.plugins = make(map[string]PluginMetadata)
-	}
 	if _, ok := s.plugins[plugin.Name()]; ok {
 		return PluginMetadata{}, fmt.Errorf("plugin %s already registered", plugin.Name())
 	}
@@ -217,10 +293,9 @@ func (s *Service) InstallPlugin(plugin Plugin) (PluginMetadata, error) {
 		return PluginMetadata{}, err
 	}
 
-	// Rules engine only available for memory-backed stores today.
-	if ms, ok := s.store.(*MemoryStore); ok {
-		for _, rule := range registry.Rules() {
-			ms.RulesEngine().Register(rule)
+	for _, rule := range registry.Rules() {
+		if s.engine != nil {
+			s.engine.Register(rule)
 		}
 	}
 
@@ -230,11 +305,8 @@ func (s *Service) InstallPlugin(plugin Plugin) (PluginMetadata, error) {
 		Schemas: registry.Schemas(),
 	}
 
-	// Provide dataset environment (time source only if memory store for now).
-	env := DatasetEnvironment{Store: s.store}
-	if ms, ok := s.store.(*MemoryStore); ok {
-		env.Now = ms.NowFunc()
-	} else {
+	env := DatasetEnvironment{Store: s.store, Now: s.now}
+	if env.Now == nil {
 		env.Now = func() time.Time { return time.Now().UTC() }
 	}
 
@@ -244,9 +316,6 @@ func (s *Service) InstallPlugin(plugin Plugin) (PluginMetadata, error) {
 			return PluginMetadata{}, fmt.Errorf("bind dataset %s: %w", dataset.Key, err)
 		}
 		slug := dataset.slug()
-		if s.datasets == nil {
-			s.datasets = make(map[string]DatasetTemplate)
-		}
 		if _, exists := s.datasets[slug]; exists {
 			return PluginMetadata{}, fmt.Errorf("dataset template %s already installed", slug)
 		}
@@ -259,6 +328,7 @@ func (s *Service) InstallPlugin(plugin Plugin) (PluginMetadata, error) {
 	}
 
 	s.plugins[plugin.Name()] = meta
+	s.logger.Info("plugin installed", "plugin", plugin.Name(), "version", plugin.Version(), "datasets", len(meta.Datasets))
 	return meta, nil
 }
 
@@ -306,4 +376,41 @@ func (s *Service) ResolveDatasetTemplate(slug string) (DatasetTemplate, bool) {
 	defer s.mu.RUnlock()
 	template, ok := s.datasets[slug]
 	return template, ok
+}
+
+func (s *Service) run(ctx context.Context, op string, fn func(Transaction) error) (Result, error) {
+	res, err := s.store.RunInTransaction(ctx, fn)
+	if err != nil {
+		s.logger.Error("service operation failed", "op", op, "error", err)
+		return res, err
+	}
+	s.logger.Debug("service operation succeeded", "op", op)
+	return res, nil
+}
+
+type rulesEngineProvider interface {
+	RulesEngine() *RulesEngine
+}
+
+type nowFuncProvider interface {
+	NowFunc() func() time.Time
+}
+
+func extractRulesEngine(store PersistentStore) *RulesEngine {
+	if provider, ok := store.(rulesEngineProvider); ok {
+		return provider.RulesEngine()
+	}
+	return nil
+}
+
+func selectNowFunc(store PersistentStore, clock Clock) func() time.Time {
+	if provider, ok := store.(nowFuncProvider); ok {
+		if fn := provider.NowFunc(); fn != nil {
+			return func() time.Time { return fn().UTC() }
+		}
+	}
+	if clock != nil {
+		return func() time.Time { return clock.Now().UTC() }
+	}
+	return func() time.Time { return time.Now().UTC() }
 }


### PR DESCRIPTION
## What  
<!-- Describe the change. -->
Introduce new Service layer to orchestrate transactions, rules engine, plugin registration, dataset binding, injecting a Clock and logger. It now exclusively orchestrates transactions, rules engine, plugin registration, dataset binding, injecting a Clock and logger.

## Why  
<!-- What's the motivation. -->

Working on #43 

## How  
<!-- Bullet list or description of key changes. -->
* Introduced option-driven dependencies
* Introduced new wrapper and dependency discovery helpers for pluggable clock and logger
* Plugin installation now wires rules into any store exposing `RulesEngine()` and binds dataset templates with the resolved clock before logging the install event

## Notes  
<!-- Breaking changes or follow-ups (if any). -->

## Checklist  

- [x] I have used conventional commits (conventionalcommits.com)
- [ ] I have updated the documentation
- [ ] I have updated the relevant RFC and its linked resources
- [x] I have added tests
- [x] I ran manual tests