### PR TITLE
feat(core): add CRUD for added core entities

### DIFF
--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -142,6 +142,35 @@ func (s *Service) CreateProtocol(ctx context.Context, protocol domain.Protocol) 
 	return created, res, err
 }
 
+// CreateFacility persists facility metadata.
+func (s *Service) CreateFacility(ctx context.Context, facility domain.Facility) (domain.Facility, domain.Result, error) {
+	var created domain.Facility
+	res, err := s.run(ctx, "create_facility", func(tx domain.Transaction) error {
+		var innerErr error
+		created, innerErr = tx.CreateFacility(facility)
+		return innerErr
+	})
+	return created, res, err
+}
+
+// UpdateFacility mutates a facility record.
+func (s *Service) UpdateFacility(ctx context.Context, id string, mutator func(*domain.Facility) error) (domain.Facility, domain.Result, error) {
+	var updated domain.Facility
+	res, err := s.run(ctx, "update_facility", func(tx domain.Transaction) error {
+		var innerErr error
+		updated, innerErr = tx.UpdateFacility(id, mutator)
+		return innerErr
+	})
+	return updated, res, err
+}
+
+// DeleteFacility removes a facility.
+func (s *Service) DeleteFacility(ctx context.Context, id string) (domain.Result, error) {
+	return s.run(ctx, "delete_facility", func(tx domain.Transaction) error {
+		return tx.DeleteFacility(id)
+	})
+}
+
 // CreateHousingUnit persists housing metadata.
 func (s *Service) CreateHousingUnit(ctx context.Context, housing domain.HousingUnit) (domain.HousingUnit, domain.Result, error) {
 	var created domain.HousingUnit
@@ -264,6 +293,151 @@ func (s *Service) UpdateProcedure(ctx context.Context, id string, mutator func(*
 func (s *Service) DeleteProcedure(ctx context.Context, id string) (domain.Result, error) {
 	return s.run(ctx, "delete_procedure", func(tx domain.Transaction) error {
 		return tx.DeleteProcedure(id)
+	})
+}
+
+// CreateTreatment persists a treatment record.
+func (s *Service) CreateTreatment(ctx context.Context, treatment domain.Treatment) (domain.Treatment, domain.Result, error) {
+	var created domain.Treatment
+	res, err := s.run(ctx, "create_treatment", func(tx domain.Transaction) error {
+		var innerErr error
+		created, innerErr = tx.CreateTreatment(treatment)
+		return innerErr
+	})
+	return created, res, err
+}
+
+// UpdateTreatment mutates a treatment record.
+func (s *Service) UpdateTreatment(ctx context.Context, id string, mutator func(*domain.Treatment) error) (domain.Treatment, domain.Result, error) {
+	var updated domain.Treatment
+	res, err := s.run(ctx, "update_treatment", func(tx domain.Transaction) error {
+		var innerErr error
+		updated, innerErr = tx.UpdateTreatment(id, mutator)
+		return innerErr
+	})
+	return updated, res, err
+}
+
+// DeleteTreatment removes a treatment.
+func (s *Service) DeleteTreatment(ctx context.Context, id string) (domain.Result, error) {
+	return s.run(ctx, "delete_treatment", func(tx domain.Transaction) error {
+		return tx.DeleteTreatment(id)
+	})
+}
+
+// CreateObservation persists an observation.
+func (s *Service) CreateObservation(ctx context.Context, observation domain.Observation) (domain.Observation, domain.Result, error) {
+	var created domain.Observation
+	res, err := s.run(ctx, "create_observation", func(tx domain.Transaction) error {
+		var innerErr error
+		created, innerErr = tx.CreateObservation(observation)
+		return innerErr
+	})
+	return created, res, err
+}
+
+// UpdateObservation mutates an observation.
+func (s *Service) UpdateObservation(ctx context.Context, id string, mutator func(*domain.Observation) error) (domain.Observation, domain.Result, error) {
+	var updated domain.Observation
+	res, err := s.run(ctx, "update_observation", func(tx domain.Transaction) error {
+		var innerErr error
+		updated, innerErr = tx.UpdateObservation(id, mutator)
+		return innerErr
+	})
+	return updated, res, err
+}
+
+// DeleteObservation removes an observation.
+func (s *Service) DeleteObservation(ctx context.Context, id string) (domain.Result, error) {
+	return s.run(ctx, "delete_observation", func(tx domain.Transaction) error {
+		return tx.DeleteObservation(id)
+	})
+}
+
+// CreateSample persists a sample.
+func (s *Service) CreateSample(ctx context.Context, sample domain.Sample) (domain.Sample, domain.Result, error) {
+	var created domain.Sample
+	res, err := s.run(ctx, "create_sample", func(tx domain.Transaction) error {
+		var innerErr error
+		created, innerErr = tx.CreateSample(sample)
+		return innerErr
+	})
+	return created, res, err
+}
+
+// UpdateSample mutates a sample record.
+func (s *Service) UpdateSample(ctx context.Context, id string, mutator func(*domain.Sample) error) (domain.Sample, domain.Result, error) {
+	var updated domain.Sample
+	res, err := s.run(ctx, "update_sample", func(tx domain.Transaction) error {
+		var innerErr error
+		updated, innerErr = tx.UpdateSample(id, mutator)
+		return innerErr
+	})
+	return updated, res, err
+}
+
+// DeleteSample removes a sample.
+func (s *Service) DeleteSample(ctx context.Context, id string) (domain.Result, error) {
+	return s.run(ctx, "delete_sample", func(tx domain.Transaction) error {
+		return tx.DeleteSample(id)
+	})
+}
+
+// CreatePermit persists a permit.
+func (s *Service) CreatePermit(ctx context.Context, permit domain.Permit) (domain.Permit, domain.Result, error) {
+	var created domain.Permit
+	res, err := s.run(ctx, "create_permit", func(tx domain.Transaction) error {
+		var innerErr error
+		created, innerErr = tx.CreatePermit(permit)
+		return innerErr
+	})
+	return created, res, err
+}
+
+// UpdatePermit mutates a permit record.
+func (s *Service) UpdatePermit(ctx context.Context, id string, mutator func(*domain.Permit) error) (domain.Permit, domain.Result, error) {
+	var updated domain.Permit
+	res, err := s.run(ctx, "update_permit", func(tx domain.Transaction) error {
+		var innerErr error
+		updated, innerErr = tx.UpdatePermit(id, mutator)
+		return innerErr
+	})
+	return updated, res, err
+}
+
+// DeletePermit removes a permit.
+func (s *Service) DeletePermit(ctx context.Context, id string) (domain.Result, error) {
+	return s.run(ctx, "delete_permit", func(tx domain.Transaction) error {
+		return tx.DeletePermit(id)
+	})
+}
+
+// CreateSupplyItem persists a supply item record.
+func (s *Service) CreateSupplyItem(ctx context.Context, item domain.SupplyItem) (domain.SupplyItem, domain.Result, error) {
+	var created domain.SupplyItem
+	res, err := s.run(ctx, "create_supply_item", func(tx domain.Transaction) error {
+		var innerErr error
+		created, innerErr = tx.CreateSupplyItem(item)
+		return innerErr
+	})
+	return created, res, err
+}
+
+// UpdateSupplyItem mutates a supply item.
+func (s *Service) UpdateSupplyItem(ctx context.Context, id string, mutator func(*domain.SupplyItem) error) (domain.SupplyItem, domain.Result, error) {
+	var updated domain.SupplyItem
+	res, err := s.run(ctx, "update_supply_item", func(tx domain.Transaction) error {
+		var innerErr error
+		updated, innerErr = tx.UpdateSupplyItem(id, mutator)
+		return innerErr
+	})
+	return updated, res, err
+}
+
+// DeleteSupplyItem removes a supply item.
+func (s *Service) DeleteSupplyItem(ctx context.Context, id string) (domain.Result, error) {
+	return s.run(ctx, "delete_supply_item", func(tx domain.Transaction) error {
+		return tx.DeleteSupplyItem(id)
 	})
 }
 

--- a/internal/infra/persistence/sqlite/store.go
+++ b/internal/infra/persistence/sqlite/store.go
@@ -50,7 +50,21 @@ func NewStore(path string, engine *RulesEngine) (*Store, error) {
 	return s, nil
 }
 
-var sqliteBuckets = []string{"organisms", "cohorts", "housing", "breeding", "procedures", "protocols", "projects"}
+var sqliteBuckets = []string{
+	"organisms",
+	"cohorts",
+	"housing",
+	"facilities",
+	"breeding",
+	"procedures",
+	"treatments",
+	"observations",
+	"samples",
+	"protocols",
+	"permits",
+	"projects",
+	"supplies",
+}
 
 func (s *Store) load() error {
 	rows, err := s.db.Query(`SELECT bucket, payload FROM state`)
@@ -88,6 +102,10 @@ func (s *Store) load() error {
 			if err := json.Unmarshal(r.payload, &snapshot.Housing); err != nil {
 				return fmt.Errorf("decode housing: %w", err)
 			}
+		case "facilities":
+			if err := json.Unmarshal(r.payload, &snapshot.Facilities); err != nil {
+				return fmt.Errorf("decode facilities: %w", err)
+			}
 		case "breeding":
 			if err := json.Unmarshal(r.payload, &snapshot.Breeding); err != nil {
 				return fmt.Errorf("decode breeding: %w", err)
@@ -96,13 +114,33 @@ func (s *Store) load() error {
 			if err := json.Unmarshal(r.payload, &snapshot.Procedures); err != nil {
 				return fmt.Errorf("decode procedures: %w", err)
 			}
+		case "treatments":
+			if err := json.Unmarshal(r.payload, &snapshot.Treatments); err != nil {
+				return fmt.Errorf("decode treatments: %w", err)
+			}
+		case "observations":
+			if err := json.Unmarshal(r.payload, &snapshot.Observations); err != nil {
+				return fmt.Errorf("decode observations: %w", err)
+			}
+		case "samples":
+			if err := json.Unmarshal(r.payload, &snapshot.Samples); err != nil {
+				return fmt.Errorf("decode samples: %w", err)
+			}
 		case "protocols":
 			if err := json.Unmarshal(r.payload, &snapshot.Protocols); err != nil {
 				return fmt.Errorf("decode protocols: %w", err)
 			}
+		case "permits":
+			if err := json.Unmarshal(r.payload, &snapshot.Permits); err != nil {
+				return fmt.Errorf("decode permits: %w", err)
+			}
 		case "projects":
 			if err := json.Unmarshal(r.payload, &snapshot.Projects); err != nil {
 				return fmt.Errorf("decode projects: %w", err)
+			}
+		case "supplies":
+			if err := json.Unmarshal(r.payload, &snapshot.Supplies); err != nil {
+				return fmt.Errorf("decode supplies: %w", err)
 			}
 		}
 	}
@@ -132,14 +170,26 @@ func (s *Store) persist() (retErr error) {
 			data, err = json.Marshal(snapshot.Cohorts)
 		case "housing":
 			data, err = json.Marshal(snapshot.Housing)
+		case "facilities":
+			data, err = json.Marshal(snapshot.Facilities)
 		case "breeding":
 			data, err = json.Marshal(snapshot.Breeding)
 		case "procedures":
 			data, err = json.Marshal(snapshot.Procedures)
+		case "treatments":
+			data, err = json.Marshal(snapshot.Treatments)
+		case "observations":
+			data, err = json.Marshal(snapshot.Observations)
+		case "samples":
+			data, err = json.Marshal(snapshot.Samples)
 		case "protocols":
 			data, err = json.Marshal(snapshot.Protocols)
+		case "permits":
+			data, err = json.Marshal(snapshot.Permits)
 		case "projects":
 			data, err = json.Marshal(snapshot.Projects)
+		case "supplies":
+			data, err = json.Marshal(snapshot.Supplies)
 		}
 		if err != nil {
 			retErr = err


### PR DESCRIPTION
## What  
<!-- Describe the change. -->

Propagate the contract into `internal/infra/persistence/memory/store.go` and the SQLite implementation, including new maps/tables, ID generation, cloning helpers, and tests (`*_crud_test.go`).
Enhance `internal/core/service.go` and related tests to orchestrate CRUD flows, emit `domain.Change` audit entries, and wire rule evaluation hooks for each new entity, following existing patterns used for organisms/procedures.

Add missing 

## Why  
<!-- What's the motivation. -->

Working on #66 

## How  
<!-- Bullet list or description of key changes. -->

Added core entities:
* facility
* treatment
* observation
* sample
* permit
* supply

## Notes  
<!-- Breaking changes or follow-ups (if any). -->

## Checklist  

- [x] I have used conventional commits (conventionalcommits.com)
- [ ] I have updated the documentation
- [ ] I have updated the relevant RFC and its linked resources
- [x] I have added tests
- [x] I ran manual tests