### PR TITLE
Extend missing entities and structs

### DIFF
--- a/internal/ci/datasetapi.snapshot
+++ b/internal/ci/datasetapi.snapshot
@@ -44,7 +44,7 @@ TYPE Format (string)
 TYPE FormatProvider interface { CSV() colonycore/pkg/datasetapi.Format HTML() colonycore/pkg/datasetapi.Format JSON() colonycore/pkg/datasetapi.Format PNG() colonycore/pkg/datasetapi.Format Parquet() colonycore/pkg/datasetapi.Format }
 TYPE HostTemplate struct { unexported }
 TYPE HousingContext interface { Aquatic() colonycore/pkg/datasetapi.EnvironmentTypeRef Arboreal() colonycore/pkg/datasetapi.EnvironmentTypeRef Humid() colonycore/pkg/datasetapi.EnvironmentTypeRef Terrestrial() colonycore/pkg/datasetapi.EnvironmentTypeRef }
-TYPE HousingUnit interface { Capacity() int CreatedAt() time.Time Environment() string Facility() string GetEnvironmentType() colonycore/pkg/datasetapi.EnvironmentTypeRef ID() string IsAquaticEnvironment() bool IsHumidEnvironment() bool Name() string SupportsSpecies(string) bool UpdatedAt() time.Time }
+TYPE HousingUnit interface { Capacity() int CreatedAt() time.Time Environment() string FacilityID() string GetEnvironmentType() colonycore/pkg/datasetapi.EnvironmentTypeRef ID() string IsAquaticEnvironment() bool IsHumidEnvironment() bool Name() string SupportsSpecies(string) bool UpdatedAt() time.Time }
 TYPE HousingUnitData struct { unexported }
 TYPE LifecycleStage (string)
 TYPE LifecycleStageContext interface { Adult() colonycore/pkg/datasetapi.LifecycleStageRef Deceased() colonycore/pkg/datasetapi.LifecycleStageRef Juvenile() colonycore/pkg/datasetapi.LifecycleStageRef Larva() colonycore/pkg/datasetapi.LifecycleStageRef Planned() colonycore/pkg/datasetapi.LifecycleStageRef Retired() colonycore/pkg/datasetapi.LifecycleStageRef }

--- a/internal/ci/pluginapi.snapshot
+++ b/internal/ci/pluginapi.snapshot
@@ -30,7 +30,7 @@ TYPE EntityType (string)
 TYPE EntityTypeRef interface { Equals(colonycore/pkg/pluginapi.EntityTypeRef) bool IsCore() bool String() string Value() colonycore/pkg/pluginapi.EntityType }
 TYPE EnvironmentTypeRef interface { Equals(colonycore/pkg/pluginapi.EnvironmentTypeRef) bool IsAquatic() bool IsHumid() bool String() string }
 TYPE HousingContext interface { Aquatic() colonycore/pkg/pluginapi.EnvironmentTypeRef Arboreal() colonycore/pkg/pluginapi.EnvironmentTypeRef Humid() colonycore/pkg/pluginapi.EnvironmentTypeRef Terrestrial() colonycore/pkg/pluginapi.EnvironmentTypeRef }
-TYPE HousingUnitView interface { Capacity() int CreatedAt() time.Time Environment() string Facility() string GetEnvironmentType() colonycore/pkg/pluginapi.EnvironmentTypeRef ID() string IsAquaticEnvironment() bool IsHumidEnvironment() bool Name() string SupportsSpecies(string) bool UpdatedAt() time.Time }
+TYPE HousingUnitView interface { Capacity() int CreatedAt() time.Time Environment() string FacilityID() string GetEnvironmentType() colonycore/pkg/pluginapi.EnvironmentTypeRef ID() string IsAquaticEnvironment() bool IsHumidEnvironment() bool Name() string SupportsSpecies(string) bool UpdatedAt() time.Time }
 TYPE LifecycleStage (string)
 TYPE LifecycleStageContext interface { Adult() colonycore/pkg/pluginapi.LifecycleStageRef Deceased() colonycore/pkg/pluginapi.LifecycleStageRef Juvenile() colonycore/pkg/pluginapi.LifecycleStageRef Larva() colonycore/pkg/pluginapi.LifecycleStageRef Planned() colonycore/pkg/pluginapi.LifecycleStageRef Retired() colonycore/pkg/pluginapi.LifecycleStageRef }
 TYPE LifecycleStageRef interface { Equals(colonycore/pkg/pluginapi.LifecycleStageRef) bool IsActive() bool String() string Value() colonycore/pkg/pluginapi.LifecycleStage }

--- a/internal/core/dataset_facade_mapper.go
+++ b/internal/core/dataset_facade_mapper.go
@@ -43,7 +43,7 @@ func facadeHousingUnitFromDomain(unit domain.HousingUnit) datasetapi.HousingUnit
 	return datasetapi.NewHousingUnit(datasetapi.HousingUnitData{
 		Base:        baseDataFromDomain(unit.Base),
 		Name:        unit.Name,
-		Facility:    unit.Facility,
+		FacilityID:  unit.FacilityID,
 		Capacity:    unit.Capacity,
 		Environment: unit.Environment,
 	})

--- a/internal/core/dataset_facade_mapper_test.go
+++ b/internal/core/dataset_facade_mapper_test.go
@@ -71,7 +71,7 @@ func TestFacadeOrganismFromDomainCopiesData(t *testing.T) {
 func TestFacadeCollectionsCloneSlices(t *testing.T) {
 	now := time.Now()
 	cohortID := testCohortID
-	housing := domain.HousingUnit{Base: domain.Base{ID: "H"}, Name: "Hab", Facility: "F", Capacity: 3, Environment: "wet"}
+	housing := domain.HousingUnit{Base: domain.Base{ID: "H"}, Name: "Hab", FacilityID: "F", Capacity: 3, Environment: "wet"}
 	protocol := domain.Protocol{Base: domain.Base{ID: "P"}, Code: "C", Title: "T", Description: "D", MaxSubjects: 5}
 	project := domain.Project{Base: domain.Base{ID: "PR"}, Code: "CC", Title: "Title", Description: "Desc"}
 	cohort := domain.Cohort{Base: domain.Base{ID: "C"}, Name: "Group", Purpose: "Study", ProjectID: &cohortID, HousingID: &cohortID, ProtocolID: &cohortID}

--- a/internal/core/plugin_rule_adapter.go
+++ b/internal/core/plugin_rule_adapter.go
@@ -179,7 +179,7 @@ func (o organismView) IsDeceased() bool {
 type housingUnitView struct {
 	baseView
 	name        string
-	facility    string
+	facilityID  string
 	capacity    int
 	environment string
 }
@@ -188,14 +188,14 @@ func newHousingUnitView(unit domain.HousingUnit) housingUnitView {
 	return housingUnitView{
 		baseView:    newBaseView(unit.Base),
 		name:        unit.Name,
-		facility:    unit.Facility,
+		facilityID:  unit.FacilityID,
 		capacity:    unit.Capacity,
 		environment: unit.Environment,
 	}
 }
 
 func (h housingUnitView) Name() string        { return h.name }
-func (h housingUnitView) Facility() string    { return h.facility }
+func (h housingUnitView) FacilityID() string  { return h.facilityID }
 func (h housingUnitView) Capacity() int       { return h.capacity }
 func (h housingUnitView) Environment() string { return h.environment }
 

--- a/internal/core/plugin_rule_adapter_test.go
+++ b/internal/core/plugin_rule_adapter_test.go
@@ -210,7 +210,7 @@ func TestHousingAndProtocolViews(t *testing.T) {
 	domainUnit := domain.HousingUnit{
 		Base:        domain.Base{ID: "HU", CreatedAt: createdAt, UpdatedAt: updatedAt},
 		Name:        "Tank",
-		Facility:    "North",
+		FacilityID:  "North",
 		Capacity:    12,
 		Environment: "humid",
 	}
@@ -221,8 +221,8 @@ func TestHousingAndProtocolViews(t *testing.T) {
 	if got := unitView.Environment(); got != domainUnit.Environment {
 		t.Fatalf("unexpected housing environment: %s", got)
 	}
-	if unitView.Facility() != domainUnit.Facility || unitView.Capacity() != domainUnit.Capacity {
-		t.Fatalf("unexpected housing facility/capacity: %s %d", unitView.Facility(), unitView.Capacity())
+	if unitView.FacilityID() != domainUnit.FacilityID || unitView.Capacity() != domainUnit.Capacity {
+		t.Fatalf("unexpected housing facility/capacity: %s %d", unitView.FacilityID(), unitView.Capacity())
 	}
 
 	domainProtocol := domain.Protocol{
@@ -306,7 +306,7 @@ func TestHousingUnitViewContextualAccessors(t *testing.T) {
 			UpdatedAt: time.Now(),
 		},
 		Name:        "Test Tank",
-		Facility:    "Lab A",
+		FacilityID:  "Lab A",
 		Capacity:    10,
 		Environment: "aquatic",
 	}

--- a/internal/core/service_test.go
+++ b/internal/core/service_test.go
@@ -19,7 +19,7 @@ func TestHousingCapacityRuleBlocksOverCapacity(t *testing.T) {
 	svc := core.NewInMemoryService(core.NewDefaultRulesEngine())
 	ctx := context.Background()
 
-	housing, res, err := svc.CreateHousingUnit(ctx, domain.HousingUnit{Name: "Tank A", Facility: "Greenhouse", Capacity: 1})
+	housing, res, err := svc.CreateHousingUnit(ctx, domain.HousingUnit{Name: "Tank A", FacilityID: "Greenhouse", Capacity: 1})
 	if err != nil {
 		t.Fatalf("create housing: %v", err)
 	}
@@ -140,7 +140,7 @@ func TestFrogPluginRegistersSchemasAndRules(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	housing, _, err := svc.CreateHousingUnit(ctx, domain.HousingUnit{Name: "Dry Terrarium", Facility: "Lab", Capacity: 2, Environment: "arid"})
+	housing, _, err := svc.CreateHousingUnit(ctx, domain.HousingUnit{Name: "Dry Terrarium", FacilityID: "Lab", Capacity: 2, Environment: "arid"})
 	if err != nil {
 		t.Fatalf("create housing: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestServiceExtendedCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create protocol: %v", err)
 	}
-	housing, _, err := svc.CreateHousingUnit(ctx, domain.HousingUnit{Name: "Humid", Facility: "Lab", Capacity: 4, Environment: "humid"})
+	housing, _, err := svc.CreateHousingUnit(ctx, domain.HousingUnit{Name: "Humid", FacilityID: "Lab", Capacity: 4, Environment: "humid"})
 	if err != nil {
 		t.Fatalf("create housing: %v", err)
 	}

--- a/internal/core/store_crud_test.go
+++ b/internal/core/store_crud_test.go
@@ -25,7 +25,7 @@ func TestMemoryStoreCRUDAndQueries(t *testing.T) {
 	)
 
 	if _, err := store.RunInTransaction(ctx, func(tx domain.Transaction) error {
-		if _, err := tx.CreateHousingUnit(domain.HousingUnit{Name: "Invalid", Facility: "Lab", Capacity: 0}); err == nil {
+		if _, err := tx.CreateHousingUnit(domain.HousingUnit{Name: "Invalid", FacilityID: "Lab", Capacity: 0}); err == nil {
 			return fmt.Errorf("expected capacity validation error")
 		}
 
@@ -41,7 +41,7 @@ func TestMemoryStoreCRUDAndQueries(t *testing.T) {
 		}
 		protocolID = protocol.ID
 
-		housing, err := tx.CreateHousingUnit(domain.HousingUnit{Name: "Tank", Facility: "Lab", Capacity: 2, Environment: "arid"})
+		housing, err := tx.CreateHousingUnit(domain.HousingUnit{Name: "Tank", FacilityID: "Lab", Capacity: 2, Environment: "arid"})
 		if err != nil {
 			return err
 		}
@@ -294,7 +294,7 @@ func TestMemoryStoreViewReadOnly(t *testing.T) {
 	var housing domain.HousingUnit
 	if _, err := store.RunInTransaction(ctx, func(tx domain.Transaction) error {
 		var err error
-		housing, err = tx.CreateHousingUnit(domain.HousingUnit{Name: "Tank", Facility: "Lab", Capacity: 1})
+		housing, err = tx.CreateHousingUnit(domain.HousingUnit{Name: "Tank", FacilityID: "Lab", Capacity: 1})
 		return err
 	}); err != nil {
 		t.Fatalf("create housing: %v", err)
@@ -320,7 +320,7 @@ func TestUpdateHousingUnitValidation(t *testing.T) {
 	var housing domain.HousingUnit
 	if _, err := store.RunInTransaction(ctx, func(tx domain.Transaction) error {
 		var err error
-		housing, err = tx.CreateHousingUnit(domain.HousingUnit{Name: "Validated", Facility: "Lab", Capacity: 2})
+		housing, err = tx.CreateHousingUnit(domain.HousingUnit{Name: "Validated", FacilityID: "Lab", Capacity: 2})
 		return err
 	}); err != nil {
 		t.Fatalf("create housing: %v", err)

--- a/internal/infra/persistence/memory/state_additional_test.go
+++ b/internal/infra/persistence/memory/state_additional_test.go
@@ -20,7 +20,7 @@ func TestSnapshotAllEntities(t *testing.T) {
 			return err
 		}
 		// Create housing
-		h, err := tx.CreateHousingUnit(domain.HousingUnit{Name: "H1", Facility: "Lab", Capacity: 2})
+		h, err := tx.CreateHousingUnit(domain.HousingUnit{Name: "H1", FacilityID: "Lab", Capacity: 2})
 		if err != nil {
 			return err
 		}

--- a/internal/infra/persistence/memory/store_crud_test.go
+++ b/internal/infra/persistence/memory/store_crud_test.go
@@ -25,7 +25,7 @@ func TestMemoryStoreCRUDAndQueries(t *testing.T) {
 	)
 
 	if _, err := store.RunInTransaction(ctx, func(tx domain.Transaction) error {
-		if _, err := tx.CreateHousingUnit(domain.HousingUnit{Name: "Invalid", Facility: "Lab", Capacity: 0}); err == nil {
+		if _, err := tx.CreateHousingUnit(domain.HousingUnit{Name: "Invalid", FacilityID: "Lab", Capacity: 0}); err == nil {
 			return fmt.Errorf("expected capacity validation error")
 		}
 
@@ -47,7 +47,7 @@ func TestMemoryStoreCRUDAndQueries(t *testing.T) {
 			return fmt.Errorf("unexpected protocol lookup success")
 		}
 
-		housing, err := tx.CreateHousingUnit(domain.HousingUnit{Name: "Tank", Facility: "Lab", Capacity: 2, Environment: "arid"})
+		housing, err := tx.CreateHousingUnit(domain.HousingUnit{Name: "Tank", FacilityID: "Lab", Capacity: 2, Environment: "arid"})
 		if err != nil {
 			return err
 		}
@@ -300,7 +300,7 @@ func TestMemoryStoreViewReadOnly(t *testing.T) {
 	var housing domain.HousingUnit
 	if _, err := store.RunInTransaction(ctx, func(tx domain.Transaction) error {
 		var err error
-		housing, err = tx.CreateHousingUnit(domain.HousingUnit{Name: "Tank", Facility: "Lab", Capacity: 1})
+		housing, err = tx.CreateHousingUnit(domain.HousingUnit{Name: "Tank", FacilityID: "Lab", Capacity: 1})
 		return err
 	}); err != nil {
 		t.Fatalf("create housing: %v", err)
@@ -326,7 +326,7 @@ func TestUpdateHousingUnitValidation(t *testing.T) {
 	var housing domain.HousingUnit
 	if _, err := store.RunInTransaction(ctx, func(tx domain.Transaction) error {
 		var err error
-		housing, err = tx.CreateHousingUnit(domain.HousingUnit{Name: "Validated", Facility: "Lab", Capacity: 2})
+		housing, err = tx.CreateHousingUnit(domain.HousingUnit{Name: "Validated", FacilityID: "Lab", Capacity: 2})
 		return err
 	}); err != nil {
 		t.Fatalf("create housing: %v", err)

--- a/internal/infra/persistence/sqlite/memstore_full_test.go
+++ b/internal/infra/persistence/sqlite/memstore_full_test.go
@@ -39,7 +39,7 @@ func TestMemStore_FullCRUDAndErrors(t *testing.T) {
 		orgA, orgB = o1, o2
 		c, _ := tx.CreateCohort(domain.Cohort{Name: "C1", Purpose: "testing"})
 		cohort = c
-		h, _ := tx.CreateHousingUnit(domain.HousingUnit{Name: "H1", Capacity: 2, Environment: "dry", Facility: "F"})
+		h, _ := tx.CreateHousingUnit(domain.HousingUnit{Name: "H1", Capacity: 2, Environment: "dry", FacilityID: "F"})
 		housing = h
 		b, _ := tx.CreateBreedingUnit(domain.BreedingUnit{Name: "B1", FemaleIDs: []string{o1.ID}, MaleIDs: []string{o2.ID}})
 		breeding = b
@@ -224,7 +224,7 @@ func TestMemStore_TransactionViewFinds(t *testing.T) {
 	var housing domain.HousingUnit
 	var protocol domain.Protocol
 	runTx(t, store, func(tx domain.Transaction) error {
-		h, err := tx.CreateHousingUnit(domain.HousingUnit{Name: "T-H", Capacity: 1, Environment: "e", Facility: "F"})
+		h, err := tx.CreateHousingUnit(domain.HousingUnit{Name: "T-H", Capacity: 1, Environment: "e", FacilityID: "F"})
 		if err != nil {
 			return err
 		}

--- a/internal/integration/smoke_test.go
+++ b/internal/integration/smoke_test.go
@@ -75,7 +75,7 @@ func TestIntegrationSmoke(t *testing.T) {
 			store := cv.open(t)
 			svc := core.NewService(store)
 			// Write one housing unit and one organism referencing it.
-			created, res, err := svc.CreateHousingUnit(ctx, domain.HousingUnit{Name: "Tank", Facility: "Lab", Capacity: 1})
+			created, res, err := svc.CreateHousingUnit(ctx, domain.HousingUnit{Name: "Tank", FacilityID: "Lab", Capacity: 1})
 			if err != nil {
 				t.Fatalf("create housing: %v", err)
 			}

--- a/pkg/datasetapi/facade.go
+++ b/pkg/datasetapi/facade.go
@@ -89,7 +89,7 @@ type CohortData struct {
 type HousingUnitData struct {
 	Base        BaseData
 	Name        string
-	Facility    string
+	FacilityID  string
 	Capacity    int
 	Environment string
 }
@@ -179,7 +179,7 @@ type HousingUnit interface {
 	CreatedAt() time.Time
 	UpdatedAt() time.Time
 	Name() string
-	Facility() string
+	FacilityID() string
 	Capacity() int
 	Environment() string
 
@@ -475,7 +475,7 @@ func (c cohort) MarshalJSON() ([]byte, error) {
 type housingUnit struct {
 	base
 	name        string
-	facility    string
+	facilityID  string
 	capacity    int
 	environment string
 }
@@ -485,14 +485,14 @@ func NewHousingUnit(data HousingUnitData) HousingUnit {
 	return housingUnit{
 		base:        newBase(data.Base),
 		name:        data.Name,
-		facility:    data.Facility,
+		facilityID:  data.FacilityID,
 		capacity:    data.Capacity,
 		environment: data.Environment,
 	}
 }
 
 func (h housingUnit) Name() string        { return h.name }
-func (h housingUnit) Facility() string    { return h.facility }
+func (h housingUnit) FacilityID() string  { return h.facilityID }
 func (h housingUnit) Capacity() int       { return h.capacity }
 func (h housingUnit) Environment() string { return h.environment }
 
@@ -545,7 +545,7 @@ func (h housingUnit) MarshalJSON() ([]byte, error) {
 		CreatedAt   time.Time `json:"created_at"`
 		UpdatedAt   time.Time `json:"updated_at"`
 		Name        string    `json:"name"`
-		Facility    string    `json:"facility"`
+		FacilityID  string    `json:"facility_id"`
 		Capacity    int       `json:"capacity"`
 		Environment string    `json:"environment"`
 	}
@@ -554,7 +554,7 @@ func (h housingUnit) MarshalJSON() ([]byte, error) {
 		CreatedAt:   h.CreatedAt(),
 		UpdatedAt:   h.UpdatedAt(),
 		Name:        h.name,
-		Facility:    h.facility,
+		FacilityID:  h.facilityID,
 		Capacity:    h.capacity,
 		Environment: h.environment,
 	})

--- a/pkg/datasetapi/facade_contextual_test.go
+++ b/pkg/datasetapi/facade_contextual_test.go
@@ -160,18 +160,18 @@ func TestHousingUnitContextualAccessors(t *testing.T) {
 		}
 	})
 
-	t.Run("Name and Facility accessors work", func(t *testing.T) {
+	t.Run("Name and FacilityID accessors work", func(t *testing.T) {
 		housing := NewHousingUnit(HousingUnitData{
-			Base:     BaseData{ID: "housing1"},
-			Name:     "Test Tank",
-			Facility: "Lab A",
+			Base:       BaseData{ID: "housing1"},
+			Name:       "Test Tank",
+			FacilityID: "Lab A",
 		})
 
 		if housing.Name() != "Test Tank" {
 			t.Errorf("Expected name 'Test Tank', got '%s'", housing.Name())
 		}
-		if housing.Facility() != "Lab A" {
-			t.Errorf("Expected facility 'Lab A', got '%s'", housing.Facility())
+		if housing.FacilityID() != "Lab A" {
+			t.Errorf("Expected facility ID 'Lab A', got '%s'", housing.FacilityID())
 		}
 	})
 }

--- a/pkg/datasetapi/facade_test.go
+++ b/pkg/datasetapi/facade_test.go
@@ -207,7 +207,7 @@ func TestProtocolProjectCohortFacades(t *testing.T) {
 	housing := NewHousingUnit(HousingUnitData{
 		Base:        BaseData{ID: "housing", CreatedAt: now},
 		Name:        "Habitat",
-		Facility:    "Facility",
+		FacilityID:  "Facility",
 		Capacity:    3,
 		Environment: "humid",
 	})

--- a/pkg/domain/entities.go
+++ b/pkg/domain/entities.go
@@ -99,7 +99,7 @@ type Cohort struct {
 type HousingUnit struct {
 	Base
 	Name        string `json:"name"`
-	Facility    string `json:"facility"`
+	FacilityID  string `json:"facility_id"`
 	Capacity    int    `json:"capacity"`
 	Environment string `json:"environment"`
 }
@@ -111,6 +111,7 @@ type Facility struct {
 	Zone                 string         `json:"zone"`
 	AccessPolicy         string         `json:"access_policy"`
 	EnvironmentBaselines map[string]any `json:"environment_baselines"`
+	HousingUnitIDs       []string       `json:"housing_unit_ids"`
 	ProjectIDs           []string       `json:"project_ids"`
 }
 
@@ -210,9 +211,10 @@ type Permit struct {
 // Project captures cost center allocations.
 type Project struct {
 	Base
-	Code        string `json:"code"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
+	Code        string   `json:"code"`
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	FacilityIDs []string `json:"facility_ids"`
 }
 
 // SupplyItem models inventory resources consumed by projects or facilities.

--- a/pkg/pluginapi/views.go
+++ b/pkg/pluginapi/views.go
@@ -33,7 +33,7 @@ type OrganismView interface {
 type HousingUnitView interface {
 	BaseView
 	Name() string
-	Facility() string
+	FacilityID() string
 	Capacity() int
 	Environment() string
 

--- a/plugins/frog/plugin_rule_test.go
+++ b/plugins/frog/plugin_rule_test.go
@@ -94,7 +94,7 @@ func (h stubHousing) ID() string          { return h.id }
 func (stubHousing) CreatedAt() time.Time  { return time.Time{} }
 func (stubHousing) UpdatedAt() time.Time  { return time.Time{} }
 func (stubHousing) Name() string          { return "" }
-func (stubHousing) Facility() string      { return "" }
+func (stubHousing) FacilityID() string    { return "" }
 func (stubHousing) Capacity() int         { return 0 }
 func (h stubHousing) Environment() string { return h.environment }
 

--- a/plugins/testhelper/dataset.go
+++ b/plugins/testhelper/dataset.go
@@ -60,7 +60,7 @@ type OrganismFixtureConfig struct {
 type HousingUnitFixtureConfig struct {
 	BaseFixture
 	Name        string
-	Facility    string
+	FacilityID  string
 	Capacity    int
 	Environment string
 }
@@ -112,7 +112,7 @@ func HousingUnit(cfg HousingUnitFixtureConfig) datasetapi.HousingUnit {
 	domainUnit := domain.HousingUnit{
 		Base:        cfg.baseDomain(),
 		Name:        cfg.Name,
-		Facility:    cfg.Facility,
+		FacilityID:  cfg.FacilityID,
 		Capacity:    cfg.Capacity,
 		Environment: cfg.Environment,
 	}
@@ -120,7 +120,7 @@ func HousingUnit(cfg HousingUnitFixtureConfig) datasetapi.HousingUnit {
 	return datasetapi.NewHousingUnit(datasetapi.HousingUnitData{
 		Base:        baseDataFromDomain(domainUnit.Base),
 		Name:        domainUnit.Name,
-		Facility:    domainUnit.Facility,
+		FacilityID:  domainUnit.FacilityID,
 		Capacity:    domainUnit.Capacity,
 		Environment: domainUnit.Environment,
 	})

--- a/plugins/testhelper/dataset_test.go
+++ b/plugins/testhelper/dataset_test.go
@@ -26,7 +26,7 @@ func TestOrganismFixtureBuilder(t *testing.T) {
 
 func TestHousingUnitFixtureBuilder(t *testing.T) {
 	now := time.Now().UTC()
-	cfg := HousingUnitFixtureConfig{BaseFixture: BaseFixture{ID: "h1", CreatedAt: now, UpdatedAt: now}, Name: "H", Facility: "F", Capacity: 2, Environment: "env"}
+	cfg := HousingUnitFixtureConfig{BaseFixture: BaseFixture{ID: "h1", CreatedAt: now, UpdatedAt: now}, Name: "H", FacilityID: "F", Capacity: 2, Environment: "env"}
 	hu := HousingUnit(cfg)
 	if hu.Capacity() != 2 || hu.Environment() != "env" {
 		t.Fatalf("unexpected housing unit values")
@@ -78,7 +78,7 @@ func TestHousingUnitHelper(t *testing.T) {
 	unit := HousingUnit(HousingUnitFixtureConfig{
 		BaseFixture: BaseFixture{ID: "unit", CreatedAt: now, UpdatedAt: now},
 		Name:        "Hab",
-		Facility:    "Facility",
+		FacilityID:  "Facility",
 		Capacity:    4,
 		Environment: "humid",
 	})


### PR DESCRIPTION
## What  
<!-- Describe the change. -->

Extend `pkg/domain/entities.go` with structs and EntityType constants for Facility, Treatment, Observation, Sample, Permit, and SupplyItem, mirroring `RFC-0001` responsibilities.

## Why  
<!-- What's the motivation. -->

The Entities and structs were yet missing from the API surface.

Partial fix of #66 

## How  
<!-- Bullet list or description of key changes. -->

* Added missing constants to `pkg/domain/entities.go`
* Updated facades and tests

## Notes  
<!-- Breaking changes or follow-ups (if any). -->

## Checklist  

- [x] I have used conventional commits (conventionalcommits.com)
- [ ] I have updated the documentation
- [ ] I have updated the relevant RFC and its linked resources
- [ ] I have added tests
- [x] I ran manual tests