### PR TITLE
fix: Remove `time.now()` from codebase

### DIFF
--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -306,9 +306,6 @@ func (s *Service) InstallPlugin(plugin Plugin) (PluginMetadata, error) {
 	}
 
 	env := DatasetEnvironment{Store: s.store, Now: s.now}
-	if env.Now == nil {
-		env.Now = func() time.Time { return time.Now().UTC() }
-	}
 
 	for _, dataset := range registry.DatasetTemplates() {
 		dataset.Plugin = plugin.Name()


### PR DESCRIPTION
## What  
<!-- Describe the change. -->
Remove unused fallback `time.now()`.

## Why  
<!-- What's the motivation. -->
Part of refactor: #43 

## How  
<!-- Bullet list or description of key changes. -->
Removed remaining traces of `time.now()` from `service.go`.

## Notes  
<!-- Breaking changes or follow-ups (if any). -->

## Checklist  

- [x] I have used conventional commits (conventionalcommits.com)
- [ ] I have updated the documentation
- [ ] I have updated the relevant RFC and its linked resources
- [ ] I have added tests
- [x] I ran manual tests