### PR TITLE
refactor: Remove core store aliases

### DIFF
--- a/internal/core/postgres_store.go
+++ b/internal/core/postgres_store.go
@@ -1,15 +1,16 @@
 package core
 
 import (
+	"colonycore/internal/infra/persistence/memory"
 	"fmt"
 )
 
 // PostgresStore placeholder – embeds an in-memory store so it satisfies the
 // PersistentStore interface while real implementation is pending.
-type PostgresStore struct{ *MemoryStore }
+type PostgresStore struct{ *memory.Store }
 
 // NewPostgresStore returns a placeholder backed by memory store plus a not-implemented error.
 func NewPostgresStore(dsn string, engine *RulesEngine) (*PostgresStore, error) {
-	ps := &PostgresStore{MemoryStore: NewMemoryStore(engine)}
+	ps := &PostgresStore{Store: NewMemoryStore(engine)}
 	return ps, fmt.Errorf("postgres driver not yet implemented")
 }

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"colonycore/pkg/pluginapi"
 	"context"
 	"fmt"
 	"sort"
@@ -276,7 +277,7 @@ func (e ErrNotFound) Error() string {
 }
 
 // InstallPlugin registers a plugin, wiring its rules into the active engine.
-func (s *Service) InstallPlugin(plugin Plugin) (PluginMetadata, error) {
+func (s *Service) InstallPlugin(plugin pluginapi.Plugin) (PluginMetadata, error) {
 	if plugin == nil {
 		return PluginMetadata{}, fmt.Errorf("plugin cannot be nil")
 	}

--- a/internal/core/sqlite_store.go
+++ b/internal/core/sqlite_store.go
@@ -2,8 +2,6 @@ package core
 
 import "colonycore/internal/persistence/sqlite"
 
-type SQLiteStore = sqlite.SQLiteStore
-
-func NewSQLiteStore(path string, engine *RulesEngine) (*SQLiteStore, error) {
+func NewSQLiteStore(path string, engine *RulesEngine) (*sqlite.SQLiteStore, error) {
 	return sqlite.NewSQLiteStore(path, engine)
 }

--- a/internal/core/storage.go
+++ b/internal/core/storage.go
@@ -1,12 +1,11 @@
 package core
 
 import (
-	"fmt"
-	"os"
-
 	"colonycore/internal/infra/persistence/memory"
 	"colonycore/internal/persistence/sqlite"
 	"colonycore/pkg/domain"
+	"fmt"
+	"os"
 )
 
 // StorageDriver identifies a concrete persistent storage implementation.

--- a/internal/core/store.go
+++ b/internal/core/store.go
@@ -2,9 +2,7 @@ package core
 
 import "colonycore/internal/infra/persistence/memory"
 
-type MemoryStore = memory.Store
-
 // NewMemoryStore constructs an in-memory store backed by the provided rules engine.
-func NewMemoryStore(engine *RulesEngine) *MemoryStore {
+func NewMemoryStore(engine *RulesEngine) *memory.Store {
 	return memory.NewStore(engine)
 }

--- a/internal/infra/blob/fs/store.go
+++ b/internal/infra/blob/fs/store.go
@@ -1,6 +1,7 @@
 package fs
 
 import (
+	"colonycore/internal/blob/core"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -15,8 +16,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-
-	"colonycore/internal/blob/core"
 )
 
 // Store implements core.Store using the local filesystem.
@@ -66,7 +65,7 @@ func (s *Store) pathFor(key string) (dataPath, metaPath string, err error) {
 	}
 	dataPath = filepath.Join(s.root, k)
 	metaPath = dataPath + ".meta"
-	return
+	return dataPath, metaPath, err
 }
 
 type metaFile struct {

--- a/internal/infra/blob/fs/store_test.go
+++ b/internal/infra/blob/fs/store_test.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"bytes"
+	"colonycore/internal/blob/core"
 	"context"
 	"errors"
 	"io"
@@ -9,8 +10,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
-
-	"colonycore/internal/blob/core"
 )
 
 func newTempStore(t *testing.T) *Store {

--- a/internal/infra/blob/memory/store.go
+++ b/internal/infra/blob/memory/store.go
@@ -2,14 +2,13 @@ package memory
 
 import (
 	"bytes"
+	"colonycore/internal/blob/core"
 	"context"
 	"fmt"
 	"io"
 	"sort"
 	"sync"
 	"time"
-
-	"colonycore/internal/blob/core"
 )
 
 type blobEntry struct {

--- a/internal/infra/blob/memory/store_test.go
+++ b/internal/infra/blob/memory/store_test.go
@@ -2,11 +2,10 @@ package memory
 
 import (
 	"bytes"
+	"colonycore/internal/blob/core"
 	"context"
 	"fmt"
 	"testing"
-
-	"colonycore/internal/blob/core"
 )
 
 func TestStore_MissingHeadGet(t *testing.T) {

--- a/internal/infra/blob/s3/store.go
+++ b/internal/infra/blob/s3/store.go
@@ -1,6 +1,7 @@
 package s3
 
 import (
+	"colonycore/internal/blob/core"
 	"context"
 	"fmt"
 	"io"
@@ -13,8 +14,6 @@ import (
 	aws "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-
-	"colonycore/internal/blob/core"
 )
 
 // Store implements core.Store using an S3-compatible backend (AWS S3 or MinIO).

--- a/internal/infra/persistence/memory/store.go
+++ b/internal/infra/persistence/memory/store.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"colonycore/pkg/domain"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -8,8 +9,6 @@ import (
 	"fmt"
 	"sync"
 	"time"
-
-	"colonycore/pkg/domain"
 )
 
 type (
@@ -182,6 +181,7 @@ func cloneBreeding(b BreedingUnit) BreedingUnit {
 	cp.MaleIDs = append([]string(nil), b.MaleIDs...)
 	return cp
 }
+
 func cloneProcedure(p Procedure) Procedure {
 	cp := p
 	cp.OrganismIDs = append([]string(nil), p.OrganismIDs...)

--- a/internal/infra/persistence/memory/store_crud_test.go
+++ b/internal/infra/persistence/memory/store_crud_test.go
@@ -1,13 +1,12 @@
 package memory_test
 
 import (
+	"colonycore/internal/infra/persistence/memory"
+	"colonycore/pkg/domain"
 	"context"
 	"fmt"
 	"testing"
 	"time"
-
-	"colonycore/internal/infra/persistence/memory"
-	"colonycore/pkg/domain"
 )
 
 func TestMemoryStoreCRUDAndQueries(t *testing.T) {

--- a/internal/infra/persistence/memory/store_test.go
+++ b/internal/infra/persistence/memory/store_test.go
@@ -1,11 +1,10 @@
 package memory
 
 import (
+	"colonycore/pkg/domain"
 	"context"
 	"fmt"
 	"testing"
-
-	"colonycore/pkg/domain"
 )
 
 func TestStoreRunInTransactionAndSnapshots(t *testing.T) {

--- a/internal/integration/smoke_test.go
+++ b/internal/integration/smoke_test.go
@@ -2,12 +2,12 @@ package integration
 
 import (
 	"bytes"
+	"colonycore/internal/blob"
 	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"colonycore/internal/blob"
 	core "colonycore/internal/core"
 	domain "colonycore/pkg/domain"
 )

--- a/internal/persistence/sqlite/memstore.go
+++ b/internal/persistence/sqlite/memstore.go
@@ -1,6 +1,7 @@
 package sqlite
 
 import (
+	"colonycore/pkg/domain"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -8,8 +9,6 @@ import (
 	"fmt"
 	"sync"
 	"time"
-
-	"colonycore/pkg/domain"
 )
 
 type (
@@ -182,6 +181,7 @@ func cloneBreeding(b BreedingUnit) BreedingUnit {
 	cp.MaleIDs = append([]string(nil), b.MaleIDs...)
 	return cp
 }
+
 func cloneProcedure(p Procedure) Procedure {
 	cp := p
 	cp.OrganismIDs = append([]string(nil), p.OrganismIDs...)

--- a/internal/persistence/sqlite/memstore_test.go
+++ b/internal/persistence/sqlite/memstore_test.go
@@ -1,12 +1,11 @@
 package sqlite
 
 import (
+	"colonycore/pkg/domain"
 	"context"
 	"fmt"
 	"testing"
 	"time"
-
-	"colonycore/pkg/domain"
 )
 
 func TestMemStoreRunInTransactionAndSnapshots(t *testing.T) {

--- a/internal/persistence/sqlite/store.go
+++ b/internal/persistence/sqlite/store.go
@@ -6,10 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	_ "modernc.org/sqlite" // pure go sqlite driver
 	"os"
 	"path/filepath"
 	"sync"
+
+	_ "modernc.org/sqlite" // pure go sqlite driver
 )
 
 // SQLiteStore persists the in-memory state to a single SQLite table as JSON blobs.

--- a/internal/persistence/sqlite/store_test.go
+++ b/internal/persistence/sqlite/store_test.go
@@ -1,14 +1,13 @@
 package sqlite
 
 import (
+	"colonycore/pkg/domain"
 	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
-
-	"colonycore/pkg/domain"
 )
 
 func TestSQLiteStorePersistAndReload(t *testing.T) {

--- a/pkg/datasetapi/types.go
+++ b/pkg/datasetapi/types.go
@@ -1,10 +1,9 @@
 package datasetapi
 
 import (
+	"colonycore/pkg/domain"
 	"context"
 	"time"
-
-	"colonycore/pkg/domain"
 )
 
 type Dialect string

--- a/plugins/frog/plugin.go
+++ b/plugins/frog/plugin.go
@@ -1,14 +1,14 @@
 package frog
 
 import (
+	"colonycore/pkg/datasetapi"
+	"colonycore/pkg/pluginapi"
 	"context"
 	"fmt"
 	"strings"
 	"time"
 
-	"colonycore/pkg/datasetapi"
 	domain "colonycore/pkg/domain"
-	"colonycore/pkg/pluginapi"
 )
 
 // Plugin implements the frog reference module described in the RFC (stubbed for the PoC).

--- a/plugins/frog/plugin_test.go
+++ b/plugins/frog/plugin_test.go
@@ -1,11 +1,11 @@
 package frog
 
 import (
+	"colonycore/internal/core"
 	"context"
 	"testing"
 	"time"
 
-	"colonycore/internal/core"
 	domain "colonycore/pkg/domain"
 )
 


### PR DESCRIPTION
## What  
<!-- Describe the change. -->
Removed Type aliases in core

## Why  
<!-- What's the motivation. -->

Working on: #43 

## How  
<!-- Bullet list or description of key changes. -->
* return concrete `*memory.Store` and `*sqlite.SQLiteStore` from core constructors
* update plugin install flow and tests to use `pluginapi` interfaces and `errors.As`
* switch S3 mocks to `net/http` status constants and tidy gofmt import ordering

## Notes  
<!-- Breaking changes or follow-ups (if any). -->

## Checklist  

- [x] I have used conventional commits (conventionalcommits.com)
- [ ] I have updated the documentation
- [ ] I have updated the relevant RFC and its linked resources
- [x] I have added tests
- [x] I ran manual tests