### PR TITLE
feat: support new core entities in domain stores

### DIFF
--- a/internal/core/dataset_store_adapter_test.go
+++ b/internal/core/dataset_store_adapter_test.go
@@ -152,11 +152,17 @@ func TestDatasetPersistentStoreAdapter(t *testing.T) {
 type fakePersistentStore struct {
 	organisms     []domain.Organism
 	housingUnits  []domain.HousingUnit
+	facilities    []domain.Facility
 	protocols     []domain.Protocol
 	projects      []domain.Project
 	cohorts       []domain.Cohort
 	breedingUnits []domain.BreedingUnit
 	procedures    []domain.Procedure
+	treatments    []domain.Treatment
+	observations  []domain.Observation
+	samples       []domain.Sample
+	permits       []domain.Permit
+	supplyItems   []domain.SupplyItem
 	viewCalled    bool
 }
 
@@ -198,12 +204,50 @@ func (f *fakePersistentStore) ListHousingUnits() []domain.HousingUnit {
 	return append([]domain.HousingUnit(nil), f.housingUnits...)
 }
 
+func (f *fakePersistentStore) GetFacility(id string) (domain.Facility, bool) {
+	for _, fac := range f.facilities {
+		if fac.ID == id {
+			return fac, true
+		}
+	}
+	return domain.Facility{}, false
+}
+
+func (f *fakePersistentStore) ListFacilities() []domain.Facility {
+	return append([]domain.Facility(nil), f.facilities...)
+}
+
 func (f *fakePersistentStore) ListCohorts() []domain.Cohort {
 	return append([]domain.Cohort(nil), f.cohorts...)
 }
 
 func (f *fakePersistentStore) ListProtocols() []domain.Protocol {
 	return append([]domain.Protocol(nil), f.protocols...)
+}
+
+func (f *fakePersistentStore) ListTreatments() []domain.Treatment {
+	return append([]domain.Treatment(nil), f.treatments...)
+}
+
+func (f *fakePersistentStore) ListObservations() []domain.Observation {
+	return append([]domain.Observation(nil), f.observations...)
+}
+
+func (f *fakePersistentStore) ListSamples() []domain.Sample {
+	return append([]domain.Sample(nil), f.samples...)
+}
+
+func (f *fakePersistentStore) GetPermit(id string) (domain.Permit, bool) {
+	for _, permit := range f.permits {
+		if permit.ID == id {
+			return permit, true
+		}
+	}
+	return domain.Permit{}, false
+}
+
+func (f *fakePersistentStore) ListPermits() []domain.Permit {
+	return append([]domain.Permit(nil), f.permits...)
 }
 
 func (f *fakePersistentStore) ListProjects() []domain.Project {
@@ -218,6 +262,10 @@ func (f *fakePersistentStore) ListProcedures() []domain.Procedure {
 	return append([]domain.Procedure(nil), f.procedures...)
 }
 
+func (f *fakePersistentStore) ListSupplyItems() []domain.SupplyItem {
+	return append([]domain.SupplyItem(nil), f.supplyItems...)
+}
+
 type fakeTransactionView struct {
 	store *fakePersistentStore
 }
@@ -226,7 +274,22 @@ func (v fakeTransactionView) ListOrganisms() []domain.Organism { return v.store.
 func (v fakeTransactionView) ListHousingUnits() []domain.HousingUnit {
 	return v.store.ListHousingUnits()
 }
+func (v fakeTransactionView) ListFacilities() []domain.Facility {
+	return v.store.ListFacilities()
+}
 func (v fakeTransactionView) ListProtocols() []domain.Protocol { return v.store.ListProtocols() }
+func (v fakeTransactionView) ListTreatments() []domain.Treatment {
+	return v.store.ListTreatments()
+}
+func (v fakeTransactionView) ListObservations() []domain.Observation {
+	return v.store.ListObservations()
+}
+func (v fakeTransactionView) ListSamples() []domain.Sample   { return v.store.ListSamples() }
+func (v fakeTransactionView) ListPermits() []domain.Permit   { return v.store.ListPermits() }
+func (v fakeTransactionView) ListProjects() []domain.Project { return v.store.ListProjects() }
+func (v fakeTransactionView) ListSupplyItems() []domain.SupplyItem {
+	return v.store.ListSupplyItems()
+}
 
 func (v fakeTransactionView) FindOrganism(id string) (domain.Organism, bool) {
 	return v.store.GetOrganism(id)
@@ -234,4 +297,48 @@ func (v fakeTransactionView) FindOrganism(id string) (domain.Organism, bool) {
 
 func (v fakeTransactionView) FindHousingUnit(id string) (domain.HousingUnit, bool) {
 	return v.store.GetHousingUnit(id)
+}
+
+func (v fakeTransactionView) FindFacility(id string) (domain.Facility, bool) {
+	return v.store.GetFacility(id)
+}
+
+func (v fakeTransactionView) FindTreatment(id string) (domain.Treatment, bool) {
+	for _, t := range v.store.treatments {
+		if t.ID == id {
+			return t, true
+		}
+	}
+	return domain.Treatment{}, false
+}
+
+func (v fakeTransactionView) FindObservation(id string) (domain.Observation, bool) {
+	for _, o := range v.store.observations {
+		if o.ID == id {
+			return o, true
+		}
+	}
+	return domain.Observation{}, false
+}
+
+func (v fakeTransactionView) FindSample(id string) (domain.Sample, bool) {
+	for _, s := range v.store.samples {
+		if s.ID == id {
+			return s, true
+		}
+	}
+	return domain.Sample{}, false
+}
+
+func (v fakeTransactionView) FindPermit(id string) (domain.Permit, bool) {
+	return v.store.GetPermit(id)
+}
+
+func (v fakeTransactionView) FindSupplyItem(id string) (domain.SupplyItem, bool) {
+	for _, s := range v.store.supplyItems {
+		if s.ID == id {
+			return s, true
+		}
+	}
+	return domain.SupplyItem{}, false
 }

--- a/internal/core/service_test.go
+++ b/internal/core/service_test.go
@@ -384,12 +384,40 @@ func (s clocklessStore) ListHousingUnits() []domain.HousingUnit {
 	return s.inner.ListHousingUnits()
 }
 
+func (s clocklessStore) GetFacility(id string) (domain.Facility, bool) {
+	return s.inner.GetFacility(id)
+}
+
+func (s clocklessStore) ListFacilities() []domain.Facility {
+	return s.inner.ListFacilities()
+}
+
 func (s clocklessStore) ListCohorts() []domain.Cohort {
 	return s.inner.ListCohorts()
 }
 
 func (s clocklessStore) ListProtocols() []domain.Protocol {
 	return s.inner.ListProtocols()
+}
+
+func (s clocklessStore) ListTreatments() []domain.Treatment {
+	return s.inner.ListTreatments()
+}
+
+func (s clocklessStore) ListObservations() []domain.Observation {
+	return s.inner.ListObservations()
+}
+
+func (s clocklessStore) ListSamples() []domain.Sample {
+	return s.inner.ListSamples()
+}
+
+func (s clocklessStore) GetPermit(id string) (domain.Permit, bool) {
+	return s.inner.GetPermit(id)
+}
+
+func (s clocklessStore) ListPermits() []domain.Permit {
+	return s.inner.ListPermits()
 }
 
 func (s clocklessStore) ListProjects() []domain.Project {
@@ -402,6 +430,10 @@ func (s clocklessStore) ListBreedingUnits() []domain.BreedingUnit {
 
 func (s clocklessStore) ListProcedures() []domain.Procedure {
 	return s.inner.ListProcedures()
+}
+
+func (s clocklessStore) ListSupplyItems() []domain.SupplyItem {
+	return s.inner.ListSupplyItems()
 }
 
 func (s clocklessStore) RulesEngine() *domain.RulesEngine {

--- a/internal/infra/persistence/memory/store.go
+++ b/internal/infra/persistence/memory/store.go
@@ -25,12 +25,24 @@ type (
 	HousingUnit = domain.HousingUnit
 	// BreedingUnit aliases domain.BreedingUnit.
 	BreedingUnit = domain.BreedingUnit
+	// Facility aliases domain.Facility.
+	Facility = domain.Facility
 	// Procedure aliases domain.Procedure.
 	Procedure = domain.Procedure
+	// Treatment aliases domain.Treatment.
+	Treatment = domain.Treatment
+	// Observation aliases domain.Observation.
+	Observation = domain.Observation
+	// Sample aliases domain.Sample.
+	Sample = domain.Sample
 	// Protocol aliases domain.Protocol.
 	Protocol = domain.Protocol
+	// Permit aliases domain.Permit.
+	Permit = domain.Permit
 	// Project aliases domain.Project.
 	Project = domain.Project
+	// SupplyItem aliases domain.SupplyItem.
+	SupplyItem = domain.SupplyItem
 	// Change aliases domain.Change captured in transactions.
 	Change = domain.Change
 	// Result aliases domain.Result summarizing rule evaluation.
@@ -49,47 +61,71 @@ type (
 // No constant aliases needed - use domain.EntityType, domain.Action values directly
 
 type memoryState struct {
-	organisms  map[string]Organism
-	cohorts    map[string]Cohort
-	housing    map[string]HousingUnit
-	breeding   map[string]BreedingUnit
-	procedures map[string]Procedure
-	protocols  map[string]Protocol
-	projects   map[string]Project
+	organisms    map[string]Organism
+	cohorts      map[string]Cohort
+	housing      map[string]HousingUnit
+	facilities   map[string]Facility
+	breeding     map[string]BreedingUnit
+	procedures   map[string]Procedure
+	treatments   map[string]Treatment
+	observations map[string]Observation
+	samples      map[string]Sample
+	protocols    map[string]Protocol
+	permits      map[string]Permit
+	projects     map[string]Project
+	supplies     map[string]SupplyItem
 }
 
 // Snapshot captures a point-in-time clone of the store state.
 type Snapshot struct {
-	Organisms  map[string]Organism     `json:"organisms"`
-	Cohorts    map[string]Cohort       `json:"cohorts"`
-	Housing    map[string]HousingUnit  `json:"housing"`
-	Breeding   map[string]BreedingUnit `json:"breeding"`
-	Procedures map[string]Procedure    `json:"procedures"`
-	Protocols  map[string]Protocol     `json:"protocols"`
-	Projects   map[string]Project      `json:"projects"`
+	Organisms    map[string]Organism     `json:"organisms"`
+	Cohorts      map[string]Cohort       `json:"cohorts"`
+	Housing      map[string]HousingUnit  `json:"housing"`
+	Facilities   map[string]Facility     `json:"facilities"`
+	Breeding     map[string]BreedingUnit `json:"breeding"`
+	Procedures   map[string]Procedure    `json:"procedures"`
+	Treatments   map[string]Treatment    `json:"treatments"`
+	Observations map[string]Observation  `json:"observations"`
+	Samples      map[string]Sample       `json:"samples"`
+	Protocols    map[string]Protocol     `json:"protocols"`
+	Permits      map[string]Permit       `json:"permits"`
+	Projects     map[string]Project      `json:"projects"`
+	Supplies     map[string]SupplyItem   `json:"supplies"`
 }
 
 func newMemoryState() memoryState {
 	return memoryState{
-		organisms:  make(map[string]Organism),
-		cohorts:    make(map[string]Cohort),
-		housing:    make(map[string]HousingUnit),
-		breeding:   make(map[string]BreedingUnit),
-		procedures: make(map[string]Procedure),
-		protocols:  make(map[string]Protocol),
-		projects:   make(map[string]Project),
+		organisms:    make(map[string]Organism),
+		cohorts:      make(map[string]Cohort),
+		housing:      make(map[string]HousingUnit),
+		facilities:   make(map[string]Facility),
+		breeding:     make(map[string]BreedingUnit),
+		procedures:   make(map[string]Procedure),
+		treatments:   make(map[string]Treatment),
+		observations: make(map[string]Observation),
+		samples:      make(map[string]Sample),
+		protocols:    make(map[string]Protocol),
+		permits:      make(map[string]Permit),
+		projects:     make(map[string]Project),
+		supplies:     make(map[string]SupplyItem),
 	}
 }
 
 func snapshotFromMemoryState(state memoryState) Snapshot {
 	s := Snapshot{
-		Organisms:  make(map[string]Organism, len(state.organisms)),
-		Cohorts:    make(map[string]Cohort, len(state.cohorts)),
-		Housing:    make(map[string]HousingUnit, len(state.housing)),
-		Breeding:   make(map[string]BreedingUnit, len(state.breeding)),
-		Procedures: make(map[string]Procedure, len(state.procedures)),
-		Protocols:  make(map[string]Protocol, len(state.protocols)),
-		Projects:   make(map[string]Project, len(state.projects)),
+		Organisms:    make(map[string]Organism, len(state.organisms)),
+		Cohorts:      make(map[string]Cohort, len(state.cohorts)),
+		Housing:      make(map[string]HousingUnit, len(state.housing)),
+		Facilities:   make(map[string]Facility, len(state.facilities)),
+		Breeding:     make(map[string]BreedingUnit, len(state.breeding)),
+		Procedures:   make(map[string]Procedure, len(state.procedures)),
+		Treatments:   make(map[string]Treatment, len(state.treatments)),
+		Observations: make(map[string]Observation, len(state.observations)),
+		Samples:      make(map[string]Sample, len(state.samples)),
+		Protocols:    make(map[string]Protocol, len(state.protocols)),
+		Permits:      make(map[string]Permit, len(state.permits)),
+		Projects:     make(map[string]Project, len(state.projects)),
+		Supplies:     make(map[string]SupplyItem, len(state.supplies)),
 	}
 	for k, v := range state.organisms {
 		s.Organisms[k] = cloneOrganism(v)
@@ -100,17 +136,35 @@ func snapshotFromMemoryState(state memoryState) Snapshot {
 	for k, v := range state.housing {
 		s.Housing[k] = cloneHousing(v)
 	}
+	for k, v := range state.facilities {
+		s.Facilities[k] = cloneFacility(v)
+	}
 	for k, v := range state.breeding {
 		s.Breeding[k] = cloneBreeding(v)
 	}
 	for k, v := range state.procedures {
 		s.Procedures[k] = cloneProcedure(v)
 	}
+	for k, v := range state.treatments {
+		s.Treatments[k] = cloneTreatment(v)
+	}
+	for k, v := range state.observations {
+		s.Observations[k] = cloneObservation(v)
+	}
+	for k, v := range state.samples {
+		s.Samples[k] = cloneSample(v)
+	}
 	for k, v := range state.protocols {
 		s.Protocols[k] = cloneProtocol(v)
 	}
+	for k, v := range state.permits {
+		s.Permits[k] = clonePermit(v)
+	}
 	for k, v := range state.projects {
 		s.Projects[k] = cloneProject(v)
+	}
+	for k, v := range state.supplies {
+		s.Supplies[k] = cloneSupplyItem(v)
 	}
 	return s
 }
@@ -126,17 +180,35 @@ func memoryStateFromSnapshot(s Snapshot) memoryState {
 	for k, v := range s.Housing {
 		state.housing[k] = cloneHousing(v)
 	}
+	for k, v := range s.Facilities {
+		state.facilities[k] = cloneFacility(v)
+	}
 	for k, v := range s.Breeding {
 		state.breeding[k] = cloneBreeding(v)
 	}
 	for k, v := range s.Procedures {
 		state.procedures[k] = cloneProcedure(v)
 	}
+	for k, v := range s.Treatments {
+		state.treatments[k] = cloneTreatment(v)
+	}
+	for k, v := range s.Observations {
+		state.observations[k] = cloneObservation(v)
+	}
+	for k, v := range s.Samples {
+		state.samples[k] = cloneSample(v)
+	}
 	for k, v := range s.Protocols {
 		state.protocols[k] = cloneProtocol(v)
 	}
+	for k, v := range s.Permits {
+		state.permits[k] = clonePermit(v)
+	}
 	for k, v := range s.Projects {
 		state.projects[k] = cloneProject(v)
+	}
+	for k, v := range s.Supplies {
+		state.supplies[k] = cloneSupplyItem(v)
 	}
 	return state
 }
@@ -152,17 +224,35 @@ func (s memoryState) clone() memoryState {
 	for k, v := range s.housing {
 		cloned.housing[k] = cloneHousing(v)
 	}
+	for k, v := range s.facilities {
+		cloned.facilities[k] = cloneFacility(v)
+	}
 	for k, v := range s.breeding {
 		cloned.breeding[k] = cloneBreeding(v)
 	}
 	for k, v := range s.procedures {
 		cloned.procedures[k] = cloneProcedure(v)
 	}
+	for k, v := range s.treatments {
+		cloned.treatments[k] = cloneTreatment(v)
+	}
+	for k, v := range s.observations {
+		cloned.observations[k] = cloneObservation(v)
+	}
+	for k, v := range s.samples {
+		cloned.samples[k] = cloneSample(v)
+	}
 	for k, v := range s.protocols {
 		cloned.protocols[k] = cloneProtocol(v)
 	}
+	for k, v := range s.permits {
+		cloned.permits[k] = clonePermit(v)
+	}
 	for k, v := range s.projects {
 		cloned.projects[k] = cloneProject(v)
+	}
+	for k, v := range s.supplies {
+		cloned.supplies[k] = cloneSupplyItem(v)
 	}
 	return cloned
 }
@@ -194,6 +284,76 @@ func cloneProcedure(p Procedure) Procedure {
 }
 func cloneProtocol(p Protocol) Protocol { return p }
 func cloneProject(p Project) Project    { return p }
+
+func cloneFacility(f Facility) Facility {
+	cp := f
+	if f.EnvironmentBaselines != nil {
+		cp.EnvironmentBaselines = make(map[string]any, len(f.EnvironmentBaselines))
+		for k, v := range f.EnvironmentBaselines {
+			cp.EnvironmentBaselines[k] = v
+		}
+	}
+	cp.HousingUnitIDs = append([]string(nil), f.HousingUnitIDs...)
+	cp.ProjectIDs = append([]string(nil), f.ProjectIDs...)
+	return cp
+}
+
+func cloneTreatment(t Treatment) Treatment {
+	cp := t
+	cp.OrganismIDs = append([]string(nil), t.OrganismIDs...)
+	cp.CohortIDs = append([]string(nil), t.CohortIDs...)
+	cp.AdministrationLog = append([]string(nil), t.AdministrationLog...)
+	cp.AdverseEvents = append([]string(nil), t.AdverseEvents...)
+	return cp
+}
+
+func cloneObservation(o Observation) Observation {
+	cp := o
+	if o.Data != nil {
+		cp.Data = make(map[string]any, len(o.Data))
+		for k, v := range o.Data {
+			cp.Data[k] = v
+		}
+	}
+	return cp
+}
+
+func cloneSample(s Sample) Sample {
+	cp := s
+	cp.ChainOfCustody = append([]domain.SampleCustodyEvent(nil), s.ChainOfCustody...)
+	if s.Attributes != nil {
+		cp.Attributes = make(map[string]any, len(s.Attributes))
+		for k, v := range s.Attributes {
+			cp.Attributes[k] = v
+		}
+	}
+	return cp
+}
+
+func clonePermit(p Permit) Permit {
+	cp := p
+	cp.AllowedActivities = append([]string(nil), p.AllowedActivities...)
+	cp.FacilityIDs = append([]string(nil), p.FacilityIDs...)
+	cp.ProtocolIDs = append([]string(nil), p.ProtocolIDs...)
+	return cp
+}
+
+func cloneSupplyItem(s SupplyItem) SupplyItem {
+	cp := s
+	if s.ExpiresAt != nil {
+		t := *s.ExpiresAt
+		cp.ExpiresAt = &t
+	}
+	cp.FacilityIDs = append([]string(nil), s.FacilityIDs...)
+	cp.ProjectIDs = append([]string(nil), s.ProjectIDs...)
+	if s.Attributes != nil {
+		cp.Attributes = make(map[string]any, len(s.Attributes))
+		for k, v := range s.Attributes {
+			cp.Attributes[k] = v
+		}
+	}
+	return cp
+}
 
 // Store provides an in-memory transactional store for the core domain.
 type Store struct {
@@ -286,6 +446,15 @@ func (v transactionView) ListHousingUnits() []HousingUnit {
 	return out
 }
 
+// ListFacilities returns all facilities in the snapshot.
+func (v transactionView) ListFacilities() []Facility {
+	out := make([]Facility, 0, len(v.state.facilities))
+	for _, f := range v.state.facilities {
+		out = append(out, cloneFacility(f))
+	}
+	return out
+}
+
 // FindOrganism retrieves an organism by ID from the snapshot.
 func (v transactionView) FindOrganism(id string) (Organism, bool) {
 	o, ok := v.state.organisms[id]
@@ -304,6 +473,15 @@ func (v transactionView) FindHousingUnit(id string) (HousingUnit, bool) {
 	return cloneHousing(h), true
 }
 
+// FindFacility retrieves a facility by ID from the snapshot.
+func (v transactionView) FindFacility(id string) (Facility, bool) {
+	f, ok := v.state.facilities[id]
+	if !ok {
+		return Facility{}, false
+	}
+	return cloneFacility(f), true
+}
+
 // ListProtocols returns all protocols present in the snapshot.
 func (v transactionView) ListProtocols() []Protocol {
 	out := make([]Protocol, 0, len(v.state.protocols))
@@ -311,6 +489,105 @@ func (v transactionView) ListProtocols() []Protocol {
 		out = append(out, cloneProtocol(p))
 	}
 	return out
+}
+
+// ListTreatments returns all treatments in the snapshot.
+func (v transactionView) ListTreatments() []Treatment {
+	out := make([]Treatment, 0, len(v.state.treatments))
+	for _, t := range v.state.treatments {
+		out = append(out, cloneTreatment(t))
+	}
+	return out
+}
+
+// FindTreatment retrieves a treatment by ID from the snapshot.
+func (v transactionView) FindTreatment(id string) (Treatment, bool) {
+	t, ok := v.state.treatments[id]
+	if !ok {
+		return Treatment{}, false
+	}
+	return cloneTreatment(t), true
+}
+
+// ListObservations returns all observations in the snapshot.
+func (v transactionView) ListObservations() []Observation {
+	out := make([]Observation, 0, len(v.state.observations))
+	for _, o := range v.state.observations {
+		out = append(out, cloneObservation(o))
+	}
+	return out
+}
+
+// FindObservation retrieves an observation by ID from the snapshot.
+func (v transactionView) FindObservation(id string) (Observation, bool) {
+	o, ok := v.state.observations[id]
+	if !ok {
+		return Observation{}, false
+	}
+	return cloneObservation(o), true
+}
+
+// ListSamples returns all samples in the snapshot.
+func (v transactionView) ListSamples() []Sample {
+	out := make([]Sample, 0, len(v.state.samples))
+	for _, s := range v.state.samples {
+		out = append(out, cloneSample(s))
+	}
+	return out
+}
+
+// FindSample retrieves a sample by ID from the snapshot.
+func (v transactionView) FindSample(id string) (Sample, bool) {
+	s, ok := v.state.samples[id]
+	if !ok {
+		return Sample{}, false
+	}
+	return cloneSample(s), true
+}
+
+// ListPermits returns all permits in the snapshot.
+func (v transactionView) ListPermits() []Permit {
+	out := make([]Permit, 0, len(v.state.permits))
+	for _, p := range v.state.permits {
+		out = append(out, clonePermit(p))
+	}
+	return out
+}
+
+// FindPermit retrieves a permit by ID from the snapshot.
+func (v transactionView) FindPermit(id string) (Permit, bool) {
+	p, ok := v.state.permits[id]
+	if !ok {
+		return Permit{}, false
+	}
+	return clonePermit(p), true
+}
+
+// ListProjects returns all projects in the snapshot.
+func (v transactionView) ListProjects() []Project {
+	out := make([]Project, 0, len(v.state.projects))
+	for _, p := range v.state.projects {
+		out = append(out, cloneProject(p))
+	}
+	return out
+}
+
+// ListSupplyItems returns all supply items in the snapshot.
+func (v transactionView) ListSupplyItems() []SupplyItem {
+	out := make([]SupplyItem, 0, len(v.state.supplies))
+	for _, s := range v.state.supplies {
+		out = append(out, cloneSupplyItem(s))
+	}
+	return out
+}
+
+// FindSupplyItem retrieves a supply item by ID from the snapshot.
+func (v transactionView) FindSupplyItem(id string) (SupplyItem, bool) {
+	s, ok := v.state.supplies[id]
+	if !ok {
+		return SupplyItem{}, false
+	}
+	return cloneSupplyItem(s), true
 }
 
 // RunInTransaction executes fn within a transactional copy of the store state.
@@ -381,6 +658,60 @@ func (tx *transaction) FindProtocol(id string) (Protocol, bool) {
 		return Protocol{}, false
 	}
 	return cloneProtocol(p), true
+}
+
+// FindFacility exposes facility lookup within the transaction scope.
+func (tx *transaction) FindFacility(id string) (Facility, bool) {
+	f, ok := tx.state.facilities[id]
+	if !ok {
+		return Facility{}, false
+	}
+	return cloneFacility(f), true
+}
+
+// FindTreatment exposes treatment lookup within the transaction scope.
+func (tx *transaction) FindTreatment(id string) (Treatment, bool) {
+	t, ok := tx.state.treatments[id]
+	if !ok {
+		return Treatment{}, false
+	}
+	return cloneTreatment(t), true
+}
+
+// FindObservation exposes observation lookup within the transaction scope.
+func (tx *transaction) FindObservation(id string) (Observation, bool) {
+	o, ok := tx.state.observations[id]
+	if !ok {
+		return Observation{}, false
+	}
+	return cloneObservation(o), true
+}
+
+// FindSample exposes sample lookup within the transaction scope.
+func (tx *transaction) FindSample(id string) (Sample, bool) {
+	s, ok := tx.state.samples[id]
+	if !ok {
+		return Sample{}, false
+	}
+	return cloneSample(s), true
+}
+
+// FindPermit exposes permit lookup within the transaction scope.
+func (tx *transaction) FindPermit(id string) (Permit, bool) {
+	p, ok := tx.state.permits[id]
+	if !ok {
+		return Permit{}, false
+	}
+	return clonePermit(p), true
+}
+
+// FindSupplyItem exposes supply item lookup within the transaction scope.
+func (tx *transaction) FindSupplyItem(id string) (SupplyItem, bool) {
+	s, ok := tx.state.supplies[id]
+	if !ok {
+		return SupplyItem{}, false
+	}
+	return cloneSupplyItem(s), true
 }
 
 // CreateOrganism stores a new organism within the transaction.
@@ -521,6 +852,55 @@ func (tx *transaction) DeleteHousingUnit(id string) error {
 	return nil
 }
 
+// CreateFacility stores a new facility record.
+func (tx *transaction) CreateFacility(f Facility) (Facility, error) {
+	if f.ID == "" {
+		f.ID = tx.store.newID()
+	}
+	if _, exists := tx.state.facilities[f.ID]; exists {
+		return Facility{}, fmt.Errorf("facility %q already exists", f.ID)
+	}
+	f.CreatedAt = tx.now
+	f.UpdatedAt = tx.now
+	if f.EnvironmentBaselines == nil {
+		f.EnvironmentBaselines = map[string]any{}
+	}
+	tx.state.facilities[f.ID] = cloneFacility(f)
+	tx.recordChange(Change{Entity: domain.EntityFacility, Action: domain.ActionCreate, After: cloneFacility(f)})
+	return cloneFacility(f), nil
+}
+
+// UpdateFacility mutates an existing facility.
+func (tx *transaction) UpdateFacility(id string, mutator func(*Facility) error) (Facility, error) {
+	current, ok := tx.state.facilities[id]
+	if !ok {
+		return Facility{}, fmt.Errorf("facility %q not found", id)
+	}
+	before := cloneFacility(current)
+	if err := mutator(&current); err != nil {
+		return Facility{}, err
+	}
+	if current.EnvironmentBaselines == nil {
+		current.EnvironmentBaselines = map[string]any{}
+	}
+	current.ID = id
+	current.UpdatedAt = tx.now
+	tx.state.facilities[id] = cloneFacility(current)
+	tx.recordChange(Change{Entity: domain.EntityFacility, Action: domain.ActionUpdate, Before: before, After: cloneFacility(current)})
+	return cloneFacility(current), nil
+}
+
+// DeleteFacility removes a facility from state.
+func (tx *transaction) DeleteFacility(id string) error {
+	current, ok := tx.state.facilities[id]
+	if !ok {
+		return fmt.Errorf("facility %q not found", id)
+	}
+	delete(tx.state.facilities, id)
+	tx.recordChange(Change{Entity: domain.EntityFacility, Action: domain.ActionDelete, Before: cloneFacility(current)})
+	return nil
+}
+
 // CreateBreedingUnit stores a new breeding unit definition.
 func (tx *transaction) CreateBreedingUnit(b BreedingUnit) (BreedingUnit, error) {
 	if b.ID == "" {
@@ -607,6 +987,147 @@ func (tx *transaction) DeleteProcedure(id string) error {
 	return nil
 }
 
+// CreateTreatment stores a treatment record.
+func (tx *transaction) CreateTreatment(t Treatment) (Treatment, error) {
+	if t.ID == "" {
+		t.ID = tx.store.newID()
+	}
+	if _, exists := tx.state.treatments[t.ID]; exists {
+		return Treatment{}, fmt.Errorf("treatment %q already exists", t.ID)
+	}
+	t.CreatedAt = tx.now
+	t.UpdatedAt = tx.now
+	tx.state.treatments[t.ID] = cloneTreatment(t)
+	tx.recordChange(Change{Entity: domain.EntityTreatment, Action: domain.ActionCreate, After: cloneTreatment(t)})
+	return cloneTreatment(t), nil
+}
+
+// UpdateTreatment mutates an existing treatment.
+func (tx *transaction) UpdateTreatment(id string, mutator func(*Treatment) error) (Treatment, error) {
+	current, ok := tx.state.treatments[id]
+	if !ok {
+		return Treatment{}, fmt.Errorf("treatment %q not found", id)
+	}
+	before := cloneTreatment(current)
+	if err := mutator(&current); err != nil {
+		return Treatment{}, err
+	}
+	current.ID = id
+	current.UpdatedAt = tx.now
+	tx.state.treatments[id] = cloneTreatment(current)
+	tx.recordChange(Change{Entity: domain.EntityTreatment, Action: domain.ActionUpdate, Before: before, After: cloneTreatment(current)})
+	return cloneTreatment(current), nil
+}
+
+// DeleteTreatment removes a treatment from state.
+func (tx *transaction) DeleteTreatment(id string) error {
+	current, ok := tx.state.treatments[id]
+	if !ok {
+		return fmt.Errorf("treatment %q not found", id)
+	}
+	delete(tx.state.treatments, id)
+	tx.recordChange(Change{Entity: domain.EntityTreatment, Action: domain.ActionDelete, Before: cloneTreatment(current)})
+	return nil
+}
+
+// CreateObservation stores an observation record.
+func (tx *transaction) CreateObservation(o Observation) (Observation, error) {
+	if o.ID == "" {
+		o.ID = tx.store.newID()
+	}
+	if _, exists := tx.state.observations[o.ID]; exists {
+		return Observation{}, fmt.Errorf("observation %q already exists", o.ID)
+	}
+	o.CreatedAt = tx.now
+	o.UpdatedAt = tx.now
+	if o.Data == nil {
+		o.Data = map[string]any{}
+	}
+	tx.state.observations[o.ID] = cloneObservation(o)
+	tx.recordChange(Change{Entity: domain.EntityObservation, Action: domain.ActionCreate, After: cloneObservation(o)})
+	return cloneObservation(o), nil
+}
+
+// UpdateObservation mutates an existing observation.
+func (tx *transaction) UpdateObservation(id string, mutator func(*Observation) error) (Observation, error) {
+	current, ok := tx.state.observations[id]
+	if !ok {
+		return Observation{}, fmt.Errorf("observation %q not found", id)
+	}
+	before := cloneObservation(current)
+	if err := mutator(&current); err != nil {
+		return Observation{}, err
+	}
+	if current.Data == nil {
+		current.Data = map[string]any{}
+	}
+	current.ID = id
+	current.UpdatedAt = tx.now
+	tx.state.observations[id] = cloneObservation(current)
+	tx.recordChange(Change{Entity: domain.EntityObservation, Action: domain.ActionUpdate, Before: before, After: cloneObservation(current)})
+	return cloneObservation(current), nil
+}
+
+// DeleteObservation removes an observation from state.
+func (tx *transaction) DeleteObservation(id string) error {
+	current, ok := tx.state.observations[id]
+	if !ok {
+		return fmt.Errorf("observation %q not found", id)
+	}
+	delete(tx.state.observations, id)
+	tx.recordChange(Change{Entity: domain.EntityObservation, Action: domain.ActionDelete, Before: cloneObservation(current)})
+	return nil
+}
+
+// CreateSample stores a sample record.
+func (tx *transaction) CreateSample(s Sample) (Sample, error) {
+	if s.ID == "" {
+		s.ID = tx.store.newID()
+	}
+	if _, exists := tx.state.samples[s.ID]; exists {
+		return Sample{}, fmt.Errorf("sample %q already exists", s.ID)
+	}
+	s.CreatedAt = tx.now
+	s.UpdatedAt = tx.now
+	if s.Attributes == nil {
+		s.Attributes = map[string]any{}
+	}
+	tx.state.samples[s.ID] = cloneSample(s)
+	tx.recordChange(Change{Entity: domain.EntitySample, Action: domain.ActionCreate, After: cloneSample(s)})
+	return cloneSample(s), nil
+}
+
+// UpdateSample mutates an existing sample.
+func (tx *transaction) UpdateSample(id string, mutator func(*Sample) error) (Sample, error) {
+	current, ok := tx.state.samples[id]
+	if !ok {
+		return Sample{}, fmt.Errorf("sample %q not found", id)
+	}
+	before := cloneSample(current)
+	if err := mutator(&current); err != nil {
+		return Sample{}, err
+	}
+	if current.Attributes == nil {
+		current.Attributes = map[string]any{}
+	}
+	current.ID = id
+	current.UpdatedAt = tx.now
+	tx.state.samples[id] = cloneSample(current)
+	tx.recordChange(Change{Entity: domain.EntitySample, Action: domain.ActionUpdate, Before: before, After: cloneSample(current)})
+	return cloneSample(current), nil
+}
+
+// DeleteSample removes a sample from state.
+func (tx *transaction) DeleteSample(id string) error {
+	current, ok := tx.state.samples[id]
+	if !ok {
+		return fmt.Errorf("sample %q not found", id)
+	}
+	delete(tx.state.samples, id)
+	tx.recordChange(Change{Entity: domain.EntitySample, Action: domain.ActionDelete, Before: cloneSample(current)})
+	return nil
+}
+
 // CreateProtocol stores a new protocol record.
 func (tx *transaction) CreateProtocol(p Protocol) (Protocol, error) {
 	if p.ID == "" {
@@ -650,6 +1171,49 @@ func (tx *transaction) DeleteProtocol(id string) error {
 	return nil
 }
 
+// CreatePermit stores a permit record.
+func (tx *transaction) CreatePermit(p Permit) (Permit, error) {
+	if p.ID == "" {
+		p.ID = tx.store.newID()
+	}
+	if _, exists := tx.state.permits[p.ID]; exists {
+		return Permit{}, fmt.Errorf("permit %q already exists", p.ID)
+	}
+	p.CreatedAt = tx.now
+	p.UpdatedAt = tx.now
+	tx.state.permits[p.ID] = clonePermit(p)
+	tx.recordChange(Change{Entity: domain.EntityPermit, Action: domain.ActionCreate, After: clonePermit(p)})
+	return clonePermit(p), nil
+}
+
+// UpdatePermit mutates an existing permit.
+func (tx *transaction) UpdatePermit(id string, mutator func(*Permit) error) (Permit, error) {
+	current, ok := tx.state.permits[id]
+	if !ok {
+		return Permit{}, fmt.Errorf("permit %q not found", id)
+	}
+	before := clonePermit(current)
+	if err := mutator(&current); err != nil {
+		return Permit{}, err
+	}
+	current.ID = id
+	current.UpdatedAt = tx.now
+	tx.state.permits[id] = clonePermit(current)
+	tx.recordChange(Change{Entity: domain.EntityPermit, Action: domain.ActionUpdate, Before: before, After: clonePermit(current)})
+	return clonePermit(current), nil
+}
+
+// DeletePermit removes a permit from state.
+func (tx *transaction) DeletePermit(id string) error {
+	current, ok := tx.state.permits[id]
+	if !ok {
+		return fmt.Errorf("permit %q not found", id)
+	}
+	delete(tx.state.permits, id)
+	tx.recordChange(Change{Entity: domain.EntityPermit, Action: domain.ActionDelete, Before: clonePermit(current)})
+	return nil
+}
+
 // CreateProject stores a project record.
 func (tx *transaction) CreateProject(p Project) (Project, error) {
 	if p.ID == "" {
@@ -690,6 +1254,59 @@ func (tx *transaction) DeleteProject(id string) error {
 	}
 	delete(tx.state.projects, id)
 	tx.recordChange(Change{Entity: domain.EntityProject, Action: domain.ActionDelete, Before: cloneProject(current)})
+	return nil
+}
+
+// CreateSupplyItem stores a supply item record.
+func (tx *transaction) CreateSupplyItem(s SupplyItem) (SupplyItem, error) {
+	if s.ID == "" {
+		s.ID = tx.store.newID()
+	}
+	if _, exists := tx.state.supplies[s.ID]; exists {
+		return SupplyItem{}, fmt.Errorf("supply item %q already exists", s.ID)
+	}
+	s.CreatedAt = tx.now
+	s.UpdatedAt = tx.now
+	if s.Attributes == nil {
+		s.Attributes = map[string]any{}
+	}
+	tx.state.supplies[s.ID] = cloneSupplyItem(s)
+	tx.recordChange(Change{Entity: domain.EntitySupplyItem, Action: domain.ActionCreate, After: cloneSupplyItem(s)})
+	return cloneSupplyItem(s), nil
+}
+
+// UpdateSupplyItem mutates an existing supply item.
+func (tx *transaction) UpdateSupplyItem(id string, mutator func(*SupplyItem) error) (SupplyItem, error) {
+	current, ok := tx.state.supplies[id]
+	if !ok {
+		return SupplyItem{}, fmt.Errorf("supply item %q not found", id)
+	}
+	before := cloneSupplyItem(current)
+	if err := mutator(&current); err != nil {
+		return SupplyItem{}, err
+	}
+	if current.Attributes == nil {
+		current.Attributes = map[string]any{}
+	}
+	if current.ExpiresAt != nil {
+		t := *current.ExpiresAt
+		current.ExpiresAt = &t
+	}
+	current.ID = id
+	current.UpdatedAt = tx.now
+	tx.state.supplies[id] = cloneSupplyItem(current)
+	tx.recordChange(Change{Entity: domain.EntitySupplyItem, Action: domain.ActionUpdate, Before: before, After: cloneSupplyItem(current)})
+	return cloneSupplyItem(current), nil
+}
+
+// DeleteSupplyItem removes a supply item from state.
+func (tx *transaction) DeleteSupplyItem(id string) error {
+	current, ok := tx.state.supplies[id]
+	if !ok {
+		return fmt.Errorf("supply item %q not found", id)
+	}
+	delete(tx.state.supplies, id)
+	tx.recordChange(Change{Entity: domain.EntitySupplyItem, Action: domain.ActionDelete, Before: cloneSupplyItem(current)})
 	return nil
 }
 
@@ -739,6 +1356,28 @@ func (s *Store) ListHousingUnits() []HousingUnit {
 	return out
 }
 
+// GetFacility retrieves a facility by ID.
+func (s *Store) GetFacility(id string) (Facility, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	f, ok := s.state.facilities[id]
+	if !ok {
+		return Facility{}, false
+	}
+	return cloneFacility(f), true
+}
+
+// ListFacilities returns all facilities.
+func (s *Store) ListFacilities() []Facility {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Facility, 0, len(s.state.facilities))
+	for _, f := range s.state.facilities {
+		out = append(out, cloneFacility(f))
+	}
+	return out
+}
+
 // ListCohorts returns all cohorts.
 func (s *Store) ListCohorts() []Cohort {
 	s.mu.RLock()
@@ -757,6 +1396,61 @@ func (s *Store) ListProtocols() []Protocol {
 	out := make([]Protocol, 0, len(s.state.protocols))
 	for _, p := range s.state.protocols {
 		out = append(out, cloneProtocol(p))
+	}
+	return out
+}
+
+// ListTreatments returns all treatments.
+func (s *Store) ListTreatments() []Treatment {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Treatment, 0, len(s.state.treatments))
+	for _, t := range s.state.treatments {
+		out = append(out, cloneTreatment(t))
+	}
+	return out
+}
+
+// ListObservations returns all observations.
+func (s *Store) ListObservations() []Observation {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Observation, 0, len(s.state.observations))
+	for _, o := range s.state.observations {
+		out = append(out, cloneObservation(o))
+	}
+	return out
+}
+
+// ListSamples returns all samples.
+func (s *Store) ListSamples() []Sample {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Sample, 0, len(s.state.samples))
+	for _, sample := range s.state.samples {
+		out = append(out, cloneSample(sample))
+	}
+	return out
+}
+
+// GetPermit retrieves a permit by ID.
+func (s *Store) GetPermit(id string) (Permit, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	p, ok := s.state.permits[id]
+	if !ok {
+		return Permit{}, false
+	}
+	return clonePermit(p), true
+}
+
+// ListPermits returns all permits.
+func (s *Store) ListPermits() []Permit {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Permit, 0, len(s.state.permits))
+	for _, p := range s.state.permits {
+		out = append(out, clonePermit(p))
 	}
 	return out
 }
@@ -790,6 +1484,17 @@ func (s *Store) ListProcedures() []Procedure {
 	out := make([]Procedure, 0, len(s.state.procedures))
 	for _, p := range s.state.procedures {
 		out = append(out, cloneProcedure(p))
+	}
+	return out
+}
+
+// ListSupplyItems returns all supply items.
+func (s *Store) ListSupplyItems() []SupplyItem {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]SupplyItem, 0, len(s.state.supplies))
+	for _, sitem := range s.state.supplies {
+		out = append(out, cloneSupplyItem(sitem))
 	}
 	return out
 }

--- a/internal/infra/persistence/memory/store_crud_test.go
+++ b/internal/infra/persistence/memory/store_crud_test.go
@@ -9,64 +9,107 @@ import (
 	"time"
 )
 
+type memoryIDs struct {
+	projectID     string
+	protocolID    string
+	facilityID    string
+	housingID     string
+	cohortID      string
+	breedingID    string
+	procedureID   string
+	treatmentID   string
+	observationID string
+	sampleID      string
+	permitID      string
+	supplyItemID  string
+	organismAID   string
+	organismBID   string
+}
+
+const permitNumberFixture = "PER-1"
+
 func TestMemoryStoreCRUDAndQueries(t *testing.T) {
 	store := memory.NewStore(nil)
+
+	ids := seedMemoryStore(t, store)
+	verifyMemoryStorePostCreate(t, store, ids)
+	exerciseMemoryUpdates(t, store, ids)
+	exerciseMemoryDeletes(t, store, ids)
+	verifyMemoryStorePostDelete(t, store)
+}
+
+func seedMemoryStore(t *testing.T, store *memory.Store) memoryIDs {
+	t.Helper()
 	ctx := context.Background()
 
-	var (
-		projectID   string
-		protocolID  string
-		housingID   string
-		cohortID    string
-		breedingID  string
-		procedureID string
-		organismAID string
-		organismBID string
-	)
-
+	var ids memoryIDs
 	if _, err := store.RunInTransaction(ctx, func(tx domain.Transaction) error {
 		if _, err := tx.CreateHousingUnit(domain.HousingUnit{Name: "Invalid", FacilityID: "Lab", Capacity: 0}); err == nil {
 			return fmt.Errorf("expected capacity validation error")
 		}
 
-		project, err := tx.CreateProject(domain.Project{Code: "PRJ-1", Title: "domain.Project"})
-		if err != nil {
-			return err
-		}
-		projectID = project.ID
+		projectVal, err := tx.CreateProject(domain.Project{Code: "PRJ-1", Title: "domain.Project"})
+		project := must(t, projectVal, err)
+		ids.projectID = project.ID
 
-		protocol, err := tx.CreateProtocol(domain.Protocol{Code: "PROT-1", Title: "domain.Protocol", MaxSubjects: 5})
-		if err != nil {
-			return err
-		}
-		protocolID = protocol.ID
-		if _, ok := tx.FindProtocol(protocolID); !ok {
-			return fmt.Errorf("expected to find protocol %s", protocolID)
-		}
-		if _, ok := tx.FindProtocol("missing-protocol"); ok {
-			return fmt.Errorf("unexpected protocol lookup success")
-		}
+		facilityVal, err := tx.CreateFacility(domain.Facility{
+			Name:                 "Vivarium",
+			Zone:                 "Zone-A",
+			AccessPolicy:         "badge-required",
+			EnvironmentBaselines: map[string]any{"temperature": "22C"},
+			ProjectIDs:           []string{ids.projectID},
+		})
+		facility := must(t, facilityVal, err)
+		ids.facilityID = facility.ID
 
-		housing, err := tx.CreateHousingUnit(domain.HousingUnit{Name: "Tank", FacilityID: "Lab", Capacity: 2, Environment: "arid"})
-		if err != nil {
-			return err
+		foundFacility, ok := tx.FindFacility(ids.facilityID)
+		requireFound(t, foundFacility, ok, "expected to find facility")
+		if foundFacility.ID != ids.facilityID {
+			t.Fatalf("unexpected facility returned from lookup")
 		}
-		housingID = housing.ID
+		_, ok = tx.FindFacility("missing-facility")
+		requireMissing(t, ok, "unexpected facility lookup success")
 
-		projectPtr := projectID
-		housingPtr := housingID
-		protocolPtr := protocolID
-
-		cohort, err := tx.CreateCohort(domain.Cohort{Name: "domain.Cohort", Purpose: "Observation", ProjectID: &projectPtr, HousingID: &housingPtr, ProtocolID: &protocolPtr})
-		if err != nil {
-			return err
+		protocolVal, err := tx.CreateProtocol(domain.Protocol{Code: "PROT-1", Title: "domain.Protocol", MaxSubjects: 5})
+		protocol := must(t, protocolVal, err)
+		ids.protocolID = protocol.ID
+		foundProtocol, ok := tx.FindProtocol(ids.protocolID)
+		requireFound(t, foundProtocol, ok, "expected to find protocol")
+		if foundProtocol.Code != "PROT-1" {
+			t.Fatalf("unexpected protocol returned from lookup")
 		}
-		cohortID = cohort.ID
+		_, ok = tx.FindProtocol("missing-protocol")
+		requireMissing(t, ok, "unexpected protocol lookup success")
 
-		cohortPtr := cohortID
+		housingVal, err := tx.CreateHousingUnit(domain.HousingUnit{Name: "Tank", FacilityID: ids.facilityID, Capacity: 2, Environment: "arid"})
+		housing := must(t, housingVal, err)
+		ids.housingID = housing.ID
+		_, err = tx.UpdateFacility(ids.facilityID, func(f *domain.Facility) error {
+			f.HousingUnitIDs = append(f.HousingUnitIDs, ids.housingID)
+			return nil
+		})
+		mustNoErr(t, err)
+		_, ok = tx.FindTreatment("missing-treatment")
+		requireMissing(t, ok, "unexpected treatment lookup success")
+
+		projectPtr := ids.projectID
+		housingPtr := ids.housingID
+		protocolPtr := ids.protocolID
+
+		cohortVal, err := tx.CreateCohort(domain.Cohort{
+			Name:       "domain.Cohort",
+			Purpose:    "Observation",
+			ProjectID:  &projectPtr,
+			HousingID:  &housingPtr,
+			ProtocolID: &protocolPtr,
+		})
+		cohort := must(t, cohortVal, err)
+		ids.cohortID = cohort.ID
+
+		cohortPtr := ids.cohortID
 
 		attrs := map[string]any{"skin_color_index": 5}
-		organismA, err := tx.CreateOrganism(domain.Organism{
+		organismAVal, err := tx.CreateOrganism(domain.Organism{
 			Name:       "Alpha",
 			Species:    "Test Frog",
 			Stage:      domain.StageJuvenile,
@@ -76,78 +119,225 @@ func TestMemoryStoreCRUDAndQueries(t *testing.T) {
 			HousingID:  &housingPtr,
 			Attributes: attrs,
 		})
-		if err != nil {
-			return err
-		}
-		organismAID = organismA.ID
+		organismA := must(t, organismAVal, err)
+		ids.organismAID = organismA.ID
 
 		attrs["skin_color_index"] = 9
 
-		organismB, err := tx.CreateOrganism(domain.Organism{
+		organismBVal, err := tx.CreateOrganism(domain.Organism{
 			Name:     "Beta",
 			Species:  "Test Toad",
 			Stage:    domain.StageAdult,
 			CohortID: &cohortPtr,
 		})
-		if err != nil {
-			return err
-		}
-		organismBID = organismB.ID
+		organismB := must(t, organismBVal, err)
+		ids.organismBID = organismB.ID
 
-		if _, err := tx.CreateOrganism(domain.Organism{Base: domain.Base{ID: organismAID}, Name: "Duplicate"}); err == nil {
+		if _, err := tx.CreateOrganism(domain.Organism{Base: domain.Base{ID: ids.organismAID}, Name: "Duplicate"}); err == nil {
 			return fmt.Errorf("expected duplicate organism error")
 		}
 
-		breeding, err := tx.CreateBreedingUnit(domain.BreedingUnit{
+		breedingVal, err := tx.CreateBreedingUnit(domain.BreedingUnit{
 			Name:       "Pair",
 			Strategy:   "pair",
 			HousingID:  &housingPtr,
 			ProtocolID: &protocolPtr,
-			FemaleIDs:  []string{organismAID},
-			MaleIDs:    []string{organismBID},
+			FemaleIDs:  []string{ids.organismAID},
+			MaleIDs:    []string{ids.organismBID},
 		})
-		if err != nil {
-			return err
-		}
-		breedingID = breeding.ID
+		breeding := must(t, breedingVal, err)
+		ids.breedingID = breeding.ID
 
-		procedure, err := tx.CreateProcedure(domain.Procedure{
+		procedureVal, err := tx.CreateProcedure(domain.Procedure{
 			Name:        "Check",
 			Status:      "scheduled",
 			ScheduledAt: time.Now().Add(time.Minute),
-			ProtocolID:  protocolID,
-			OrganismIDs: []string{organismAID, organismBID},
+			ProtocolID:  ids.protocolID,
+			OrganismIDs: []string{ids.organismAID, ids.organismBID},
 		})
-		if err != nil {
-			return err
+		procedure := must(t, procedureVal, err)
+		ids.procedureID = procedure.ID
+
+		treatmentVal, err := tx.CreateTreatment(domain.Treatment{
+			Name:              "Dose",
+			ProcedureID:       ids.procedureID,
+			OrganismIDs:       []string{ids.organismAID},
+			CohortIDs:         []string{ids.cohortID},
+			DosagePlan:        "10mg/kg",
+			AdministrationLog: []string{"t0: administered"},
+			AdverseEvents:     []string{},
+		})
+		treatment := must(t, treatmentVal, err)
+		ids.treatmentID = treatment.ID
+
+		foundTreatment, ok := tx.FindTreatment(ids.treatmentID)
+		requireFound(t, foundTreatment, ok, "expected to find treatment")
+		if foundTreatment.Name != "Dose" {
+			t.Fatalf("unexpected treatment returned from lookup")
 		}
-		procedureID = procedure.ID
+
+		recorded := time.Now().UTC()
+		observationVal, err := tx.CreateObservation(domain.Observation{
+			ProcedureID: &ids.procedureID,
+			OrganismID:  &ids.organismAID,
+			RecordedAt:  recorded,
+			Observer:    "tech",
+			Data:        map[string]any{"score": 5},
+			Notes:       "baseline",
+		})
+		observation := must(t, observationVal, err)
+		ids.observationID = observation.ID
+
+		foundObservation, ok := tx.FindObservation(ids.observationID)
+		requireFound(t, foundObservation, ok, "expected to find observation")
+		if foundObservation.Observer != "tech" {
+			t.Fatalf("unexpected observation returned from lookup")
+		}
+
+		custody := []domain.SampleCustodyEvent{{Actor: "tech", Location: "bench", Timestamp: time.Now().UTC(), Notes: "collected"}}
+		sampleVal, err := tx.CreateSample(domain.Sample{
+			Identifier:      "S-1",
+			SourceType:      "blood",
+			OrganismID:      &ids.organismAID,
+			FacilityID:      ids.facilityID,
+			CollectedAt:     time.Now().UTC(),
+			Status:          "stored",
+			StorageLocation: "freezer-1",
+			AssayType:       "PCR",
+			ChainOfCustody:  custody,
+			Attributes:      map[string]any{"volume_ml": 1.5},
+		})
+		sample := must(t, sampleVal, err)
+		ids.sampleID = sample.ID
+
+		foundSample, ok := tx.FindSample(ids.sampleID)
+		requireFound(t, foundSample, ok, "expected to find sample")
+		if foundSample.Identifier != "S-1" {
+			t.Fatalf("unexpected sample returned from lookup")
+		}
+		_, ok = tx.FindSample("missing-sample")
+		requireMissing(t, ok, "unexpected sample lookup success")
+
+		permitVal, err := tx.CreatePermit(domain.Permit{
+			PermitNumber:      permitNumberFixture,
+			Authority:         "Agency",
+			ValidFrom:         time.Now().Add(-time.Hour),
+			ValidUntil:        time.Now().Add(24 * time.Hour),
+			AllowedActivities: []string{"collect"},
+			FacilityIDs:       []string{ids.facilityID},
+			ProtocolIDs:       []string{ids.protocolID},
+			Notes:             "initial issuance",
+		})
+		permit := must(t, permitVal, err)
+		ids.permitID = permit.ID
+
+		foundPermit, ok := tx.FindPermit(ids.permitID)
+		requireFound(t, foundPermit, ok, "expected to find permit")
+		if foundPermit.PermitNumber != permitNumberFixture {
+			t.Fatalf("unexpected permit returned from lookup")
+		}
+		_, ok = tx.FindPermit("missing-permit")
+		requireMissing(t, ok, "unexpected permit lookup success")
+
+		expiry := time.Now().Add(48 * time.Hour)
+		supplyVal, err := tx.CreateSupplyItem(domain.SupplyItem{
+			SKU:            "SKU-1",
+			Name:           "Diet Blocks",
+			Description:    "nutrient feed",
+			QuantityOnHand: 100,
+			Unit:           "grams",
+			LotNumber:      "LOT-44",
+			ExpiresAt:      &expiry,
+			FacilityIDs:    []string{ids.facilityID},
+			ProjectIDs:     []string{ids.projectID},
+			ReorderLevel:   20,
+			Attributes:     map[string]any{"supplier": "Acme"},
+		})
+		supply := must(t, supplyVal, err)
+		ids.supplyItemID = supply.ID
+
+		foundSupply, ok := tx.FindSupplyItem(ids.supplyItemID)
+		requireFound(t, foundSupply, ok, "expected to find supply item")
+		if foundSupply.SKU != "SKU-1" {
+			t.Fatalf("unexpected supply item returned from lookup")
+		}
+		_, ok = tx.FindSupplyItem("missing-supply")
+		requireMissing(t, ok, "unexpected supply item lookup success")
 
 		view := tx.Snapshot()
-		if got := len(view.ListOrganisms()); got != 2 {
-			return fmt.Errorf("expected 2 organisms in view, got %d", got)
+		requireLen(t, view.ListOrganisms(), 2, "view organisms count")
+		_, ok = view.FindOrganism("missing")
+		requireMissing(t, ok, "unexpected organism lookup success")
+		_, ok = view.FindHousingUnit("missing")
+		requireMissing(t, ok, "unexpected housing lookup success")
+
+		requireLen(t, view.ListFacilities(), 1, "view facilities count")
+		facilityView, ok := view.FindFacility(ids.facilityID)
+		requireFound(t, facilityView, ok, "expected facility lookup success in view")
+		if facilityView.ID != ids.facilityID {
+			t.Fatalf("facility snapshot mismatch")
 		}
-		if _, ok := view.FindOrganism("missing"); ok {
-			return fmt.Errorf("unexpected organism lookup success")
+		_, ok = view.FindFacility("missing")
+		requireMissing(t, ok, "unexpected facility lookup success in view")
+
+		requireLen(t, view.ListTreatments(), 1, "view treatments count")
+		treatmentView, ok := view.FindTreatment(ids.treatmentID)
+		requireFound(t, treatmentView, ok, "expected treatment lookup success in view")
+		if treatmentView.Name != "Dose" {
+			t.Fatalf("treatment snapshot mismatch")
 		}
-		if _, ok := view.FindHousingUnit("missing"); ok {
-			return fmt.Errorf("unexpected housing lookup success")
+
+		requireLen(t, view.ListObservations(), 1, "view observations count")
+		observationView, ok := view.FindObservation(ids.observationID)
+		requireFound(t, observationView, ok, "expected observation lookup success in view")
+		if observationView.Observer != "tech" {
+			t.Fatalf("observation snapshot mismatch")
 		}
-		if got := len(view.ListProtocols()); got != 1 {
-			return fmt.Errorf("expected 1 protocol in view, got %d", got)
+		_, ok = view.FindObservation("missing")
+		requireMissing(t, ok, "unexpected observation lookup success in view")
+
+		requireLen(t, view.ListSamples(), 1, "view samples count")
+		sampleView, ok := view.FindSample(ids.sampleID)
+		requireFound(t, sampleView, ok, "expected sample lookup success in view")
+		if sampleView.Identifier != "S-1" {
+			t.Fatalf("sample snapshot mismatch")
 		}
+		_, ok = view.FindSample("missing")
+		requireMissing(t, ok, "unexpected sample lookup success in view")
+
+		requireLen(t, view.ListPermits(), 1, "view permits count")
+		permitView, ok := view.FindPermit(ids.permitID)
+		requireFound(t, permitView, ok, "expected permit lookup success in view")
+		if permitView.PermitNumber != permitNumberFixture {
+			t.Fatalf("permit snapshot mismatch")
+		}
+
+		requireLen(t, view.ListProtocols(), 1, "view protocols count")
+		requireLen(t, view.ListProjects(), 1, "view projects count")
+		requireLen(t, view.ListSupplyItems(), 1, "view supply items count")
+		supplyView, ok := view.FindSupplyItem(ids.supplyItemID)
+		requireFound(t, supplyView, ok, "expected supply item lookup success in view")
+		if supplyView.SKU != "SKU-1" {
+			t.Fatalf("supply item snapshot mismatch")
+		}
+
 		return nil
 	}); err != nil {
 		t.Fatalf("create transaction: %v", err)
 	}
 
+	return ids
+}
+
+func verifyMemoryStorePostCreate(t *testing.T, store *memory.Store, ids memoryIDs) {
+	t.Helper()
+
 	organisms := store.ListOrganisms()
-	if len(organisms) != 2 {
-		t.Fatalf("expected 2 organisms, got %d", len(organisms))
-	}
+	requireLen(t, organisms, 2, "organism list length")
+
 	var copyCheckDone bool
 	for _, organism := range organisms {
-		if organism.ID != organismAID {
+		if organism.ID != ids.organismAID {
 			continue
 		}
 		if organism.Attributes["skin_color_index"].(int) != 5 {
@@ -157,30 +347,52 @@ func TestMemoryStoreCRUDAndQueries(t *testing.T) {
 		copyCheckDone = true
 	}
 	if !copyCheckDone {
-		t.Fatalf("organism %s not found in list", organismAID)
+		t.Fatalf("organism %s not found in list", ids.organismAID)
 	}
-	if refreshed, ok := store.GetOrganism(organismAID); !ok {
-		t.Fatalf("expected organism %s to exist", organismAID)
-	} else if refreshed.Attributes["skin_color_index"].(int) != 5 {
+
+	refreshedVal, ok := store.GetOrganism(ids.organismAID)
+	refreshed := mustGet(t, refreshedVal, ok, "expected organism to exist")
+	if refreshed.Attributes["skin_color_index"].(int) != 5 {
 		t.Fatalf("expected store attributes to remain 5, got %v", refreshed.Attributes["skin_color_index"])
 	}
 
 	housingList := store.ListHousingUnits()
-	if len(housingList) != 1 {
-		t.Fatalf("expected 1 housing unit, got %d", len(housingList))
-	}
+	requireLen(t, housingList, 1, "housing list length")
 	housingList[0].Environment = "modified"
-	if stored, ok := store.GetHousingUnit(housingID); !ok {
-		t.Fatalf("expected housing unit %s to exist", housingID)
-	} else if stored.Environment != "arid" {
-		t.Fatalf("expected environment to remain arid, got %s", stored.Environment)
+
+	storedHousingVal, ok := store.GetHousingUnit(ids.housingID)
+	storedHousing := mustGet(t, storedHousingVal, ok, "expected housing unit to exist")
+	if storedHousing.Environment != "arid" {
+		t.Fatalf("expected environment to remain arid, got %s", storedHousing.Environment)
 	}
 
+	facilityVal, ok := store.GetFacility(ids.facilityID)
+	facility := mustGet(t, facilityVal, ok, "expected facility to exist")
+	if facility.AccessPolicy != "badge-required" {
+		t.Fatalf("unexpected access policy %s", facility.AccessPolicy)
+	}
+
+	permitVal, ok := store.GetPermit(ids.permitID)
+	permit := mustGet(t, permitVal, ok, "expected permit to exist")
+	if permit.PermitNumber != permitNumberFixture {
+		t.Fatalf("unexpected permit number %s", permit.PermitNumber)
+	}
+
+	projects := store.ListProjects()
+	requireLen(t, projects, 1, "project list length")
+
+	supplyItems := store.ListSupplyItems()
+	requireLen(t, supplyItems, 1, "supply list length")
+}
+
+func exerciseMemoryUpdates(t *testing.T, store *memory.Store, ids memoryIDs) {
+	t.Helper()
+	ctx := context.Background()
 	if _, err := store.RunInTransaction(ctx, func(tx domain.Transaction) error {
 		if _, err := tx.UpdateOrganism("missing", func(*domain.Organism) error { return nil }); err == nil {
 			return fmt.Errorf("expected update error for missing organism")
 		}
-		if _, err := tx.UpdateHousingUnit(housingID, func(h *domain.HousingUnit) error {
+		if _, err := tx.UpdateHousingUnit(ids.housingID, func(h *domain.HousingUnit) error {
 			h.Capacity = 0
 			return nil
 		}); err == nil {
@@ -189,109 +401,172 @@ func TestMemoryStoreCRUDAndQueries(t *testing.T) {
 		if _, err := tx.UpdateHousingUnit("missing", func(*domain.HousingUnit) error { return nil }); err == nil {
 			return fmt.Errorf("expected missing housing update error")
 		}
+
 		const updatedDesc = "updated"
-		if _, err := tx.UpdateProject(projectID, func(p *domain.Project) error {
+		_, err := tx.UpdateProject(ids.projectID, func(p *domain.Project) error {
 			p.Description = updatedDesc
 			return nil
-		}); err != nil {
-			return err
-		}
-		if _, err := tx.UpdateProtocol(protocolID, func(p *domain.Protocol) error {
+		})
+		mustNoErr(t, err)
+		_, err = tx.UpdateProtocol(ids.protocolID, func(p *domain.Protocol) error {
 			p.Description = updatedDesc
 			return nil
-		}); err != nil {
-			return err
-		}
-		if _, err := tx.UpdateCohort(cohortID, func(c *domain.Cohort) error {
+		})
+		mustNoErr(t, err)
+		_, err = tx.UpdateCohort(ids.cohortID, func(c *domain.Cohort) error {
 			c.Purpose = updatedDesc
 			return nil
-		}); err != nil {
-			return err
-		}
-		if _, err := tx.UpdateBreedingUnit(breedingID, func(b *domain.BreedingUnit) error {
+		})
+		mustNoErr(t, err)
+		_, err = tx.UpdateBreedingUnit(ids.breedingID, func(b *domain.BreedingUnit) error {
 			b.Strategy = updatedDesc
-			b.FemaleIDs = append(b.FemaleIDs, organismBID)
+			b.FemaleIDs = append(b.FemaleIDs, ids.organismBID)
 			return nil
-		}); err != nil {
-			return err
-		}
-		if _, err := tx.UpdateProcedure(procedureID, func(p *domain.Procedure) error {
+		})
+		mustNoErr(t, err)
+		_, err = tx.UpdateProcedure(ids.procedureID, func(p *domain.Procedure) error {
 			p.Status = "completed"
 			return nil
-		}); err != nil {
-			return err
-		}
-		if _, err := tx.UpdateOrganism(organismBID, func(o *domain.Organism) error {
+		})
+		mustNoErr(t, err)
+		_, err = tx.UpdateFacility(ids.facilityID, func(f *domain.Facility) error {
+			f.AccessPolicy = "biosafety-training"
+			if f.EnvironmentBaselines == nil {
+				f.EnvironmentBaselines = map[string]any{}
+			}
+			f.EnvironmentBaselines["humidity"] = "55%"
+			return nil
+		})
+		mustNoErr(t, err)
+		_, err = tx.UpdateTreatment(ids.treatmentID, func(tr *domain.Treatment) error {
+			tr.AdministrationLog = append(tr.AdministrationLog, "t2: follow-up")
+			tr.AdverseEvents = append(tr.AdverseEvents, "minor redness")
+			return nil
+		})
+		mustNoErr(t, err)
+		_, err = tx.UpdateObservation(ids.observationID, func(o *domain.Observation) error {
+			o.Notes = updatedDesc
+			if o.Data == nil {
+				o.Data = map[string]any{}
+			}
+			o.Data["score"] = 6
+			return nil
+		})
+		mustNoErr(t, err)
+		_, err = tx.UpdateSample(ids.sampleID, func(s *domain.Sample) error {
+			s.Status = "consumed"
+			s.ChainOfCustody = append(s.ChainOfCustody, domain.SampleCustodyEvent{Actor: "lab", Location: "analysis", Timestamp: time.Now().UTC()})
+			if s.Attributes == nil {
+				s.Attributes = map[string]any{}
+			}
+			s.Attributes["volume_ml"] = 1.0
+			return nil
+		})
+		mustNoErr(t, err)
+		_, err = tx.UpdatePermit(ids.permitID, func(p *domain.Permit) error {
+			p.Notes = updatedDesc
+			p.AllowedActivities = append(p.AllowedActivities, "dispose")
+			return nil
+		})
+		mustNoErr(t, err)
+		_, err = tx.UpdateSupplyItem(ids.supplyItemID, func(s *domain.SupplyItem) error {
+			s.QuantityOnHand = 80
+			return nil
+		})
+		mustNoErr(t, err)
+		_, err = tx.UpdateOrganism(ids.organismBID, func(o *domain.Organism) error {
 			o.Stage = domain.StageRetired
 			return nil
-		}); err != nil {
-			return err
-		}
+		})
+		mustNoErr(t, err)
 		return nil
 	}); err != nil {
 		t.Fatalf("update transaction: %v", err)
 	}
 
-	if updated, ok := store.GetOrganism(organismBID); !ok {
-		t.Fatalf("expected organism %s", organismBID)
-	} else if updated.Stage != domain.StageRetired {
-		t.Fatalf("expected stage to be retired, got %s", updated.Stage)
+	updatedOrganismVal, ok := store.GetOrganism(ids.organismBID)
+	updatedOrganism := mustGet(t, updatedOrganismVal, ok, "expected organism after update")
+	if updatedOrganism.Stage != domain.StageRetired {
+		t.Fatalf("expected stage to be retired, got %s", updatedOrganism.Stage)
 	}
 
+	facilityVal, ok := store.GetFacility(ids.facilityID)
+	facility := mustGet(t, facilityVal, ok, "expected facility after update")
+	if facility.AccessPolicy != "biosafety-training" {
+		t.Fatalf("expected updated access policy, got %s", facility.AccessPolicy)
+	}
+	if facility.EnvironmentBaselines["humidity"] != "55%" {
+		t.Fatalf("expected humidity baseline to be updated")
+	}
+
+	permitVal, ok := store.GetPermit(ids.permitID)
+	permit := mustGet(t, permitVal, ok, "expected permit after update")
+	if len(permit.AllowedActivities) != 2 {
+		t.Fatalf("expected permit activities to be extended")
+	}
+
+	treatments := store.ListTreatments()
+	requireLen(t, treatments, 1, "treatment list length after update")
+	if len(treatments[0].AdministrationLog) != 2 {
+		t.Fatalf("expected treatment administration log to grow")
+	}
+
+	samples := store.ListSamples()
+	requireLen(t, samples, 1, "sample list length after update")
+	if samples[0].Status != "consumed" {
+		t.Fatalf("expected sample status to be consumed, got %s", samples[0].Status)
+	}
+
+	supplyItems := store.ListSupplyItems()
+	requireLen(t, supplyItems, 1, "supply list length after update")
+	if supplyItems[0].QuantityOnHand != 80 {
+		t.Fatalf("expected supply quantity to change, got %d", supplyItems[0].QuantityOnHand)
+	}
+}
+
+func exerciseMemoryDeletes(t *testing.T, store *memory.Store, ids memoryIDs) {
+	t.Helper()
+	ctx := context.Background()
 	if _, err := store.RunInTransaction(ctx, func(tx domain.Transaction) error {
-		if err := tx.DeleteProcedure(procedureID); err != nil {
-			return err
-		}
-		if err := tx.DeleteBreedingUnit(breedingID); err != nil {
-			return err
-		}
-		if err := tx.DeleteOrganism(organismAID); err != nil {
-			return err
-		}
-		if err := tx.DeleteOrganism(organismBID); err != nil {
-			return err
-		}
-		if err := tx.DeleteCohort(cohortID); err != nil {
-			return err
-		}
-		if err := tx.DeleteHousingUnit(housingID); err != nil {
-			return err
-		}
-		if err := tx.DeleteProtocol(protocolID); err != nil {
-			return err
-		}
-		if err := tx.DeleteProject(projectID); err != nil {
-			return err
-		}
-		if err := tx.DeleteOrganism(organismAID); err == nil {
+		mustNoErr(t, tx.DeleteProcedure(ids.procedureID))
+		mustNoErr(t, tx.DeleteBreedingUnit(ids.breedingID))
+		mustNoErr(t, tx.DeleteOrganism(ids.organismAID))
+		mustNoErr(t, tx.DeleteOrganism(ids.organismBID))
+		mustNoErr(t, tx.DeleteCohort(ids.cohortID))
+		mustNoErr(t, tx.DeleteHousingUnit(ids.housingID))
+		mustNoErr(t, tx.DeleteFacility(ids.facilityID))
+		mustNoErr(t, tx.DeleteProtocol(ids.protocolID))
+		mustNoErr(t, tx.DeleteTreatment(ids.treatmentID))
+		mustNoErr(t, tx.DeleteObservation(ids.observationID))
+		mustNoErr(t, tx.DeleteSample(ids.sampleID))
+		mustNoErr(t, tx.DeletePermit(ids.permitID))
+		mustNoErr(t, tx.DeleteProject(ids.projectID))
+		mustNoErr(t, tx.DeleteSupplyItem(ids.supplyItemID))
+		if err := tx.DeleteOrganism(ids.organismAID); err == nil {
 			return fmt.Errorf("expected delete error for missing organism")
 		}
 		return nil
 	}); err != nil {
 		t.Fatalf("delete transaction: %v", err)
 	}
+}
 
-	if len(store.ListOrganisms()) != 0 {
-		t.Fatalf("expected no organisms after deletion")
-	}
-	if len(store.ListCohorts()) != 0 {
-		t.Fatalf("expected no cohorts after deletion")
-	}
-	if len(store.ListHousingUnits()) != 0 {
-		t.Fatalf("expected no housing units after deletion")
-	}
-	if len(store.ListProtocols()) != 0 {
-		t.Fatalf("expected no protocols after deletion")
-	}
-	if len(store.ListProjects()) != 0 {
-		t.Fatalf("expected no projects after deletion")
-	}
-	if len(store.ListBreedingUnits()) != 0 {
-		t.Fatalf("expected no breeding units after deletion")
-	}
-	if len(store.ListProcedures()) != 0 {
-		t.Fatalf("expected no procedures after deletion")
-	}
+func verifyMemoryStorePostDelete(t *testing.T, store *memory.Store) {
+	t.Helper()
+
+	requireLen(t, store.ListOrganisms(), 0, "organisms after deletion")
+	requireLen(t, store.ListCohorts(), 0, "cohorts after deletion")
+	requireLen(t, store.ListHousingUnits(), 0, "housing units after deletion")
+	requireLen(t, store.ListFacilities(), 0, "facilities after deletion")
+	requireLen(t, store.ListProtocols(), 0, "protocols after deletion")
+	requireLen(t, store.ListProjects(), 0, "projects after deletion")
+	requireLen(t, store.ListBreedingUnits(), 0, "breeding units after deletion")
+	requireLen(t, store.ListProcedures(), 0, "procedures after deletion")
+	requireLen(t, store.ListTreatments(), 0, "treatments after deletion")
+	requireLen(t, store.ListObservations(), 0, "observations after deletion")
+	requireLen(t, store.ListSamples(), 0, "samples after deletion")
+	requireLen(t, store.ListPermits(), 0, "permits after deletion")
+	requireLen(t, store.ListSupplyItems(), 0, "supplies after deletion")
 }
 
 func TestMemoryStoreViewReadOnly(t *testing.T) {
@@ -389,4 +664,45 @@ func (r staticRule) Name() string { return r.name }
 
 func (r staticRule) Evaluate(_ context.Context, _ domain.RuleView, _ []domain.Change) (domain.Result, error) {
 	return domain.Result{Violations: []domain.Violation{{Rule: r.name, Severity: r.severity}}}, nil
+}
+
+func must[T any](t *testing.T, value T, err error) T {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return value
+}
+
+func mustNoErr(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func mustGet[T any](t *testing.T, value T, ok bool, msg string) T {
+	return requireFound(t, value, ok, msg)
+}
+
+func requireFound[T any](t *testing.T, value T, ok bool, msg string) T {
+	t.Helper()
+	if !ok {
+		t.Fatal(msg)
+	}
+	return value
+}
+
+func requireMissing(t *testing.T, ok bool, msg string) {
+	t.Helper()
+	if ok {
+		t.Fatal(msg)
+	}
+}
+
+func requireLen[T any](t *testing.T, items []T, expected int, msg string) {
+	t.Helper()
+	if len(items) != expected {
+		t.Fatalf("%s: expected %d, got %d", msg, expected, len(items))
+	}
 }

--- a/internal/infra/persistence/sqlite/memstore.go
+++ b/internal/infra/persistence/sqlite/memstore.go
@@ -25,12 +25,24 @@ type (
 	HousingUnit = domain.HousingUnit
 	// BreedingUnit is an alias of domain.BreedingUnit.
 	BreedingUnit = domain.BreedingUnit
+	// Facility is an alias of domain.Facility.
+	Facility = domain.Facility
 	// Procedure is an alias of domain.Procedure.
 	Procedure = domain.Procedure
+	// Treatment is an alias of domain.Treatment.
+	Treatment = domain.Treatment
+	// Observation is an alias of domain.Observation.
+	Observation = domain.Observation
+	// Sample is an alias of domain.Sample.
+	Sample = domain.Sample
 	// Protocol is an alias of domain.Protocol.
 	Protocol = domain.Protocol
+	// Permit is an alias of domain.Permit.
+	Permit = domain.Permit
 	// Project is an alias of domain.Project.
 	Project = domain.Project
+	// SupplyItem is an alias of domain.SupplyItem.
+	SupplyItem = domain.SupplyItem
 	// Change is an alias of domain.Change.
 	Change = domain.Change
 	// Result is an alias of domain.Result.
@@ -49,47 +61,71 @@ type (
 // No constant aliases needed - use domain.EntityType, domain.Action values directly
 
 type memoryState struct {
-	organisms  map[string]Organism
-	cohorts    map[string]Cohort
-	housing    map[string]HousingUnit
-	breeding   map[string]BreedingUnit
-	procedures map[string]Procedure
-	protocols  map[string]Protocol
-	projects   map[string]Project
+	organisms    map[string]Organism
+	cohorts      map[string]Cohort
+	housing      map[string]HousingUnit
+	facilities   map[string]Facility
+	breeding     map[string]BreedingUnit
+	procedures   map[string]Procedure
+	treatments   map[string]Treatment
+	observations map[string]Observation
+	samples      map[string]Sample
+	protocols    map[string]Protocol
+	permits      map[string]Permit
+	projects     map[string]Project
+	supplies     map[string]SupplyItem
 }
 
 // Snapshot is the serialisable representation of the in-memory state.
 type Snapshot struct {
-	Organisms  map[string]Organism     `json:"organisms"`
-	Cohorts    map[string]Cohort       `json:"cohorts"`
-	Housing    map[string]HousingUnit  `json:"housing"`
-	Breeding   map[string]BreedingUnit `json:"breeding"`
-	Procedures map[string]Procedure    `json:"procedures"`
-	Protocols  map[string]Protocol     `json:"protocols"`
-	Projects   map[string]Project      `json:"projects"`
+	Organisms    map[string]Organism     `json:"organisms"`
+	Cohorts      map[string]Cohort       `json:"cohorts"`
+	Housing      map[string]HousingUnit  `json:"housing"`
+	Facilities   map[string]Facility     `json:"facilities"`
+	Breeding     map[string]BreedingUnit `json:"breeding"`
+	Procedures   map[string]Procedure    `json:"procedures"`
+	Treatments   map[string]Treatment    `json:"treatments"`
+	Observations map[string]Observation  `json:"observations"`
+	Samples      map[string]Sample       `json:"samples"`
+	Protocols    map[string]Protocol     `json:"protocols"`
+	Permits      map[string]Permit       `json:"permits"`
+	Projects     map[string]Project      `json:"projects"`
+	Supplies     map[string]SupplyItem   `json:"supplies"`
 }
 
 func newMemoryState() memoryState {
 	return memoryState{
-		organisms:  map[string]Organism{},
-		cohorts:    map[string]Cohort{},
-		housing:    map[string]HousingUnit{},
-		breeding:   map[string]BreedingUnit{},
-		procedures: map[string]Procedure{},
-		protocols:  map[string]Protocol{},
-		projects:   map[string]Project{},
+		organisms:    map[string]Organism{},
+		cohorts:      map[string]Cohort{},
+		housing:      map[string]HousingUnit{},
+		facilities:   map[string]Facility{},
+		breeding:     map[string]BreedingUnit{},
+		procedures:   map[string]Procedure{},
+		treatments:   map[string]Treatment{},
+		observations: map[string]Observation{},
+		samples:      map[string]Sample{},
+		protocols:    map[string]Protocol{},
+		permits:      map[string]Permit{},
+		projects:     map[string]Project{},
+		supplies:     map[string]SupplyItem{},
 	}
 }
 
 func snapshotFromMemoryState(state memoryState) Snapshot {
 	s := Snapshot{
-		Organisms:  make(map[string]Organism, len(state.organisms)),
-		Cohorts:    make(map[string]Cohort, len(state.cohorts)),
-		Housing:    make(map[string]HousingUnit, len(state.housing)),
-		Breeding:   make(map[string]BreedingUnit, len(state.breeding)),
-		Procedures: make(map[string]Procedure, len(state.procedures)),
-		Protocols:  make(map[string]Protocol, len(state.protocols)),
-		Projects:   make(map[string]Project, len(state.projects)),
+		Organisms:    make(map[string]Organism, len(state.organisms)),
+		Cohorts:      make(map[string]Cohort, len(state.cohorts)),
+		Housing:      make(map[string]HousingUnit, len(state.housing)),
+		Facilities:   make(map[string]Facility, len(state.facilities)),
+		Breeding:     make(map[string]BreedingUnit, len(state.breeding)),
+		Procedures:   make(map[string]Procedure, len(state.procedures)),
+		Treatments:   make(map[string]Treatment, len(state.treatments)),
+		Observations: make(map[string]Observation, len(state.observations)),
+		Samples:      make(map[string]Sample, len(state.samples)),
+		Protocols:    make(map[string]Protocol, len(state.protocols)),
+		Permits:      make(map[string]Permit, len(state.permits)),
+		Projects:     make(map[string]Project, len(state.projects)),
+		Supplies:     make(map[string]SupplyItem, len(state.supplies)),
 	}
 	for k, v := range state.organisms {
 		s.Organisms[k] = cloneOrganism(v)
@@ -100,17 +136,35 @@ func snapshotFromMemoryState(state memoryState) Snapshot {
 	for k, v := range state.housing {
 		s.Housing[k] = cloneHousing(v)
 	}
+	for k, v := range state.facilities {
+		s.Facilities[k] = cloneFacility(v)
+	}
 	for k, v := range state.breeding {
 		s.Breeding[k] = cloneBreeding(v)
 	}
 	for k, v := range state.procedures {
 		s.Procedures[k] = cloneProcedure(v)
 	}
+	for k, v := range state.treatments {
+		s.Treatments[k] = cloneTreatment(v)
+	}
+	for k, v := range state.observations {
+		s.Observations[k] = cloneObservation(v)
+	}
+	for k, v := range state.samples {
+		s.Samples[k] = cloneSample(v)
+	}
 	for k, v := range state.protocols {
 		s.Protocols[k] = cloneProtocol(v)
 	}
+	for k, v := range state.permits {
+		s.Permits[k] = clonePermit(v)
+	}
 	for k, v := range state.projects {
 		s.Projects[k] = cloneProject(v)
+	}
+	for k, v := range state.supplies {
+		s.Supplies[k] = cloneSupplyItem(v)
 	}
 	return s
 }
@@ -126,17 +180,35 @@ func memoryStateFromSnapshot(s Snapshot) memoryState {
 	for k, v := range s.Housing {
 		st.housing[k] = cloneHousing(v)
 	}
+	for k, v := range s.Facilities {
+		st.facilities[k] = cloneFacility(v)
+	}
 	for k, v := range s.Breeding {
 		st.breeding[k] = cloneBreeding(v)
 	}
 	for k, v := range s.Procedures {
 		st.procedures[k] = cloneProcedure(v)
 	}
+	for k, v := range s.Treatments {
+		st.treatments[k] = cloneTreatment(v)
+	}
+	for k, v := range s.Observations {
+		st.observations[k] = cloneObservation(v)
+	}
+	for k, v := range s.Samples {
+		st.samples[k] = cloneSample(v)
+	}
 	for k, v := range s.Protocols {
 		st.protocols[k] = cloneProtocol(v)
 	}
+	for k, v := range s.Permits {
+		st.permits[k] = clonePermit(v)
+	}
 	for k, v := range s.Projects {
 		st.projects[k] = cloneProject(v)
+	}
+	for k, v := range s.Supplies {
+		st.supplies[k] = cloneSupplyItem(v)
 	}
 	return st
 }
@@ -168,6 +240,76 @@ func cloneProcedure(p Procedure) Procedure {
 }
 func cloneProtocol(p Protocol) Protocol { return p }
 func cloneProject(p Project) Project    { return p }
+
+func cloneFacility(f Facility) Facility {
+	cp := f
+	if f.EnvironmentBaselines != nil {
+		cp.EnvironmentBaselines = make(map[string]any, len(f.EnvironmentBaselines))
+		for k, v := range f.EnvironmentBaselines {
+			cp.EnvironmentBaselines[k] = v
+		}
+	}
+	cp.HousingUnitIDs = append([]string(nil), f.HousingUnitIDs...)
+	cp.ProjectIDs = append([]string(nil), f.ProjectIDs...)
+	return cp
+}
+
+func cloneTreatment(t Treatment) Treatment {
+	cp := t
+	cp.OrganismIDs = append([]string(nil), t.OrganismIDs...)
+	cp.CohortIDs = append([]string(nil), t.CohortIDs...)
+	cp.AdministrationLog = append([]string(nil), t.AdministrationLog...)
+	cp.AdverseEvents = append([]string(nil), t.AdverseEvents...)
+	return cp
+}
+
+func cloneObservation(o Observation) Observation {
+	cp := o
+	if o.Data != nil {
+		cp.Data = make(map[string]any, len(o.Data))
+		for k, v := range o.Data {
+			cp.Data[k] = v
+		}
+	}
+	return cp
+}
+
+func cloneSample(s Sample) Sample {
+	cp := s
+	cp.ChainOfCustody = append([]domain.SampleCustodyEvent(nil), s.ChainOfCustody...)
+	if s.Attributes != nil {
+		cp.Attributes = make(map[string]any, len(s.Attributes))
+		for k, v := range s.Attributes {
+			cp.Attributes[k] = v
+		}
+	}
+	return cp
+}
+
+func clonePermit(p Permit) Permit {
+	cp := p
+	cp.AllowedActivities = append([]string(nil), p.AllowedActivities...)
+	cp.FacilityIDs = append([]string(nil), p.FacilityIDs...)
+	cp.ProtocolIDs = append([]string(nil), p.ProtocolIDs...)
+	return cp
+}
+
+func cloneSupplyItem(s SupplyItem) SupplyItem {
+	cp := s
+	if s.ExpiresAt != nil {
+		t := *s.ExpiresAt
+		cp.ExpiresAt = &t
+	}
+	cp.FacilityIDs = append([]string(nil), s.FacilityIDs...)
+	cp.ProjectIDs = append([]string(nil), s.ProjectIDs...)
+	if s.Attributes != nil {
+		cp.Attributes = make(map[string]any, len(s.Attributes))
+		for k, v := range s.Attributes {
+			cp.Attributes[k] = v
+		}
+	}
+	return cp
+}
 
 type memStore struct {
 	mu     sync.RWMutex
@@ -225,6 +367,13 @@ func (v transactionView) ListHousingUnits() []HousingUnit {
 	}
 	return out
 }
+func (v transactionView) ListFacilities() []Facility {
+	out := make([]Facility, 0, len(v.state.facilities))
+	for _, f := range v.state.facilities {
+		out = append(out, cloneFacility(f))
+	}
+	return out
+}
 func (v transactionView) FindOrganism(id string) (Organism, bool) {
 	o, ok := v.state.organisms[id]
 	if !ok {
@@ -239,12 +388,96 @@ func (v transactionView) FindHousingUnit(id string) (HousingUnit, bool) {
 	}
 	return cloneHousing(h), true
 }
+func (v transactionView) FindFacility(id string) (Facility, bool) {
+	f, ok := v.state.facilities[id]
+	if !ok {
+		return Facility{}, false
+	}
+	return cloneFacility(f), true
+}
 func (v transactionView) ListProtocols() []Protocol {
 	out := make([]Protocol, 0, len(v.state.protocols))
 	for _, p := range v.state.protocols {
 		out = append(out, cloneProtocol(p))
 	}
 	return out
+}
+func (v transactionView) ListTreatments() []Treatment {
+	out := make([]Treatment, 0, len(v.state.treatments))
+	for _, t := range v.state.treatments {
+		out = append(out, cloneTreatment(t))
+	}
+	return out
+}
+func (v transactionView) FindTreatment(id string) (Treatment, bool) {
+	t, ok := v.state.treatments[id]
+	if !ok {
+		return Treatment{}, false
+	}
+	return cloneTreatment(t), true
+}
+func (v transactionView) ListObservations() []Observation {
+	out := make([]Observation, 0, len(v.state.observations))
+	for _, o := range v.state.observations {
+		out = append(out, cloneObservation(o))
+	}
+	return out
+}
+func (v transactionView) FindObservation(id string) (Observation, bool) {
+	o, ok := v.state.observations[id]
+	if !ok {
+		return Observation{}, false
+	}
+	return cloneObservation(o), true
+}
+func (v transactionView) ListSamples() []Sample {
+	out := make([]Sample, 0, len(v.state.samples))
+	for _, s := range v.state.samples {
+		out = append(out, cloneSample(s))
+	}
+	return out
+}
+func (v transactionView) FindSample(id string) (Sample, bool) {
+	s, ok := v.state.samples[id]
+	if !ok {
+		return Sample{}, false
+	}
+	return cloneSample(s), true
+}
+func (v transactionView) ListPermits() []Permit {
+	out := make([]Permit, 0, len(v.state.permits))
+	for _, p := range v.state.permits {
+		out = append(out, clonePermit(p))
+	}
+	return out
+}
+func (v transactionView) FindPermit(id string) (Permit, bool) {
+	p, ok := v.state.permits[id]
+	if !ok {
+		return Permit{}, false
+	}
+	return clonePermit(p), true
+}
+func (v transactionView) ListProjects() []Project {
+	out := make([]Project, 0, len(v.state.projects))
+	for _, p := range v.state.projects {
+		out = append(out, cloneProject(p))
+	}
+	return out
+}
+func (v transactionView) ListSupplyItems() []SupplyItem {
+	out := make([]SupplyItem, 0, len(v.state.supplies))
+	for _, s := range v.state.supplies {
+		out = append(out, cloneSupplyItem(s))
+	}
+	return out
+}
+func (v transactionView) FindSupplyItem(id string) (SupplyItem, bool) {
+	s, ok := v.state.supplies[id]
+	if !ok {
+		return SupplyItem{}, false
+	}
+	return cloneSupplyItem(s), true
 }
 
 func (s *memStore) RunInTransaction(ctx context.Context, fn func(tx Transaction) error) (Result, error) {
@@ -292,6 +525,48 @@ func (tx *transaction) FindProtocol(id string) (Protocol, bool) {
 		return Protocol{}, false
 	}
 	return cloneProtocol(p), true
+}
+func (tx *transaction) FindFacility(id string) (Facility, bool) {
+	f, ok := tx.state.facilities[id]
+	if !ok {
+		return Facility{}, false
+	}
+	return cloneFacility(f), true
+}
+func (tx *transaction) FindTreatment(id string) (Treatment, bool) {
+	t, ok := tx.state.treatments[id]
+	if !ok {
+		return Treatment{}, false
+	}
+	return cloneTreatment(t), true
+}
+func (tx *transaction) FindObservation(id string) (Observation, bool) {
+	o, ok := tx.state.observations[id]
+	if !ok {
+		return Observation{}, false
+	}
+	return cloneObservation(o), true
+}
+func (tx *transaction) FindSample(id string) (Sample, bool) {
+	s, ok := tx.state.samples[id]
+	if !ok {
+		return Sample{}, false
+	}
+	return cloneSample(s), true
+}
+func (tx *transaction) FindPermit(id string) (Permit, bool) {
+	p, ok := tx.state.permits[id]
+	if !ok {
+		return Permit{}, false
+	}
+	return clonePermit(p), true
+}
+func (tx *transaction) FindSupplyItem(id string) (SupplyItem, bool) {
+	s, ok := tx.state.supplies[id]
+	if !ok {
+		return SupplyItem{}, false
+	}
+	return cloneSupplyItem(s), true
 }
 func (tx *transaction) CreateOrganism(o Organism) (Organism, error) {
 	if o.ID == "" {
@@ -413,6 +688,49 @@ func (tx *transaction) DeleteHousingUnit(id string) error {
 	tx.recordChange(Change{Entity: domain.EntityHousingUnit, Action: domain.ActionDelete, Before: cloneHousing(current)})
 	return nil
 }
+func (tx *transaction) CreateFacility(f Facility) (Facility, error) {
+	if f.ID == "" {
+		f.ID = tx.store.newID()
+	}
+	if _, exists := tx.state.facilities[f.ID]; exists {
+		return Facility{}, fmt.Errorf("facility %q already exists", f.ID)
+	}
+	f.CreatedAt = tx.now
+	f.UpdatedAt = tx.now
+	if f.EnvironmentBaselines == nil {
+		f.EnvironmentBaselines = map[string]any{}
+	}
+	tx.state.facilities[f.ID] = cloneFacility(f)
+	tx.recordChange(Change{Entity: domain.EntityFacility, Action: domain.ActionCreate, After: cloneFacility(f)})
+	return cloneFacility(f), nil
+}
+func (tx *transaction) UpdateFacility(id string, mutator func(*Facility) error) (Facility, error) {
+	current, ok := tx.state.facilities[id]
+	if !ok {
+		return Facility{}, fmt.Errorf("facility %q not found", id)
+	}
+	before := cloneFacility(current)
+	if err := mutator(&current); err != nil {
+		return Facility{}, err
+	}
+	if current.EnvironmentBaselines == nil {
+		current.EnvironmentBaselines = map[string]any{}
+	}
+	current.ID = id
+	current.UpdatedAt = tx.now
+	tx.state.facilities[id] = cloneFacility(current)
+	tx.recordChange(Change{Entity: domain.EntityFacility, Action: domain.ActionUpdate, Before: before, After: cloneFacility(current)})
+	return cloneFacility(current), nil
+}
+func (tx *transaction) DeleteFacility(id string) error {
+	current, ok := tx.state.facilities[id]
+	if !ok {
+		return fmt.Errorf("facility %q not found", id)
+	}
+	delete(tx.state.facilities, id)
+	tx.recordChange(Change{Entity: domain.EntityFacility, Action: domain.ActionDelete, Before: cloneFacility(current)})
+	return nil
+}
 func (tx *transaction) CreateBreedingUnit(b BreedingUnit) (BreedingUnit, error) {
 	if b.ID == "" {
 		b.ID = tx.store.newID()
@@ -487,6 +805,129 @@ func (tx *transaction) DeleteProcedure(id string) error {
 	tx.recordChange(Change{Entity: domain.EntityProcedure, Action: domain.ActionDelete, Before: cloneProcedure(current)})
 	return nil
 }
+func (tx *transaction) CreateTreatment(t Treatment) (Treatment, error) {
+	if t.ID == "" {
+		t.ID = tx.store.newID()
+	}
+	if _, exists := tx.state.treatments[t.ID]; exists {
+		return Treatment{}, fmt.Errorf("treatment %q already exists", t.ID)
+	}
+	t.CreatedAt = tx.now
+	t.UpdatedAt = tx.now
+	tx.state.treatments[t.ID] = cloneTreatment(t)
+	tx.recordChange(Change{Entity: domain.EntityTreatment, Action: domain.ActionCreate, After: cloneTreatment(t)})
+	return cloneTreatment(t), nil
+}
+func (tx *transaction) UpdateTreatment(id string, mutator func(*Treatment) error) (Treatment, error) {
+	current, ok := tx.state.treatments[id]
+	if !ok {
+		return Treatment{}, fmt.Errorf("treatment %q not found", id)
+	}
+	before := cloneTreatment(current)
+	if err := mutator(&current); err != nil {
+		return Treatment{}, err
+	}
+	current.ID = id
+	current.UpdatedAt = tx.now
+	tx.state.treatments[id] = cloneTreatment(current)
+	tx.recordChange(Change{Entity: domain.EntityTreatment, Action: domain.ActionUpdate, Before: before, After: cloneTreatment(current)})
+	return cloneTreatment(current), nil
+}
+func (tx *transaction) DeleteTreatment(id string) error {
+	current, ok := tx.state.treatments[id]
+	if !ok {
+		return fmt.Errorf("treatment %q not found", id)
+	}
+	delete(tx.state.treatments, id)
+	tx.recordChange(Change{Entity: domain.EntityTreatment, Action: domain.ActionDelete, Before: cloneTreatment(current)})
+	return nil
+}
+func (tx *transaction) CreateObservation(o Observation) (Observation, error) {
+	if o.ID == "" {
+		o.ID = tx.store.newID()
+	}
+	if _, exists := tx.state.observations[o.ID]; exists {
+		return Observation{}, fmt.Errorf("observation %q already exists", o.ID)
+	}
+	o.CreatedAt = tx.now
+	o.UpdatedAt = tx.now
+	if o.Data == nil {
+		o.Data = map[string]any{}
+	}
+	tx.state.observations[o.ID] = cloneObservation(o)
+	tx.recordChange(Change{Entity: domain.EntityObservation, Action: domain.ActionCreate, After: cloneObservation(o)})
+	return cloneObservation(o), nil
+}
+func (tx *transaction) UpdateObservation(id string, mutator func(*Observation) error) (Observation, error) {
+	current, ok := tx.state.observations[id]
+	if !ok {
+		return Observation{}, fmt.Errorf("observation %q not found", id)
+	}
+	before := cloneObservation(current)
+	if err := mutator(&current); err != nil {
+		return Observation{}, err
+	}
+	if current.Data == nil {
+		current.Data = map[string]any{}
+	}
+	current.ID = id
+	current.UpdatedAt = tx.now
+	tx.state.observations[id] = cloneObservation(current)
+	tx.recordChange(Change{Entity: domain.EntityObservation, Action: domain.ActionUpdate, Before: before, After: cloneObservation(current)})
+	return cloneObservation(current), nil
+}
+func (tx *transaction) DeleteObservation(id string) error {
+	current, ok := tx.state.observations[id]
+	if !ok {
+		return fmt.Errorf("observation %q not found", id)
+	}
+	delete(tx.state.observations, id)
+	tx.recordChange(Change{Entity: domain.EntityObservation, Action: domain.ActionDelete, Before: cloneObservation(current)})
+	return nil
+}
+func (tx *transaction) CreateSample(s Sample) (Sample, error) {
+	if s.ID == "" {
+		s.ID = tx.store.newID()
+	}
+	if _, exists := tx.state.samples[s.ID]; exists {
+		return Sample{}, fmt.Errorf("sample %q already exists", s.ID)
+	}
+	s.CreatedAt = tx.now
+	s.UpdatedAt = tx.now
+	if s.Attributes == nil {
+		s.Attributes = map[string]any{}
+	}
+	tx.state.samples[s.ID] = cloneSample(s)
+	tx.recordChange(Change{Entity: domain.EntitySample, Action: domain.ActionCreate, After: cloneSample(s)})
+	return cloneSample(s), nil
+}
+func (tx *transaction) UpdateSample(id string, mutator func(*Sample) error) (Sample, error) {
+	current, ok := tx.state.samples[id]
+	if !ok {
+		return Sample{}, fmt.Errorf("sample %q not found", id)
+	}
+	before := cloneSample(current)
+	if err := mutator(&current); err != nil {
+		return Sample{}, err
+	}
+	if current.Attributes == nil {
+		current.Attributes = map[string]any{}
+	}
+	current.ID = id
+	current.UpdatedAt = tx.now
+	tx.state.samples[id] = cloneSample(current)
+	tx.recordChange(Change{Entity: domain.EntitySample, Action: domain.ActionUpdate, Before: before, After: cloneSample(current)})
+	return cloneSample(current), nil
+}
+func (tx *transaction) DeleteSample(id string) error {
+	current, ok := tx.state.samples[id]
+	if !ok {
+		return fmt.Errorf("sample %q not found", id)
+	}
+	delete(tx.state.samples, id)
+	tx.recordChange(Change{Entity: domain.EntitySample, Action: domain.ActionDelete, Before: cloneSample(current)})
+	return nil
+}
 func (tx *transaction) CreateProtocol(p Protocol) (Protocol, error) {
 	if p.ID == "" {
 		p.ID = tx.store.newID()
@@ -522,6 +963,43 @@ func (tx *transaction) DeleteProtocol(id string) error {
 	}
 	delete(tx.state.protocols, id)
 	tx.recordChange(Change{Entity: domain.EntityProtocol, Action: domain.ActionDelete, Before: cloneProtocol(current)})
+	return nil
+}
+func (tx *transaction) CreatePermit(p Permit) (Permit, error) {
+	if p.ID == "" {
+		p.ID = tx.store.newID()
+	}
+	if _, exists := tx.state.permits[p.ID]; exists {
+		return Permit{}, fmt.Errorf("permit %q already exists", p.ID)
+	}
+	p.CreatedAt = tx.now
+	p.UpdatedAt = tx.now
+	tx.state.permits[p.ID] = clonePermit(p)
+	tx.recordChange(Change{Entity: domain.EntityPermit, Action: domain.ActionCreate, After: clonePermit(p)})
+	return clonePermit(p), nil
+}
+func (tx *transaction) UpdatePermit(id string, mutator func(*Permit) error) (Permit, error) {
+	current, ok := tx.state.permits[id]
+	if !ok {
+		return Permit{}, fmt.Errorf("permit %q not found", id)
+	}
+	before := clonePermit(current)
+	if err := mutator(&current); err != nil {
+		return Permit{}, err
+	}
+	current.ID = id
+	current.UpdatedAt = tx.now
+	tx.state.permits[id] = clonePermit(current)
+	tx.recordChange(Change{Entity: domain.EntityPermit, Action: domain.ActionUpdate, Before: before, After: clonePermit(current)})
+	return clonePermit(current), nil
+}
+func (tx *transaction) DeletePermit(id string) error {
+	current, ok := tx.state.permits[id]
+	if !ok {
+		return fmt.Errorf("permit %q not found", id)
+	}
+	delete(tx.state.permits, id)
+	tx.recordChange(Change{Entity: domain.EntityPermit, Action: domain.ActionDelete, Before: clonePermit(current)})
 	return nil
 }
 func (tx *transaction) CreateProject(p Project) (Project, error) {
@@ -561,6 +1039,53 @@ func (tx *transaction) DeleteProject(id string) error {
 	tx.recordChange(Change{Entity: domain.EntityProject, Action: domain.ActionDelete, Before: cloneProject(current)})
 	return nil
 }
+func (tx *transaction) CreateSupplyItem(s SupplyItem) (SupplyItem, error) {
+	if s.ID == "" {
+		s.ID = tx.store.newID()
+	}
+	if _, exists := tx.state.supplies[s.ID]; exists {
+		return SupplyItem{}, fmt.Errorf("supply item %q already exists", s.ID)
+	}
+	s.CreatedAt = tx.now
+	s.UpdatedAt = tx.now
+	if s.Attributes == nil {
+		s.Attributes = map[string]any{}
+	}
+	tx.state.supplies[s.ID] = cloneSupplyItem(s)
+	tx.recordChange(Change{Entity: domain.EntitySupplyItem, Action: domain.ActionCreate, After: cloneSupplyItem(s)})
+	return cloneSupplyItem(s), nil
+}
+func (tx *transaction) UpdateSupplyItem(id string, mutator func(*SupplyItem) error) (SupplyItem, error) {
+	current, ok := tx.state.supplies[id]
+	if !ok {
+		return SupplyItem{}, fmt.Errorf("supply item %q not found", id)
+	}
+	before := cloneSupplyItem(current)
+	if err := mutator(&current); err != nil {
+		return SupplyItem{}, err
+	}
+	if current.Attributes == nil {
+		current.Attributes = map[string]any{}
+	}
+	if current.ExpiresAt != nil {
+		t := *current.ExpiresAt
+		current.ExpiresAt = &t
+	}
+	current.ID = id
+	current.UpdatedAt = tx.now
+	tx.state.supplies[id] = cloneSupplyItem(current)
+	tx.recordChange(Change{Entity: domain.EntitySupplyItem, Action: domain.ActionUpdate, Before: before, After: cloneSupplyItem(current)})
+	return cloneSupplyItem(current), nil
+}
+func (tx *transaction) DeleteSupplyItem(id string) error {
+	current, ok := tx.state.supplies[id]
+	if !ok {
+		return fmt.Errorf("supply item %q not found", id)
+	}
+	delete(tx.state.supplies, id)
+	tx.recordChange(Change{Entity: domain.EntitySupplyItem, Action: domain.ActionDelete, Before: cloneSupplyItem(current)})
+	return nil
+}
 func (s *memStore) GetOrganism(id string) (Organism, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -597,6 +1122,24 @@ func (s *memStore) ListHousingUnits() []HousingUnit {
 	}
 	return out
 }
+func (s *memStore) GetFacility(id string) (Facility, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	f, ok := s.state.facilities[id]
+	if !ok {
+		return Facility{}, false
+	}
+	return cloneFacility(f), true
+}
+func (s *memStore) ListFacilities() []Facility {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Facility, 0, len(s.state.facilities))
+	for _, f := range s.state.facilities {
+		out = append(out, cloneFacility(f))
+	}
+	return out
+}
 func (s *memStore) ListCohorts() []Cohort {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -612,6 +1155,51 @@ func (s *memStore) ListProtocols() []Protocol {
 	out := make([]Protocol, 0, len(s.state.protocols))
 	for _, p := range s.state.protocols {
 		out = append(out, cloneProtocol(p))
+	}
+	return out
+}
+func (s *memStore) ListTreatments() []Treatment {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Treatment, 0, len(s.state.treatments))
+	for _, t := range s.state.treatments {
+		out = append(out, cloneTreatment(t))
+	}
+	return out
+}
+func (s *memStore) ListObservations() []Observation {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Observation, 0, len(s.state.observations))
+	for _, o := range s.state.observations {
+		out = append(out, cloneObservation(o))
+	}
+	return out
+}
+func (s *memStore) ListSamples() []Sample {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Sample, 0, len(s.state.samples))
+	for _, sample := range s.state.samples {
+		out = append(out, cloneSample(sample))
+	}
+	return out
+}
+func (s *memStore) GetPermit(id string) (Permit, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	p, ok := s.state.permits[id]
+	if !ok {
+		return Permit{}, false
+	}
+	return clonePermit(p), true
+}
+func (s *memStore) ListPermits() []Permit {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Permit, 0, len(s.state.permits))
+	for _, p := range s.state.permits {
+		out = append(out, clonePermit(p))
 	}
 	return out
 }
@@ -639,6 +1227,15 @@ func (s *memStore) ListProcedures() []Procedure {
 	out := make([]Procedure, 0, len(s.state.procedures))
 	for _, p := range s.state.procedures {
 		out = append(out, cloneProcedure(p))
+	}
+	return out
+}
+func (s *memStore) ListSupplyItems() []SupplyItem {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]SupplyItem, 0, len(s.state.supplies))
+	for _, sitem := range s.state.supplies {
+		out = append(out, cloneSupplyItem(sitem))
 	}
 	return out
 }

--- a/internal/infra/persistence/sqlite/memstore_test.go
+++ b/internal/infra/persistence/sqlite/memstore_test.go
@@ -60,6 +60,7 @@ func TestMemStoreCRUDReduced(t *testing.T) {
 	store := newMemStore(nil)
 	ctx := context.Background()
 	var projectID string
+	const updatedDesc = "updated"
 	if _, err := store.RunInTransaction(ctx, func(tx domain.Transaction) error {
 		proj, err := tx.CreateProject(domain.Project{Code: "PRJ", Title: "Project"})
 		if err != nil {
@@ -77,7 +78,10 @@ func TestMemStoreCRUDReduced(t *testing.T) {
 		t.Fatalf("expected 1 project, got %d", got)
 	}
 	if _, err := store.RunInTransaction(ctx, func(tx domain.Transaction) error {
-		if _, err := tx.UpdateProject(projectID, func(p *domain.Project) error { p.Description = "updated"; return nil }); err != nil {
+		if _, err := tx.UpdateProject(projectID, func(p *domain.Project) error {
+			p.Description = updatedDesc
+			return nil
+		}); err != nil {
 			return err
 		}
 		return tx.DeleteProject(projectID)

--- a/pkg/domain/persistence.go
+++ b/pkg/domain/persistence.go
@@ -15,29 +15,66 @@ type Transaction interface {
 	CreateHousingUnit(HousingUnit) (HousingUnit, error)
 	UpdateHousingUnit(id string, mutator func(*HousingUnit) error) (HousingUnit, error)
 	DeleteHousingUnit(id string) error
+	CreateFacility(Facility) (Facility, error)
+	UpdateFacility(id string, mutator func(*Facility) error) (Facility, error)
+	DeleteFacility(id string) error
 	CreateBreedingUnit(BreedingUnit) (BreedingUnit, error)
 	UpdateBreedingUnit(id string, mutator func(*BreedingUnit) error) (BreedingUnit, error)
 	DeleteBreedingUnit(id string) error
 	CreateProcedure(Procedure) (Procedure, error)
 	UpdateProcedure(id string, mutator func(*Procedure) error) (Procedure, error)
 	DeleteProcedure(id string) error
+	CreateTreatment(Treatment) (Treatment, error)
+	UpdateTreatment(id string, mutator func(*Treatment) error) (Treatment, error)
+	DeleteTreatment(id string) error
+	CreateObservation(Observation) (Observation, error)
+	UpdateObservation(id string, mutator func(*Observation) error) (Observation, error)
+	DeleteObservation(id string) error
+	CreateSample(Sample) (Sample, error)
+	UpdateSample(id string, mutator func(*Sample) error) (Sample, error)
+	DeleteSample(id string) error
 	CreateProtocol(Protocol) (Protocol, error)
 	UpdateProtocol(id string, mutator func(*Protocol) error) (Protocol, error)
 	DeleteProtocol(id string) error
+	CreatePermit(Permit) (Permit, error)
+	UpdatePermit(id string, mutator func(*Permit) error) (Permit, error)
+	DeletePermit(id string) error
 	CreateProject(Project) (Project, error)
 	UpdateProject(id string, mutator func(*Project) error) (Project, error)
 	DeleteProject(id string) error
+	CreateSupplyItem(SupplyItem) (SupplyItem, error)
+	UpdateSupplyItem(id string, mutator func(*SupplyItem) error) (SupplyItem, error)
+	DeleteSupplyItem(id string) error
 	FindHousingUnit(id string) (HousingUnit, bool)
 	FindProtocol(id string) (Protocol, bool)
+	FindFacility(id string) (Facility, bool)
+	FindTreatment(id string) (Treatment, bool)
+	FindObservation(id string) (Observation, bool)
+	FindSample(id string) (Sample, bool)
+	FindPermit(id string) (Permit, bool)
+	FindSupplyItem(id string) (SupplyItem, bool)
 }
 
 // TransactionView provides read-only access to snapshot data for rules.
 type TransactionView interface {
 	ListOrganisms() []Organism
 	ListHousingUnits() []HousingUnit
+	ListFacilities() []Facility
 	FindOrganism(id string) (Organism, bool)
 	FindHousingUnit(id string) (HousingUnit, bool)
+	FindFacility(id string) (Facility, bool)
+	ListTreatments() []Treatment
+	ListObservations() []Observation
+	ListSamples() []Sample
 	ListProtocols() []Protocol
+	ListPermits() []Permit
+	ListProjects() []Project
+	ListSupplyItems() []SupplyItem
+	FindTreatment(id string) (Treatment, bool)
+	FindObservation(id string) (Observation, bool)
+	FindSample(id string) (Sample, bool)
+	FindPermit(id string) (Permit, bool)
+	FindSupplyItem(id string) (SupplyItem, bool)
 }
 
 // PersistentStore is a minimal abstraction over durable backends. It mirrors
@@ -49,9 +86,17 @@ type PersistentStore interface {
 	ListOrganisms() []Organism
 	GetHousingUnit(id string) (HousingUnit, bool)
 	ListHousingUnits() []HousingUnit
+	GetFacility(id string) (Facility, bool)
+	ListFacilities() []Facility
 	ListCohorts() []Cohort
+	ListTreatments() []Treatment
+	ListObservations() []Observation
+	ListSamples() []Sample
 	ListProtocols() []Protocol
+	GetPermit(id string) (Permit, bool)
+	ListPermits() []Permit
 	ListProjects() []Project
 	ListBreedingUnits() []BreedingUnit
 	ListProcedures() []Procedure
+	ListSupplyItems() []SupplyItem
 }


### PR DESCRIPTION
## What  
<!-- Describe the change. -->

Extend domain persistence contracts with `facility`, `treatment`, `observation`, `sample`, `permit`, and supply item CRUD/find surface.

Align memory and SQLite stores (code + tests) with the expanded contract.

## Why  
<!-- What's the motivation. -->

RFC‑0001 requires these entities to be first-class in the core module.

Downstream services/plugins need consistent access to enforce compliance and rules.

Working on #66 

## How  
<!-- Bullet list or description of key changes. -->

* Add new methods to `pkg/domain/persistence.go` and propagate through adapters/tests.
* Expand memory store state, cloning, transactional CRUD, and read helpers.
* Mirror the same entity support in SQLite memstore implementation and tests.
* Refactor persistence tests to cover new branches while keeping lint happy.

## Notes  
<!-- Breaking changes or follow-ups (if any). -->

No breaking API changes.

## Checklist  

- [x] I have used conventional commits (conventionalcommits.com)
- [ ] I have updated the documentation
- [ ] I have updated the relevant RFC and its linked resources
- [x] I have added tests
- [x] I ran manual tests