### PR TITLE
feat(pkg): Refactor plugins & dataset API

### DIFF
--- a/internal/core/dataset_adapter.go
+++ b/internal/core/dataset_adapter.go
@@ -1,0 +1,224 @@
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"colonycore/pkg/datasetapi"
+)
+
+func newDatasetTemplateFromAPI(template datasetapi.Template) (DatasetTemplate, error) {
+	converted := DatasetTemplate{
+		Key:           template.Key,
+		Version:       template.Version,
+		Title:         template.Title,
+		Description:   template.Description,
+		Dialect:       DatasetDialect(template.Dialect),
+		Query:         template.Query,
+		Parameters:    copyParametersFromAPI(template.Parameters),
+		Columns:       copyColumnsFromAPI(template.Columns),
+		Metadata:      copyMetadataFromAPI(template.Metadata),
+		OutputFormats: copyFormatsFromAPI(template.OutputFormats),
+	}
+	converted.Binder = adaptDatasetBinder(template)
+	if err := converted.validate(); err != nil {
+		return DatasetTemplate{}, err
+	}
+	return converted, nil
+}
+
+func adaptDatasetBinder(template datasetapi.Template) DatasetBinder {
+	if template.Binder == nil {
+		return nil
+	}
+	return func(env DatasetEnvironment) (DatasetRunner, error) {
+		runner, err := template.Binder(datasetapi.Environment{Store: env.Store, Now: env.Now})
+		if err != nil {
+			return nil, err
+		}
+		if runner == nil {
+			return nil, fmt.Errorf("dataset binder returned nil runner")
+		}
+		return func(ctx context.Context, req DatasetRunRequest) (DatasetRunResult, error) {
+			apiReq := datasetapi.RunRequest{
+				Template:   convertDescriptorToAPI(req.Template),
+				Parameters: req.Parameters,
+				Scope:      convertScopeToAPI(req.Scope),
+			}
+			apiResult, err := runner(ctx, apiReq)
+			if err != nil {
+				return DatasetRunResult{}, err
+			}
+			return DatasetRunResult{
+				Schema:      copyColumnsFromAPI(apiResult.Schema),
+				Rows:        apiResult.Rows,
+				Metadata:    apiResult.Metadata,
+				GeneratedAt: apiResult.GeneratedAt,
+				Format:      DatasetFormat(apiResult.Format),
+			}, nil
+		}, nil
+	}
+}
+
+func convertDescriptorToAPI(descriptor DatasetTemplateDescriptor) datasetapi.TemplateDescriptor {
+	return datasetapi.TemplateDescriptor{
+		Plugin:        descriptor.Plugin,
+		Key:           descriptor.Key,
+		Version:       descriptor.Version,
+		Title:         descriptor.Title,
+		Description:   descriptor.Description,
+		Dialect:       datasetapi.Dialect(descriptor.Dialect),
+		Query:         descriptor.Query,
+		Parameters:    copyParametersToAPI(descriptor.Parameters),
+		Columns:       copyColumnsToAPI(descriptor.Columns),
+		Metadata:      copyMetadataToAPI(descriptor.Metadata),
+		OutputFormats: copyFormatsToAPI(descriptor.OutputFormats),
+		Slug:          descriptor.Slug,
+	}
+}
+
+func convertScopeToAPI(scope DatasetScope) datasetapi.Scope {
+	apiScope := datasetapi.Scope{Requestor: scope.Requestor}
+	if len(scope.Roles) > 0 {
+		apiScope.Roles = append([]string(nil), scope.Roles...)
+	}
+	if len(scope.ProjectIDs) > 0 {
+		apiScope.ProjectIDs = append([]string(nil), scope.ProjectIDs...)
+	}
+	if len(scope.ProtocolIDs) > 0 {
+		apiScope.ProtocolIDs = append([]string(nil), scope.ProtocolIDs...)
+	}
+	return apiScope
+}
+
+func copyParametersFromAPI(params []datasetapi.Parameter) []DatasetParameter {
+	if len(params) == 0 {
+		return nil
+	}
+	converted := make([]DatasetParameter, len(params))
+	for i, param := range params {
+		converted[i] = DatasetParameter{
+			Name:        param.Name,
+			Type:        param.Type,
+			Required:    param.Required,
+			Description: param.Description,
+			Unit:        param.Unit,
+			Enum:        append([]string(nil), param.Enum...),
+			Example:     param.Example,
+			Default:     param.Default,
+		}
+	}
+	return converted
+}
+
+func copyParametersToAPI(params []DatasetParameter) []datasetapi.Parameter {
+	if len(params) == 0 {
+		return nil
+	}
+	converted := make([]datasetapi.Parameter, len(params))
+	for i, param := range params {
+		converted[i] = datasetapi.Parameter{
+			Name:        param.Name,
+			Type:        param.Type,
+			Required:    param.Required,
+			Description: param.Description,
+			Unit:        param.Unit,
+			Enum:        append([]string(nil), param.Enum...),
+			Example:     param.Example,
+			Default:     param.Default,
+		}
+	}
+	return converted
+}
+
+func copyColumnsFromAPI(columns []datasetapi.Column) []DatasetColumn {
+	if len(columns) == 0 {
+		return nil
+	}
+	converted := make([]DatasetColumn, len(columns))
+	for i, column := range columns {
+		converted[i] = DatasetColumn{
+			Name:        column.Name,
+			Type:        column.Type,
+			Unit:        column.Unit,
+			Description: column.Description,
+			Format:      column.Format,
+		}
+	}
+	return converted
+}
+
+func copyColumnsToAPI(columns []DatasetColumn) []datasetapi.Column {
+	if len(columns) == 0 {
+		return nil
+	}
+	converted := make([]datasetapi.Column, len(columns))
+	for i, column := range columns {
+		converted[i] = datasetapi.Column{
+			Name:        column.Name,
+			Type:        column.Type,
+			Unit:        column.Unit,
+			Description: column.Description,
+			Format:      column.Format,
+		}
+	}
+	return converted
+}
+
+func copyMetadataFromAPI(metadata datasetapi.Metadata) DatasetTemplateMetadata {
+	converted := DatasetTemplateMetadata{
+		Source:          metadata.Source,
+		Documentation:   metadata.Documentation,
+		RefreshInterval: metadata.RefreshInterval,
+	}
+	if len(metadata.Tags) > 0 {
+		converted.Tags = append([]string(nil), metadata.Tags...)
+	}
+	if len(metadata.Annotations) > 0 {
+		converted.Annotations = make(map[string]string, len(metadata.Annotations))
+		for k, v := range metadata.Annotations {
+			converted.Annotations[k] = v
+		}
+	}
+	return converted
+}
+
+func copyMetadataToAPI(metadata DatasetTemplateMetadata) datasetapi.Metadata {
+	converted := datasetapi.Metadata{
+		Source:          metadata.Source,
+		Documentation:   metadata.Documentation,
+		RefreshInterval: metadata.RefreshInterval,
+	}
+	if len(metadata.Tags) > 0 {
+		converted.Tags = append([]string(nil), metadata.Tags...)
+	}
+	if len(metadata.Annotations) > 0 {
+		converted.Annotations = make(map[string]string, len(metadata.Annotations))
+		for k, v := range metadata.Annotations {
+			converted.Annotations[k] = v
+		}
+	}
+	return converted
+}
+
+func copyFormatsFromAPI(formats []datasetapi.Format) []DatasetFormat {
+	if len(formats) == 0 {
+		return nil
+	}
+	converted := make([]DatasetFormat, len(formats))
+	for i, format := range formats {
+		converted[i] = DatasetFormat(format)
+	}
+	return converted
+}
+
+func copyFormatsToAPI(formats []DatasetFormat) []datasetapi.Format {
+	if len(formats) == 0 {
+		return nil
+	}
+	converted := make([]datasetapi.Format, len(formats))
+	for i, format := range formats {
+		converted[i] = datasetapi.Format(format)
+	}
+	return converted
+}

--- a/internal/core/dataset_adapter_test.go
+++ b/internal/core/dataset_adapter_test.go
@@ -1,0 +1,141 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"colonycore/pkg/datasetapi"
+)
+
+func TestNewDatasetTemplateFromAPI(t *testing.T) {
+	now := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	apiTemplate := datasetapi.Template{
+		Key:         "demo",
+		Version:     "1.0.0",
+		Title:       "Demo",
+		Description: "demo",
+		Dialect:     datasetapi.DialectSQL,
+		Query:       "SELECT 1",
+		Parameters: []datasetapi.Parameter{{
+			Name:        "stage",
+			Type:        "string",
+			Enum:        []string{"adult"},
+			Description: "stage filter",
+		}},
+		Columns: []datasetapi.Column{{
+			Name:        "value",
+			Type:        "string",
+			Description: "value column",
+		}},
+		Metadata: datasetapi.Metadata{
+			Source:          "tests",
+			Documentation:   "docs",
+			RefreshInterval: "PT1H",
+			Tags:            []string{"tag"},
+			Annotations:     map[string]string{"key": "val"},
+		},
+		OutputFormats: []datasetapi.Format{datasetapi.FormatJSON, datasetapi.FormatCSV},
+	}
+
+	apiTemplate.Binder = func(env datasetapi.Environment) (datasetapi.Runner, error) {
+		if env.Now == nil {
+			t.Fatalf("expected now function")
+		}
+		return func(ctx context.Context, req datasetapi.RunRequest) (datasetapi.RunResult, error) {
+			if req.Template.Key != "demo" {
+				t.Fatalf("unexpected template key: %s", req.Template.Key)
+			}
+			if req.Scope.Requestor != "analyst" {
+				t.Fatalf("unexpected requestor: %s", req.Scope.Requestor)
+			}
+			if len(req.Scope.ProjectIDs) != 1 || req.Scope.ProjectIDs[0] != "project" {
+				t.Fatalf("unexpected project scope: %+v", req.Scope.ProjectIDs)
+			}
+			return datasetapi.RunResult{
+				Schema: []datasetapi.Column{{Name: "value", Type: "string"}},
+				Rows:   []map[string]any{{"value": 1}},
+				Metadata: map[string]any{
+					"source": "binder",
+				},
+				GeneratedAt: env.Now(),
+				Format:      datasetapi.FormatCSV,
+			}, nil
+		}, nil
+	}
+
+	converted, err := newDatasetTemplateFromAPI(apiTemplate)
+	if err != nil {
+		t.Fatalf("newDatasetTemplateFromAPI: %v", err)
+	}
+
+	apiTemplate.Parameters[0].Enum[0] = "mutated"
+	if converted.Parameters[0].Enum[0] != "adult" {
+		t.Fatalf("expected defensive copy of enum")
+	}
+
+	converted.Plugin = "frog"
+	env := DatasetEnvironment{Now: func() time.Time { return now }}
+	if err := converted.bind(env); err != nil {
+		t.Fatalf("bind converted template: %v", err)
+	}
+
+	params := map[string]any{"stage": "adult"}
+	scope := DatasetScope{
+		Requestor:   "analyst",
+		Roles:       []string{"scientist"},
+		ProjectIDs:  []string{"project"},
+		ProtocolIDs: []string{"protocol"},
+	}
+
+	result, paramErrs, err := converted.Run(context.Background(), params, scope, FormatJSON)
+	if err != nil {
+		t.Fatalf("run converted template: %v", err)
+	}
+	if len(paramErrs) != 0 {
+		t.Fatalf("unexpected parameter errors: %+v", paramErrs)
+	}
+	if result.Format != FormatJSON {
+		t.Fatalf("expected format override to JSON, got %s", result.Format)
+	}
+	if len(result.Rows) != 1 || result.Rows[0]["value"].(int) != 1 {
+		t.Fatalf("unexpected rows: %+v", result.Rows)
+	}
+	if result.Metadata["source"].(string) != "binder" {
+		t.Fatalf("unexpected metadata: %+v", result.Metadata)
+	}
+	if result.GeneratedAt != now {
+		t.Fatalf("expected generatedAt from now function")
+	}
+}
+
+func TestNewDatasetTemplateFromAPIValidation(t *testing.T) {
+	_, err := newDatasetTemplateFromAPI(datasetapi.Template{})
+	if err == nil {
+		t.Fatalf("expected validation error for empty template")
+	}
+}
+
+func TestAdaptDatasetBinderNilRunner(t *testing.T) {
+	template := datasetapi.Template{
+		Key:           "demo",
+		Version:       "1.0.0",
+		Title:         "Demo",
+		Description:   "demo",
+		Dialect:       datasetapi.DialectSQL,
+		Query:         "SELECT 1",
+		Columns:       []datasetapi.Column{{Name: "value", Type: "string"}},
+		OutputFormats: []datasetapi.Format{datasetapi.FormatJSON},
+		Binder: func(datasetapi.Environment) (datasetapi.Runner, error) {
+			return nil, nil
+		},
+	}
+
+	converted, err := newDatasetTemplateFromAPI(template)
+	if err != nil {
+		t.Fatalf("newDatasetTemplateFromAPI: %v", err)
+	}
+	if err := converted.bind(DatasetEnvironment{}); err == nil {
+		t.Fatalf("expected binder to surface nil runner error")
+	}
+}

--- a/internal/core/plugin_registry_extra_test.go
+++ b/internal/core/plugin_registry_extra_test.go
@@ -3,13 +3,15 @@ package core
 import (
 	"context"
 	"testing"
+
+	"colonycore/pkg/datasetapi"
 )
 
 func TestPluginRegistryRegisterDatasetTemplateDuplicate(t *testing.T) {
 	r := NewPluginRegistry()
-	tmpl := DatasetTemplate{Key: "k", Version: "1", Title: "T", Dialect: DatasetDialectSQL, Query: "SELECT 1", Columns: []DatasetColumn{{Name: "c", Type: "string"}}, OutputFormats: []DatasetFormat{FormatJSON}, Binder: func(DatasetEnvironment) (DatasetRunner, error) {
-		return func(ctx context.Context, req DatasetRunRequest) (DatasetRunResult, error) {
-			return DatasetRunResult{}, nil
+	tmpl := datasetapi.Template{Key: "k", Version: "1", Title: "T", Dialect: datasetapi.DialectSQL, Query: "SELECT 1", Columns: []datasetapi.Column{{Name: "c", Type: "string"}}, OutputFormats: []datasetapi.Format{datasetapi.FormatJSON}, Binder: func(datasetapi.Environment) (datasetapi.Runner, error) {
+		return func(ctx context.Context, req datasetapi.RunRequest) (datasetapi.RunResult, error) {
+			return datasetapi.RunResult{}, nil
 		}, nil
 	}}
 	if err := r.RegisterDatasetTemplate(tmpl); err != nil {

--- a/internal/core/plugin_registry_test.go
+++ b/internal/core/plugin_registry_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"colonycore/pkg/datasetapi"
 )
 
 func TestPluginRegistryGuardsAndCopies(t *testing.T) {
@@ -41,24 +43,24 @@ func TestPluginRegistryGuardsAndCopies(t *testing.T) {
 		t.Fatalf("expected registry to return defensive copies")
 	}
 
-	template := DatasetTemplate{
+	template := datasetapi.Template{
 		Key:         "demo",
 		Version:     "1.0.0",
 		Title:       "Demo",
 		Description: "Demo dataset",
-		Dialect:     DatasetDialectSQL,
+		Dialect:     datasetapi.DialectSQL,
 		Query:       "SELECT 1",
-		Parameters: []DatasetParameter{{
+		Parameters: []datasetapi.Parameter{{
 			Name: "stage",
 			Type: "string",
 			Enum: []string{"adult"},
 		}},
-		Columns:       []DatasetColumn{{Name: "value", Type: "number", Unit: "count"}},
-		Metadata:      DatasetTemplateMetadata{Tags: []string{"demo"}, Annotations: map[string]string{"k": "v"}},
-		OutputFormats: []DatasetFormat{FormatJSON},
-		Binder: func(DatasetEnvironment) (DatasetRunner, error) {
-			return func(context.Context, DatasetRunRequest) (DatasetRunResult, error) {
-				return DatasetRunResult{Rows: []map[string]any{{"value": 1}}, GeneratedAt: time.Now().UTC()}, nil
+		Columns:       []datasetapi.Column{{Name: "value", Type: "number", Unit: "count"}},
+		Metadata:      datasetapi.Metadata{Tags: []string{"demo"}, Annotations: map[string]string{"k": "v"}},
+		OutputFormats: []datasetapi.Format{datasetapi.FormatJSON},
+		Binder: func(datasetapi.Environment) (datasetapi.Runner, error) {
+			return func(context.Context, datasetapi.RunRequest) (datasetapi.RunResult, error) {
+				return datasetapi.RunResult{Rows: []map[string]any{{"value": 1}}, GeneratedAt: time.Now().UTC(), Format: datasetapi.FormatJSON}, nil
 			}, nil
 		},
 	}

--- a/internal/core/service_test.go
+++ b/internal/core/service_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"colonycore/internal/core"
+	"colonycore/pkg/datasetapi"
+	"colonycore/pkg/pluginapi"
 	"colonycore/plugins/frog"
 )
 
@@ -405,28 +407,28 @@ type testClockPlugin struct{}
 func (testClockPlugin) Name() string    { return "clock" }
 func (testClockPlugin) Version() string { return "v1" }
 
-func (testClockPlugin) Register(registry *core.PluginRegistry) error {
-	return registry.RegisterDatasetTemplate(core.DatasetTemplate{
+func (testClockPlugin) Register(registry pluginapi.Registry) error {
+	return registry.RegisterDatasetTemplate(datasetapi.Template{
 		Key:           "now",
 		Version:       "v1",
 		Title:         "Now",
 		Description:   "returns the current time",
-		Dialect:       core.DatasetDialectSQL,
+		Dialect:       datasetapi.DialectSQL,
 		Query:         "SELECT now()",
-		OutputFormats: []core.DatasetFormat{core.FormatJSON},
-		Columns:       []core.DatasetColumn{{Name: "now", Type: "timestamp"}},
-		Binder: func(env core.DatasetEnvironment) (core.DatasetRunner, error) {
-			return func(ctx context.Context, req core.DatasetRunRequest) (core.DatasetRunResult, error) {
+		OutputFormats: []datasetapi.Format{datasetapi.FormatJSON},
+		Columns:       []datasetapi.Column{{Name: "now", Type: "timestamp"}},
+		Binder: func(env datasetapi.Environment) (datasetapi.Runner, error) {
+			return func(ctx context.Context, req datasetapi.RunRequest) (datasetapi.RunResult, error) {
 				now := env.Now
 				if now == nil {
 					now = func() time.Time { return time.Now().UTC() }
 				}
 				timestamp := now().UTC()
-				return core.DatasetRunResult{
+				return datasetapi.RunResult{
 					Schema:      req.Template.Columns,
 					Rows:        []map[string]any{{"now": timestamp}},
 					GeneratedAt: timestamp,
-					Format:      core.FormatJSON,
+					Format:      datasetapi.FormatJSON,
 				}, nil
 			}, nil
 		},

--- a/internal/dataset/exporter_internal_test.go
+++ b/internal/dataset/exporter_internal_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"colonycore/internal/core"
+	"colonycore/pkg/datasetapi"
+	"colonycore/pkg/pluginapi"
 )
 
 type stringer struct{}
@@ -153,36 +155,35 @@ func (f failingStore) Delete(context.Context, string) (bool, error) { return fal
 func (f failingStore) List(context.Context, string) ([]ExportArtifact, error) { return nil, nil }
 
 type testDatasetPlugin struct {
-	dataset core.DatasetTemplate
+	dataset datasetapi.Template
 }
 
 func (p testDatasetPlugin) Name() string { return "test-dataset" }
 
 func (p testDatasetPlugin) Version() string { return "0.0.1" }
 
-func (p testDatasetPlugin) Register(registry *core.PluginRegistry) error {
+func (p testDatasetPlugin) Register(registry pluginapi.Registry) error {
 	return registry.RegisterDatasetTemplate(p.dataset)
 }
 
 func TestWorkerProcessParameterFailure(t *testing.T) {
-	template := core.DatasetTemplate{
-		Plugin:      "frog",
+	template := datasetapi.Template{
 		Key:         "fail",
 		Version:     "1.0.0",
 		Title:       "Fail",
 		Description: "missing params",
-		Dialect:     core.DatasetDialectSQL,
+		Dialect:     datasetapi.DialectSQL,
 		Query:       "SELECT 1",
-		Parameters: []core.DatasetParameter{{
+		Parameters: []datasetapi.Parameter{{
 			Name:     "required",
 			Type:     "string",
 			Required: true,
 		}},
-		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
-		OutputFormats: []core.DatasetFormat{core.FormatJSON},
-		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
-			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
-				return core.DatasetRunResult{}, nil
+		Columns:       []datasetapi.Column{{Name: "value", Type: "string"}},
+		OutputFormats: []datasetapi.Format{datasetapi.FormatJSON},
+		Binder: func(datasetapi.Environment) (datasetapi.Runner, error) {
+			return func(context.Context, datasetapi.RunRequest) (datasetapi.RunResult, error) {
+				return datasetapi.RunResult{}, nil
 			}, nil
 		},
 	}
@@ -219,19 +220,18 @@ func TestWorkerProcessParameterFailure(t *testing.T) {
 }
 
 func TestWorkerProcessStoreFailure(t *testing.T) {
-	template := core.DatasetTemplate{
-		Plugin:        "frog",
+	template := datasetapi.Template{
 		Key:           "store",
 		Version:       "1.0.0",
 		Title:         "Store",
 		Description:   "store failure",
-		Dialect:       core.DatasetDialectSQL,
+		Dialect:       datasetapi.DialectSQL,
 		Query:         "SELECT 1",
-		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
-		OutputFormats: []core.DatasetFormat{core.FormatJSON, core.FormatCSV},
-		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
-			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
-				return core.DatasetRunResult{
+		Columns:       []datasetapi.Column{{Name: "value", Type: "string"}},
+		OutputFormats: []datasetapi.Format{datasetapi.FormatJSON, datasetapi.FormatCSV},
+		Binder: func(datasetapi.Environment) (datasetapi.Runner, error) {
+			return func(context.Context, datasetapi.RunRequest) (datasetapi.RunResult, error) {
+				return datasetapi.RunResult{
 					Rows: []map[string]any{{"value": "ok"}},
 				}, nil
 			}, nil
@@ -271,19 +271,18 @@ func TestWorkerProcessStoreFailure(t *testing.T) {
 }
 
 func TestWorkerProcessSuccessMultipleFormats(t *testing.T) {
-	template := core.DatasetTemplate{
-		Plugin:        "frog",
+	template := datasetapi.Template{
 		Key:           "success",
 		Version:       "1.0.0",
 		Title:         "Success",
 		Description:   "multi format",
-		Dialect:       core.DatasetDialectSQL,
+		Dialect:       datasetapi.DialectSQL,
 		Query:         "SELECT 1",
-		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
-		OutputFormats: []core.DatasetFormat{core.FormatJSON, core.FormatCSV, core.FormatHTML},
-		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
-			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
-				return core.DatasetRunResult{
+		Columns:       []datasetapi.Column{{Name: "value", Type: "string"}},
+		OutputFormats: []datasetapi.Format{datasetapi.FormatJSON, datasetapi.FormatCSV, datasetapi.FormatHTML},
+		Binder: func(datasetapi.Environment) (datasetapi.Runner, error) {
+			return func(context.Context, datasetapi.RunRequest) (datasetapi.RunResult, error) {
+				return datasetapi.RunResult{
 					Rows: []map[string]any{{"value": "ok"}},
 				}, nil
 			}, nil
@@ -434,19 +433,18 @@ func (s staticCatalog) ResolveDatasetTemplate(slug string) (core.DatasetTemplate
 }
 
 func TestWorkerEnqueueQueueFull(t *testing.T) {
-	templateDef := core.DatasetTemplate{
-		Plugin:        "frog",
+	templateDef := datasetapi.Template{
 		Key:           "queue",
 		Version:       "1.0.0",
 		Title:         "Queue",
 		Description:   "queue fill",
-		Dialect:       core.DatasetDialectSQL,
+		Dialect:       datasetapi.DialectSQL,
 		Query:         "SELECT 1",
-		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
-		OutputFormats: []core.DatasetFormat{core.FormatJSON, core.FormatCSV},
-		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
-			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
-				return core.DatasetRunResult{Rows: []map[string]any{{"value": "ok"}}}, nil
+		Columns:       []datasetapi.Column{{Name: "value", Type: "string"}},
+		OutputFormats: []datasetapi.Format{datasetapi.FormatJSON, datasetapi.FormatCSV},
+		Binder: func(datasetapi.Environment) (datasetapi.Runner, error) {
+			return func(context.Context, datasetapi.RunRequest) (datasetapi.RunResult, error) {
+				return datasetapi.RunResult{Rows: []map[string]any{{"value": "ok"}}}, nil
 			}, nil
 		},
 	}
@@ -472,19 +470,18 @@ func TestWorkerEnqueueQueueFull(t *testing.T) {
 }
 
 func TestWorkerProcessSuccessWithoutStore(t *testing.T) {
-	templateDef := core.DatasetTemplate{
-		Plugin:        "frog",
+	templateDef := datasetapi.Template{
 		Key:           "nostore",
 		Version:       "1.0.0",
 		Title:         "No Store",
 		Description:   "no object store",
-		Dialect:       core.DatasetDialectSQL,
+		Dialect:       datasetapi.DialectSQL,
 		Query:         "SELECT 1",
-		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
-		OutputFormats: []core.DatasetFormat{core.FormatJSON},
-		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
-			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
-				return core.DatasetRunResult{Rows: []map[string]any{{"value": "ok"}}}, nil
+		Columns:       []datasetapi.Column{{Name: "value", Type: "string"}},
+		OutputFormats: []datasetapi.Format{datasetapi.FormatJSON},
+		Binder: func(datasetapi.Environment) (datasetapi.Runner, error) {
+			return func(context.Context, datasetapi.RunRequest) (datasetapi.RunResult, error) {
+				return datasetapi.RunResult{Rows: []map[string]any{{"value": "ok"}}}, nil
 			}, nil
 		},
 	}
@@ -537,19 +534,18 @@ func (zeroStore) Delete(context.Context, string) (bool, error) { return false, n
 func (zeroStore) List(context.Context, string) ([]ExportArtifact, error) { return nil, nil }
 
 func TestWorkerProcessStoreNormalization(t *testing.T) {
-	templateDef := core.DatasetTemplate{
-		Plugin:        "frog",
+	templateDef := datasetapi.Template{
 		Key:           "normalize",
 		Version:       "1.0.0",
 		Title:         "Normalize",
 		Description:   "normalize stored artifacts",
-		Dialect:       core.DatasetDialectSQL,
+		Dialect:       datasetapi.DialectSQL,
 		Query:         "SELECT 1",
-		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
-		OutputFormats: []core.DatasetFormat{core.FormatJSON},
-		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
-			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
-				return core.DatasetRunResult{Rows: []map[string]any{{"value": "ok"}}}, nil
+		Columns:       []datasetapi.Column{{Name: "value", Type: "string"}},
+		OutputFormats: []datasetapi.Format{datasetapi.FormatJSON},
+		Binder: func(datasetapi.Environment) (datasetapi.Runner, error) {
+			return func(context.Context, datasetapi.RunRequest) (datasetapi.RunResult, error) {
+				return datasetapi.RunResult{Rows: []map[string]any{{"value": "ok"}}}, nil
 			}, nil
 		},
 	}
@@ -605,19 +601,18 @@ func TestWorkerEnqueueCatalogNil(t *testing.T) {
 }
 
 func TestWorkerEnqueueDeduplicatesFormats(t *testing.T) {
-	templateDef := core.DatasetTemplate{
-		Plugin:        "frog",
+	templateDef := datasetapi.Template{
 		Key:           "dedupe",
 		Version:       "1.0.0",
 		Title:         "Dedupe",
 		Description:   "dedupe formats",
-		Dialect:       core.DatasetDialectSQL,
+		Dialect:       datasetapi.DialectSQL,
 		Query:         "SELECT 1",
-		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
-		OutputFormats: []core.DatasetFormat{core.FormatJSON, core.FormatCSV},
-		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
-			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
-				return core.DatasetRunResult{Rows: []map[string]any{{"value": "ok"}}}, nil
+		Columns:       []datasetapi.Column{{Name: "value", Type: "string"}},
+		OutputFormats: []datasetapi.Format{datasetapi.FormatJSON, datasetapi.FormatCSV},
+		Binder: func(datasetapi.Environment) (datasetapi.Runner, error) {
+			return func(context.Context, datasetapi.RunRequest) (datasetapi.RunResult, error) {
+				return datasetapi.RunResult{Rows: []map[string]any{{"value": "ok"}}}, nil
 			}, nil
 		},
 	}
@@ -644,21 +639,20 @@ func TestWorkerEnqueueDeduplicatesFormats(t *testing.T) {
 func TestWorkerStopContextDeadline(t *testing.T) {
 	block := make(chan struct{})
 	started := make(chan struct{})
-	template := core.DatasetTemplate{
-		Plugin:        "frog",
+	template := datasetapi.Template{
 		Key:           "stop",
 		Version:       "1.0.0",
 		Title:         "Stop",
 		Description:   "blocking runner",
-		Dialect:       core.DatasetDialectSQL,
+		Dialect:       datasetapi.DialectSQL,
 		Query:         "SELECT 1",
-		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
-		OutputFormats: []core.DatasetFormat{core.FormatJSON},
-		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
-			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
+		Columns:       []datasetapi.Column{{Name: "value", Type: "string"}},
+		OutputFormats: []datasetapi.Format{datasetapi.FormatJSON},
+		Binder: func(datasetapi.Environment) (datasetapi.Runner, error) {
+			return func(context.Context, datasetapi.RunRequest) (datasetapi.RunResult, error) {
 				close(started)
 				<-block
-				return core.DatasetRunResult{Rows: []map[string]any{{"value": "ok"}}}, nil
+				return datasetapi.RunResult{Rows: []map[string]any{{"value": "ok"}}}, nil
 			}, nil
 		},
 	}

--- a/internal/dataset/handler_internal_test.go
+++ b/internal/dataset/handler_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"colonycore/internal/core"
+	"colonycore/pkg/datasetapi"
 )
 
 func TestHandleTemplateMissingSegments(t *testing.T) {
@@ -23,19 +24,18 @@ func TestHandleTemplateMissingSegments(t *testing.T) {
 }
 
 func TestHandleTemplateMethodNotAllowedInternal(t *testing.T) {
-	template := core.DatasetTemplate{
-		Plugin:        "frog",
+	template := datasetapi.Template{
 		Key:           "demo",
 		Version:       "1.0.0",
 		Title:         "Demo",
 		Description:   "demo",
-		Dialect:       core.DatasetDialectSQL,
+		Dialect:       datasetapi.DialectSQL,
 		Query:         "SELECT 1",
-		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
-		OutputFormats: []core.DatasetFormat{core.FormatJSON},
-		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
-			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
-				return core.DatasetRunResult{Rows: []map[string]any{{"value": "ok"}}}, nil
+		Columns:       []datasetapi.Column{{Name: "value", Type: "string"}},
+		OutputFormats: []datasetapi.Format{datasetapi.FormatJSON},
+		Binder: func(datasetapi.Environment) (datasetapi.Runner, error) {
+			return func(context.Context, datasetapi.RunRequest) (datasetapi.RunResult, error) {
+				return datasetapi.RunResult{Rows: []map[string]any{{"value": "ok"}}}, nil
 			}, nil
 		},
 	}
@@ -75,19 +75,18 @@ func TestHandleExportsInvalidPath(t *testing.T) {
 }
 
 func TestHandleRunRunnerError(t *testing.T) {
-	template := core.DatasetTemplate{
-		Plugin:        "frog",
+	template := datasetapi.Template{
 		Key:           "error",
 		Version:       "1.0.0",
 		Title:         "Error",
 		Description:   "demo",
-		Dialect:       core.DatasetDialectSQL,
+		Dialect:       datasetapi.DialectSQL,
 		Query:         "SELECT 1",
-		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
-		OutputFormats: []core.DatasetFormat{core.FormatJSON},
-		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
-			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
-				return core.DatasetRunResult{}, fmt.Errorf("failure")
+		Columns:       []datasetapi.Column{{Name: "value", Type: "string"}},
+		OutputFormats: []datasetapi.Format{datasetapi.FormatJSON},
+		Binder: func(datasetapi.Environment) (datasetapi.Runner, error) {
+			return func(context.Context, datasetapi.RunRequest) (datasetapi.RunResult, error) {
+				return datasetapi.RunResult{}, fmt.Errorf("failure")
 			}, nil
 		},
 	}
@@ -110,19 +109,18 @@ func TestHandleRunRunnerError(t *testing.T) {
 }
 
 func TestHandleExportCreateWithPluginFields(t *testing.T) {
-	template := core.DatasetTemplate{
-		Plugin:        "frog",
+	template := datasetapi.Template{
 		Key:           "create",
 		Version:       "1.0.0",
 		Title:         "Create",
 		Description:   "demo",
-		Dialect:       core.DatasetDialectSQL,
+		Dialect:       datasetapi.DialectSQL,
 		Query:         "SELECT 1",
-		Columns:       []core.DatasetColumn{{Name: "value", Type: "string"}},
-		OutputFormats: []core.DatasetFormat{core.FormatJSON},
-		Binder: func(core.DatasetEnvironment) (core.DatasetRunner, error) {
-			return func(context.Context, core.DatasetRunRequest) (core.DatasetRunResult, error) {
-				return core.DatasetRunResult{Rows: []map[string]any{{"value": "ok"}}}, nil
+		Columns:       []datasetapi.Column{{Name: "value", Type: "string"}},
+		OutputFormats: []datasetapi.Format{datasetapi.FormatJSON},
+		Binder: func(datasetapi.Environment) (datasetapi.Runner, error) {
+			return func(context.Context, datasetapi.RunRequest) (datasetapi.RunResult, error) {
+				return datasetapi.RunResult{Rows: []map[string]any{{"value": "ok"}}}, nil
 			}, nil
 		},
 	}

--- a/pkg/datasetapi/types.go
+++ b/pkg/datasetapi/types.go
@@ -1,0 +1,111 @@
+package datasetapi
+
+import (
+	"context"
+	"time"
+
+	"colonycore/pkg/domain"
+)
+
+type Dialect string
+
+const (
+	DialectSQL Dialect = "sql"
+	DialectDSL Dialect = "dsl"
+)
+
+type Format string
+
+const (
+	FormatJSON    Format = "json"
+	FormatCSV     Format = "csv"
+	FormatParquet Format = "parquet"
+	FormatPNG     Format = "png"
+	FormatHTML    Format = "html"
+)
+
+type Scope struct {
+	Requestor   string   `json:"requestor"`
+	Roles       []string `json:"roles,omitempty"`
+	ProjectIDs  []string `json:"project_ids,omitempty"`
+	ProtocolIDs []string `json:"protocol_ids,omitempty"`
+}
+
+type Parameter struct {
+	Name        string   `json:"name"`
+	Type        string   `json:"type"`
+	Required    bool     `json:"required"`
+	Description string   `json:"description,omitempty"`
+	Unit        string   `json:"unit,omitempty"`
+	Enum        []string `json:"enum,omitempty"`
+	Example     any      `json:"example,omitempty"`
+	Default     any      `json:"default,omitempty"`
+}
+
+type Column struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Unit        string `json:"unit,omitempty"`
+	Description string `json:"description,omitempty"`
+	Format      string `json:"format,omitempty"`
+}
+
+type Metadata struct {
+	Source          string            `json:"source,omitempty"`
+	Documentation   string            `json:"documentation,omitempty"`
+	RefreshInterval string            `json:"refresh_interval,omitempty"`
+	Tags            []string          `json:"tags,omitempty"`
+	Annotations     map[string]string `json:"annotations,omitempty"`
+}
+
+type Environment struct {
+	Store domain.PersistentStore
+	Now   func() time.Time
+}
+
+type Template struct {
+	Key           string
+	Version       string
+	Title         string
+	Description   string
+	Dialect       Dialect
+	Query         string
+	Parameters    []Parameter
+	Columns       []Column
+	Metadata      Metadata
+	OutputFormats []Format
+	Binder        Binder
+}
+
+type TemplateDescriptor struct {
+	Plugin        string      `json:"plugin"`
+	Key           string      `json:"key"`
+	Version       string      `json:"version"`
+	Title         string      `json:"title"`
+	Description   string      `json:"description"`
+	Dialect       Dialect     `json:"dialect"`
+	Query         string      `json:"query"`
+	Parameters    []Parameter `json:"parameters"`
+	Columns       []Column    `json:"columns"`
+	Metadata      Metadata    `json:"metadata"`
+	OutputFormats []Format    `json:"output_formats"`
+	Slug          string      `json:"slug"`
+}
+
+type RunRequest struct {
+	Template   TemplateDescriptor
+	Parameters map[string]any
+	Scope      Scope
+}
+
+type RunResult struct {
+	Schema      []Column         `json:"schema"`
+	Rows        []map[string]any `json:"rows"`
+	Metadata    map[string]any   `json:"metadata,omitempty"`
+	GeneratedAt time.Time        `json:"generated_at"`
+	Format      Format           `json:"format"`
+}
+
+type Runner func(context.Context, RunRequest) (RunResult, error)
+
+type Binder func(Environment) (Runner, error)

--- a/pkg/pluginapi/plugin.go
+++ b/pkg/pluginapi/plugin.go
@@ -1,0 +1,20 @@
+package pluginapi
+
+import (
+	"colonycore/pkg/datasetapi"
+	"colonycore/pkg/domain"
+)
+
+type Registry interface {
+	RegisterSchema(entity string, schema map[string]any)
+	RegisterRule(rule domain.Rule)
+	RegisterDatasetTemplate(template datasetapi.Template) error
+}
+
+type Plugin interface {
+	Name() string
+	Version() string
+	Register(Registry) error
+}
+
+const Version = "v1"


### PR DESCRIPTION
## What  
<!-- Describe the change. -->
Create new `pkg/pluginapi` & `pkg/datasetapi` packages for minimal, versionable interfaces and types for external plugins & dataset templates.
Ensured the frog plugin builds, referencing only `pkg/pluginapi` and `pkg/datasetapi`.

## Why  
<!-- What's the motivation. -->

Working on #43 

## How  
<!-- Bullet list or description of key changes. -->
* Added public plugin/dataset contracts
* Tell the core registry to accept new APIs by aliasing `Plugin` and translating incoming templates to core structs
* Refactored the frog reference plugin to consume only the new packages
* Updated service/catalog tests


## Notes  
<!-- Breaking changes or follow-ups (if any). -->

## Checklist  

- [x] I have used conventional commits (conventionalcommits.com)
- [ ] I have updated the documentation
- [ ] I have updated the relevant RFC and its linked resources
- [x] I have added tests
- [x] I ran manual tests