### PR TITLE
feat(internal/adapters): Relocate dataset handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If the environment variable `COLONYCORE_STORAGE_DRIVER` is unset, the code will 
 - Species plugins register versioned dataset templates through the core plugin registry; see
   `internal/core/dataset.go` and the frog reference module (`plugins/frog`) for a working example aligned
   with RFC 0001's reporting guidance.
-- A background export worker (package `internal/dataset`) applies RBAC scope filters, emits audit entries,
+- A background export worker (package `internal/adapters/datasets`) applies RBAC scope filters, emits audit entries,
   stores signed artifacts in the managed object store, and serves export status via `/api/v1/datasets/exports`.
 - Sample analyst clients are provided in `clients/python/dataset_client.py` (requests-based) and
   `clients/R/dataset_client.R` (httr-based) to illustrate reproducing exports from external runtimes.

--- a/docs/adr/0008-object-storage-contract.md
+++ b/docs/adr/0008-object-storage-contract.md
@@ -4,7 +4,7 @@
 Accepted (proposed in v0.1 timeframe to unblock dataset export lifecycle and future plugin artifacts)
 
 ## Context
-Dataset exports (see `internal/dataset/exporter.go`) currently define an `ObjectStore` interface with only a `Put` method. This limits testability, observability, and future integration with real object storage backends (e.g., S3, GCS, MinIO) or on-prem content-addressable stores. Additionally, downstream needs have emerged:
+Dataset exports (see `internal/adapters/datasets/exporter.go`) currently define an `ObjectStore` interface with only a `Put` method. This limits testability, observability, and future integration with real object storage backends (e.g., S3, GCS, MinIO) or on-prem content-addressable stores. Additionally, downstream needs have emerged:
 
 - Retrieve artifact payloads or signed URLs after creation (UI & API consumption)
 - Enumerate artifacts for a given export, template, scope, or retention policy sweep
@@ -57,7 +57,7 @@ Key properties:
 3. Add a generic `Do(operation string, args ...any)` extension point. Rejected: opaque, weakly typed.
 
 ## Implications
-- `internal/dataset/exporter.go` will be updated to consume only `Put` for now, but downstream services can start using `Get`/`List` for additional API endpoints (future story: expose artifact download endpoint).
+- `internal/adapters/datasets/exporter.go` will be updated to consume only `Put` for now, but downstream services can start using `Get`/`List` for additional API endpoints (future story: expose artifact download endpoint).
 - `MemoryObjectStore` must store payload bytes internally to support `Get`.
 - A follow-up ADR will be needed for retention & lifecycle policies (time-to-live, size quotas, encryption, region replication).
 
@@ -81,5 +81,5 @@ Key properties:
 
 ## References
 - Existing snapshot persistence ADR: `0007-storage-baseline.md`
-- Dataset export worker: `internal/dataset/exporter.go`
+- Dataset export worker: `internal/adapters/datasets/exporter.go`
 - Inspired by simplified subsets of AWS S3, GCS, MinIO client patterns.

--- a/internal/adapters/datasets/exporter.go
+++ b/internal/adapters/datasets/exporter.go
@@ -1,4 +1,4 @@
-package dataset
+package datasets
 
 import (
 	"bytes"

--- a/internal/adapters/datasets/exporter_internal_test.go
+++ b/internal/adapters/datasets/exporter_internal_test.go
@@ -1,4 +1,4 @@
-package dataset
+package datasets
 
 import (
 	"context"

--- a/internal/adapters/datasets/exporter_materialize_test.go
+++ b/internal/adapters/datasets/exporter_materialize_test.go
@@ -1,4 +1,4 @@
-package dataset
+package datasets
 
 import (
 	"colonycore/internal/core"

--- a/internal/adapters/datasets/handler.go
+++ b/internal/adapters/datasets/handler.go
@@ -1,4 +1,4 @@
-package dataset
+package datasets
 
 import (
 	"encoding/csv"

--- a/internal/adapters/datasets/handler_internal_test.go
+++ b/internal/adapters/datasets/handler_internal_test.go
@@ -1,4 +1,4 @@
-package dataset
+package datasets
 
 import (
 	"bytes"

--- a/internal/adapters/datasets/objectstore_test.go
+++ b/internal/adapters/datasets/objectstore_test.go
@@ -1,4 +1,4 @@
-package dataset
+package datasets
 
 import (
 	"context"


### PR DESCRIPTION
## What  
<!-- Describe the change. -->
Relocate dataset exporter/handler logic `internal/adapters/datasets`.

## Why  
<!-- What's the motivation. -->
Working on #43 

## How  
<!-- Bullet list or description of key changes. -->
* Relocated the dataset export worker and HTTP handler into the adapters layer
* Relocated the dataset package to `datasets`
* Re-pointed adapter tests to the new import path and kept the in-memory helpers available for consumers
* Dropped the obsolete internal/dataset tree
* Confirmed all references use the new adapter location
* Updated documentation to reference the new dataset adapter path

## Notes  
<!-- Breaking changes or follow-ups (if any). -->

## Checklist  

- [x] I have used conventional commits (conventionalcommits.com)
- [x] I have updated the documentation
- [x] I have updated the relevant RFC and its linked resources
- [x] I have added tests
- [x] I ran manual tests