### PR TITLE
feat: Expand datasetapi and pluginapi entities

### DIFF
--- a/internal/adapters/datasets/handler_list_test.go
+++ b/internal/adapters/datasets/handler_list_test.go
@@ -1,0 +1,70 @@
+package datasets
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"colonycore/pkg/datasetapi"
+)
+
+type stubCatalog struct {
+	templates []datasetapi.TemplateDescriptor
+}
+
+func (s stubCatalog) DatasetTemplates() []datasetapi.TemplateDescriptor {
+	out := make([]datasetapi.TemplateDescriptor, len(s.templates))
+	copy(out, s.templates)
+	return out
+}
+
+func (stubCatalog) ResolveDatasetTemplate(string) (datasetapi.TemplateRuntime, bool) {
+	return nil, false
+}
+
+func TestHandleListTemplatesSortsByPluginKeyVersion(t *testing.T) {
+	h := &Handler{
+		Catalog: stubCatalog{
+			templates: []datasetapi.TemplateDescriptor{
+				{Plugin: "b", Key: "alpha", Version: "1.0.0"},
+				{Plugin: "a", Key: "beta", Version: "1.0.0"},
+				{Plugin: "a", Key: "alpha", Version: "2.0.0"},
+				{Plugin: "a", Key: "alpha", Version: "1.0.0"},
+			},
+		},
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/datasets/templates", nil)
+	h.handleListTemplates(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d", rec.Code)
+	}
+
+	var payload struct {
+		Templates []datasetapi.TemplateDescriptor `json:"templates"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	expectedOrder := []string{
+		"a/alpha@1.0.0",
+		"a/alpha@2.0.0",
+		"a/beta@1.0.0",
+		"b/alpha@1.0.0",
+	}
+	var gotOrder []string
+	for _, tpl := range payload.Templates {
+		gotOrder = append(gotOrder, fmt.Sprintf("%s/%s@%s", tpl.Plugin, tpl.Key, tpl.Version))
+	}
+	if len(gotOrder) != len(expectedOrder) {
+		t.Fatalf("expected %d templates, got %d", len(expectedOrder), len(gotOrder))
+	}
+	for i, want := range expectedOrder {
+		if gotOrder[i] != want {
+			t.Fatalf("unexpected order at index %d: want %s, got %s", i, want, gotOrder[i])
+		}
+	}
+}

--- a/internal/ci/datasetapi.snapshot
+++ b/internal/ci/datasetapi.snapshot
@@ -6,16 +6,28 @@ FUNC NewBreedingContext() colonycore/pkg/datasetapi.BreedingContext
 FUNC NewBreedingUnit(colonycore/pkg/datasetapi.BreedingUnitData) colonycore/pkg/datasetapi.BreedingUnit
 FUNC NewCohort(colonycore/pkg/datasetapi.CohortData) colonycore/pkg/datasetapi.Cohort
 FUNC NewCohortContext() colonycore/pkg/datasetapi.CohortContext
+FUNC NewFacility(colonycore/pkg/datasetapi.FacilityData) colonycore/pkg/datasetapi.Facility
+FUNC NewFacilityContext() colonycore/pkg/datasetapi.FacilityContext
 FUNC NewHostTemplate(string,colonycore/pkg/datasetapi.Template) (colonycore/pkg/datasetapi.HostTemplate,error)
 FUNC NewHousingContext() colonycore/pkg/datasetapi.HousingContext
 FUNC NewHousingUnit(colonycore/pkg/datasetapi.HousingUnitData) colonycore/pkg/datasetapi.HousingUnit
 FUNC NewLifecycleStageContext() colonycore/pkg/datasetapi.LifecycleStageContext
+FUNC NewObservation(colonycore/pkg/datasetapi.ObservationData) colonycore/pkg/datasetapi.Observation
+FUNC NewObservationContext() colonycore/pkg/datasetapi.ObservationContext
 FUNC NewOrganism(colonycore/pkg/datasetapi.OrganismData) colonycore/pkg/datasetapi.Organism
+FUNC NewPermit(colonycore/pkg/datasetapi.PermitData) colonycore/pkg/datasetapi.Permit
+FUNC NewPermitContext() colonycore/pkg/datasetapi.PermitContext
 FUNC NewProcedure(colonycore/pkg/datasetapi.ProcedureData) colonycore/pkg/datasetapi.Procedure
 FUNC NewProcedureContext() colonycore/pkg/datasetapi.ProcedureContext
 FUNC NewProject(colonycore/pkg/datasetapi.ProjectData) colonycore/pkg/datasetapi.Project
 FUNC NewProtocol(colonycore/pkg/datasetapi.ProtocolData) colonycore/pkg/datasetapi.Protocol
 FUNC NewProtocolContext() colonycore/pkg/datasetapi.ProtocolContext
+FUNC NewSample(colonycore/pkg/datasetapi.SampleData) colonycore/pkg/datasetapi.Sample
+FUNC NewSampleContext() colonycore/pkg/datasetapi.SampleContext
+FUNC NewSupplyContext() colonycore/pkg/datasetapi.SupplyContext
+FUNC NewSupplyItem(colonycore/pkg/datasetapi.SupplyItemData) colonycore/pkg/datasetapi.SupplyItem
+FUNC NewTreatment(colonycore/pkg/datasetapi.TreatmentData) colonycore/pkg/datasetapi.Treatment
+FUNC NewTreatmentContext() colonycore/pkg/datasetapi.TreatmentContext
 FUNC SortTemplateDescriptors([]colonycore/pkg/datasetapi.TemplateDescriptor)
 TYPE BaseData struct { unexported }
 TYPE Binder (func(colonycore/pkg/datasetapi.Environment) (colonycore/pkg/datasetapi.Runner, error))
@@ -40,6 +52,13 @@ TYPE DialectProvider interface { DSL() colonycore/pkg/datasetapi.Dialect SQL() c
 TYPE EntityRef struct { unexported }
 TYPE Environment struct { unexported }
 TYPE EnvironmentTypeRef interface { Equals(colonycore/pkg/datasetapi.EnvironmentTypeRef) bool IsAquatic() bool IsHumid() bool String() string }
+TYPE Facility interface { AccessPolicy() string CreatedAt() time.Time EnvironmentBaselines() map[string]any GetAccessPolicy() colonycore/pkg/datasetapi.FacilityAccessPolicyRef GetZone() colonycore/pkg/datasetapi.FacilityZoneRef HousingUnitIDs() []string ID() string Name() string ProjectIDs() []string SupportsHousingUnit(string) bool UpdatedAt() time.Time Zone() string }
+TYPE FacilityAccessPolicyProvider interface { Open() colonycore/pkg/datasetapi.FacilityAccessPolicyRef Restricted() colonycore/pkg/datasetapi.FacilityAccessPolicyRef StaffOnly() colonycore/pkg/datasetapi.FacilityAccessPolicyRef }
+TYPE FacilityAccessPolicyRef interface { AllowsVisitors() bool Equals(colonycore/pkg/datasetapi.FacilityAccessPolicyRef) bool IsRestricted() bool String() string }
+TYPE FacilityContext interface { AccessPolicies() colonycore/pkg/datasetapi.FacilityAccessPolicyProvider Zones() colonycore/pkg/datasetapi.FacilityZoneProvider }
+TYPE FacilityData struct { unexported }
+TYPE FacilityZoneProvider interface { Biosecure() colonycore/pkg/datasetapi.FacilityZoneRef General() colonycore/pkg/datasetapi.FacilityZoneRef Quarantine() colonycore/pkg/datasetapi.FacilityZoneRef }
+TYPE FacilityZoneRef interface { Equals(colonycore/pkg/datasetapi.FacilityZoneRef) bool IsBiosecure() bool IsQuarantine() bool String() string }
 TYPE Format (string)
 TYPE FormatProvider interface { CSV() colonycore/pkg/datasetapi.Format HTML() colonycore/pkg/datasetapi.Format JSON() colonycore/pkg/datasetapi.Format PNG() colonycore/pkg/datasetapi.Format Parquet() colonycore/pkg/datasetapi.Format }
 TYPE HostTemplate struct { unexported }
@@ -50,16 +69,26 @@ TYPE LifecycleStage (string)
 TYPE LifecycleStageContext interface { Adult() colonycore/pkg/datasetapi.LifecycleStageRef Deceased() colonycore/pkg/datasetapi.LifecycleStageRef Juvenile() colonycore/pkg/datasetapi.LifecycleStageRef Larva() colonycore/pkg/datasetapi.LifecycleStageRef Planned() colonycore/pkg/datasetapi.LifecycleStageRef Retired() colonycore/pkg/datasetapi.LifecycleStageRef }
 TYPE LifecycleStageRef interface { Equals(colonycore/pkg/datasetapi.LifecycleStageRef) bool IsActive() bool String() string Value() colonycore/pkg/datasetapi.LifecycleStage }
 TYPE Metadata struct { unexported }
+TYPE Observation interface { CohortID() (string,bool) CreatedAt() time.Time Data() map[string]any GetDataShape() colonycore/pkg/datasetapi.ObservationShapeRef HasNarrativeNotes() bool HasStructuredPayload() bool ID() string Notes() string Observer() string OrganismID() (string,bool) ProcedureID() (string,bool) RecordedAt() time.Time UpdatedAt() time.Time }
+TYPE ObservationContext interface { Shapes() colonycore/pkg/datasetapi.ObservationShapeProvider }
+TYPE ObservationData struct { unexported }
+TYPE ObservationShapeProvider interface { Mixed() colonycore/pkg/datasetapi.ObservationShapeRef Narrative() colonycore/pkg/datasetapi.ObservationShapeRef Structured() colonycore/pkg/datasetapi.ObservationShapeRef }
+TYPE ObservationShapeRef interface { Equals(colonycore/pkg/datasetapi.ObservationShapeRef) bool HasNarrativeNotes() bool HasStructuredPayload() bool String() string }
 TYPE Organism interface { Attributes() map[string]any CohortID() (string,bool) CreatedAt() time.Time GetCurrentStage() colonycore/pkg/datasetapi.LifecycleStageRef HousingID() (string,bool) ID() string IsActive() bool IsDeceased() bool IsRetired() bool Line() string Name() string ProjectID() (string,bool) ProtocolID() (string,bool) Species() string Stage() colonycore/pkg/datasetapi.LifecycleStage UpdatedAt() time.Time }
 TYPE OrganismData struct { unexported }
 TYPE Parameter struct { unexported }
 TYPE ParameterError struct { unexported }
-TYPE PersistentStore interface { GetHousingUnit(string) (colonycore/pkg/datasetapi.HousingUnit,bool) GetOrganism(string) (colonycore/pkg/datasetapi.Organism,bool) ListBreedingUnits() []colonycore/pkg/datasetapi.BreedingUnit ListCohorts() []colonycore/pkg/datasetapi.Cohort ListHousingUnits() []colonycore/pkg/datasetapi.HousingUnit ListOrganisms() []colonycore/pkg/datasetapi.Organism ListProcedures() []colonycore/pkg/datasetapi.Procedure ListProjects() []colonycore/pkg/datasetapi.Project ListProtocols() []colonycore/pkg/datasetapi.Protocol View(context.Context,func(colonycore/pkg/datasetapi.TransactionView) error) error }
+TYPE Permit interface { AllowedActivities() []string Authority() string CreatedAt() time.Time FacilityIDs() []string GetStatus(time.Time) colonycore/pkg/datasetapi.PermitStatusRef ID() string IsActive(time.Time) bool IsExpired(time.Time) bool Notes() string PermitNumber() string ProtocolIDs() []string UpdatedAt() time.Time ValidFrom() time.Time ValidUntil() time.Time }
+TYPE PermitContext interface { Statuses() colonycore/pkg/datasetapi.PermitStatusProvider }
+TYPE PermitData struct { unexported }
+TYPE PermitStatusProvider interface { Active() colonycore/pkg/datasetapi.PermitStatusRef Expired() colonycore/pkg/datasetapi.PermitStatusRef Pending() colonycore/pkg/datasetapi.PermitStatusRef }
+TYPE PermitStatusRef interface { Equals(colonycore/pkg/datasetapi.PermitStatusRef) bool IsActive() bool IsExpired() bool String() string }
+TYPE PersistentStore interface { GetFacility(string) (colonycore/pkg/datasetapi.Facility,bool) GetHousingUnit(string) (colonycore/pkg/datasetapi.HousingUnit,bool) GetOrganism(string) (colonycore/pkg/datasetapi.Organism,bool) GetPermit(string) (colonycore/pkg/datasetapi.Permit,bool) ListBreedingUnits() []colonycore/pkg/datasetapi.BreedingUnit ListCohorts() []colonycore/pkg/datasetapi.Cohort ListFacilities() []colonycore/pkg/datasetapi.Facility ListHousingUnits() []colonycore/pkg/datasetapi.HousingUnit ListObservations() []colonycore/pkg/datasetapi.Observation ListOrganisms() []colonycore/pkg/datasetapi.Organism ListPermits() []colonycore/pkg/datasetapi.Permit ListProcedures() []colonycore/pkg/datasetapi.Procedure ListProjects() []colonycore/pkg/datasetapi.Project ListProtocols() []colonycore/pkg/datasetapi.Protocol ListSamples() []colonycore/pkg/datasetapi.Sample ListSupplyItems() []colonycore/pkg/datasetapi.SupplyItem ListTreatments() []colonycore/pkg/datasetapi.Treatment View(context.Context,func(colonycore/pkg/datasetapi.TransactionView) error) error }
 TYPE Procedure interface { CohortID() (string,bool) CreatedAt() time.Time GetCurrentStatus() colonycore/pkg/datasetapi.ProcedureStatusRef ID() string IsActiveProcedure() bool IsSuccessful() bool IsTerminalStatus() bool Name() string OrganismIDs() []string ProtocolID() string ScheduledAt() time.Time Status() string UpdatedAt() time.Time }
 TYPE ProcedureContext interface { Cancelled() colonycore/pkg/datasetapi.ProcedureStatusRef Completed() colonycore/pkg/datasetapi.ProcedureStatusRef Failed() colonycore/pkg/datasetapi.ProcedureStatusRef InProgress() colonycore/pkg/datasetapi.ProcedureStatusRef Scheduled() colonycore/pkg/datasetapi.ProcedureStatusRef }
 TYPE ProcedureData struct { unexported }
 TYPE ProcedureStatusRef interface { Equals(colonycore/pkg/datasetapi.ProcedureStatusRef) bool IsActive() bool IsSuccessful() bool IsTerminal() bool String() string }
-TYPE Project interface { Code() string CreatedAt() time.Time Description() string ID() string Title() string UpdatedAt() time.Time }
+TYPE Project interface { Code() string CreatedAt() time.Time Description() string FacilityIDs() []string ID() string Title() string UpdatedAt() time.Time }
 TYPE ProjectData struct { unexported }
 TYPE Protocol interface { CanAcceptNewSubjects() bool Code() string CreatedAt() time.Time Description() string GetCurrentStatus() colonycore/pkg/datasetapi.ProtocolStatusRef ID() string IsActiveProtocol() bool IsTerminalStatus() bool MaxSubjects() int Title() string UpdatedAt() time.Time }
 TYPE ProtocolContext interface { Active() colonycore/pkg/datasetapi.ProtocolStatusRef Cancelled() colonycore/pkg/datasetapi.ProtocolStatusRef Completed() colonycore/pkg/datasetapi.ProtocolStatusRef Draft() colonycore/pkg/datasetapi.ProtocolStatusRef Suspended() colonycore/pkg/datasetapi.ProtocolStatusRef }
@@ -69,8 +98,27 @@ TYPE Row (map[string]any)
 TYPE RunRequest struct { unexported }
 TYPE RunResult struct { unexported }
 TYPE Runner (func(context.Context, colonycore/pkg/datasetapi.RunRequest) (colonycore/pkg/datasetapi.RunResult, error))
+TYPE Sample interface { AssayType() string Attributes() map[string]any ChainOfCustody() []colonycore/pkg/datasetapi.SampleCustodyEvent CohortID() (string,bool) CollectedAt() time.Time CreatedAt() time.Time FacilityID() string GetSource() colonycore/pkg/datasetapi.SampleSourceRef GetStatus() colonycore/pkg/datasetapi.SampleStatusRef ID() string Identifier() string IsAvailable() bool OrganismID() (string,bool) SourceType() string Status() string StorageLocation() string UpdatedAt() time.Time }
+TYPE SampleContext interface { Sources() colonycore/pkg/datasetapi.SampleSourceProvider Statuses() colonycore/pkg/datasetapi.SampleStatusProvider }
+TYPE SampleCustodyEvent interface { Actor() string Location() string Notes() string Timestamp() time.Time }
+TYPE SampleCustodyEventData struct { unexported }
+TYPE SampleData struct { unexported }
+TYPE SampleSourceProvider interface { Cohort() colonycore/pkg/datasetapi.SampleSourceRef Environmental() colonycore/pkg/datasetapi.SampleSourceRef Organism() colonycore/pkg/datasetapi.SampleSourceRef Unknown() colonycore/pkg/datasetapi.SampleSourceRef }
+TYPE SampleSourceRef interface { Equals(colonycore/pkg/datasetapi.SampleSourceRef) bool IsCohortDerived() bool IsEnvironmental() bool IsOrganismDerived() bool String() string }
+TYPE SampleStatusProvider interface { Consumed() colonycore/pkg/datasetapi.SampleStatusRef Disposed() colonycore/pkg/datasetapi.SampleStatusRef InTransit() colonycore/pkg/datasetapi.SampleStatusRef Stored() colonycore/pkg/datasetapi.SampleStatusRef }
+TYPE SampleStatusRef interface { Equals(colonycore/pkg/datasetapi.SampleStatusRef) bool IsAvailable() bool IsTerminal() bool String() string }
 TYPE Scope struct { unexported }
+TYPE SupplyContext interface { Statuses() colonycore/pkg/datasetapi.SupplyStatusProvider }
+TYPE SupplyItem interface { Attributes() map[string]any CreatedAt() time.Time Description() string ExpiresAt() (*time.Time,bool) FacilityIDs() []string GetInventoryStatus(time.Time) colonycore/pkg/datasetapi.SupplyStatusRef ID() string IsExpired(time.Time) bool LotNumber() string Name() string ProjectIDs() []string QuantityOnHand() int ReorderLevel() int RequiresReorder(time.Time) bool SKU() string Unit() string UpdatedAt() time.Time }
+TYPE SupplyItemData struct { unexported }
+TYPE SupplyStatusProvider interface { Critical() colonycore/pkg/datasetapi.SupplyStatusRef Expired() colonycore/pkg/datasetapi.SupplyStatusRef Healthy() colonycore/pkg/datasetapi.SupplyStatusRef Reorder() colonycore/pkg/datasetapi.SupplyStatusRef }
+TYPE SupplyStatusRef interface { Equals(colonycore/pkg/datasetapi.SupplyStatusRef) bool IsExpired() bool RequiresReorder() bool String() string }
 TYPE Template struct { unexported }
 TYPE TemplateDescriptor struct { unexported }
 TYPE TemplateRuntime interface { Descriptor() colonycore/pkg/datasetapi.TemplateDescriptor Run(context.Context,map[string]any,colonycore/pkg/datasetapi.Scope,colonycore/pkg/datasetapi.Format) (colonycore/pkg/datasetapi.RunResult,[]colonycore/pkg/datasetapi.ParameterError,error) SupportsFormat(colonycore/pkg/datasetapi.Format) bool ValidateParameters(map[string]any) (map[string]any,[]colonycore/pkg/datasetapi.ParameterError) }
-TYPE TransactionView interface { FindHousingUnit(string) (colonycore/pkg/datasetapi.HousingUnit,bool) FindOrganism(string) (colonycore/pkg/datasetapi.Organism,bool) ListHousingUnits() []colonycore/pkg/datasetapi.HousingUnit ListOrganisms() []colonycore/pkg/datasetapi.Organism ListProtocols() []colonycore/pkg/datasetapi.Protocol }
+TYPE TransactionView interface { FindFacility(string) (colonycore/pkg/datasetapi.Facility,bool) FindHousingUnit(string) (colonycore/pkg/datasetapi.HousingUnit,bool) FindObservation(string) (colonycore/pkg/datasetapi.Observation,bool) FindOrganism(string) (colonycore/pkg/datasetapi.Organism,bool) FindPermit(string) (colonycore/pkg/datasetapi.Permit,bool) FindSample(string) (colonycore/pkg/datasetapi.Sample,bool) FindSupplyItem(string) (colonycore/pkg/datasetapi.SupplyItem,bool) FindTreatment(string) (colonycore/pkg/datasetapi.Treatment,bool) ListFacilities() []colonycore/pkg/datasetapi.Facility ListHousingUnits() []colonycore/pkg/datasetapi.HousingUnit ListObservations() []colonycore/pkg/datasetapi.Observation ListOrganisms() []colonycore/pkg/datasetapi.Organism ListPermits() []colonycore/pkg/datasetapi.Permit ListProjects() []colonycore/pkg/datasetapi.Project ListProtocols() []colonycore/pkg/datasetapi.Protocol ListSamples() []colonycore/pkg/datasetapi.Sample ListSupplyItems() []colonycore/pkg/datasetapi.SupplyItem ListTreatments() []colonycore/pkg/datasetapi.Treatment }
+TYPE Treatment interface { AdministrationLog() []string AdverseEvents() []string CohortIDs() []string CreatedAt() time.Time DosagePlan() string GetCurrentStatus() colonycore/pkg/datasetapi.TreatmentStatusRef HasAdverseEvents() bool ID() string IsCompleted() bool Name() string OrganismIDs() []string ProcedureID() string UpdatedAt() time.Time }
+TYPE TreatmentContext interface { Statuses() colonycore/pkg/datasetapi.TreatmentStatusProvider }
+TYPE TreatmentData struct { unexported }
+TYPE TreatmentStatusProvider interface { Completed() colonycore/pkg/datasetapi.TreatmentStatusRef Flagged() colonycore/pkg/datasetapi.TreatmentStatusRef InProgress() colonycore/pkg/datasetapi.TreatmentStatusRef Planned() colonycore/pkg/datasetapi.TreatmentStatusRef }
+TYPE TreatmentStatusRef interface { Equals(colonycore/pkg/datasetapi.TreatmentStatusRef) bool IsActive() bool IsCompleted() bool IsFlagged() bool String() string }

--- a/internal/ci/pluginapi.snapshot
+++ b/internal/ci/pluginapi.snapshot
@@ -7,12 +7,18 @@ FUNC NewActionContext() colonycore/pkg/pluginapi.ActionContext
 FUNC NewChange(colonycore/pkg/pluginapi.EntityTypeRef,colonycore/pkg/pluginapi.ActionRef,any,any) colonycore/pkg/pluginapi.Change
 FUNC NewChangeBuilder() *colonycore/pkg/pluginapi.ChangeBuilder
 FUNC NewEntityContext() colonycore/pkg/pluginapi.EntityContext
+FUNC NewFacilityContext() colonycore/pkg/pluginapi.FacilityContext
 FUNC NewHousingContext() colonycore/pkg/pluginapi.HousingContext
 FUNC NewLifecycleStageContext() colonycore/pkg/pluginapi.LifecycleStageContext
+FUNC NewObservationContext() colonycore/pkg/pluginapi.ObservationContext
+FUNC NewPermitContext() colonycore/pkg/pluginapi.PermitContext
 FUNC NewProtocolContext() colonycore/pkg/pluginapi.ProtocolContext
 FUNC NewResult([]colonycore/pkg/pluginapi.Violation) colonycore/pkg/pluginapi.Result
 FUNC NewResultBuilder() *colonycore/pkg/pluginapi.ResultBuilder
+FUNC NewSampleContext() colonycore/pkg/pluginapi.SampleContext
 FUNC NewSeverityContext() colonycore/pkg/pluginapi.SeverityContext
+FUNC NewSupplyContext() colonycore/pkg/pluginapi.SupplyContext
+FUNC NewTreatmentContext() colonycore/pkg/pluginapi.TreatmentContext
 FUNC NewViolation(string,colonycore/pkg/pluginapi.SeverityRef,string,colonycore/pkg/pluginapi.EntityTypeRef,string) colonycore/pkg/pluginapi.Violation
 FUNC NewViolationBuilder() *colonycore/pkg/pluginapi.ViolationBuilder
 FUNC NewViolationWithEntityRef(string,colonycore/pkg/pluginapi.SeverityRef,string,colonycore/pkg/pluginapi.EntityTypeRef,string) colonycore/pkg/pluginapi.Violation
@@ -25,17 +31,32 @@ TYPE ChangeBuilder struct { unexported }
 TYPE DefaultHousingContext struct { unexported }
 TYPE DefaultProtocolContext struct { unexported }
 TYPE DefaultVersionProvider struct { unexported }
-TYPE EntityContext interface { Housing() colonycore/pkg/pluginapi.EntityTypeRef Organism() colonycore/pkg/pluginapi.EntityTypeRef Protocol() colonycore/pkg/pluginapi.EntityTypeRef }
+TYPE EntityContext interface { Facility() colonycore/pkg/pluginapi.EntityTypeRef Housing() colonycore/pkg/pluginapi.EntityTypeRef Observation() colonycore/pkg/pluginapi.EntityTypeRef Organism() colonycore/pkg/pluginapi.EntityTypeRef Permit() colonycore/pkg/pluginapi.EntityTypeRef Procedure() colonycore/pkg/pluginapi.EntityTypeRef Project() colonycore/pkg/pluginapi.EntityTypeRef Protocol() colonycore/pkg/pluginapi.EntityTypeRef Sample() colonycore/pkg/pluginapi.EntityTypeRef SupplyItem() colonycore/pkg/pluginapi.EntityTypeRef Treatment() colonycore/pkg/pluginapi.EntityTypeRef }
 TYPE EntityType (string)
 TYPE EntityTypeRef interface { Equals(colonycore/pkg/pluginapi.EntityTypeRef) bool IsCore() bool String() string Value() colonycore/pkg/pluginapi.EntityType }
 TYPE EnvironmentTypeRef interface { Equals(colonycore/pkg/pluginapi.EnvironmentTypeRef) bool IsAquatic() bool IsHumid() bool String() string }
+TYPE FacilityAccessPolicyProvider interface { Open() colonycore/pkg/pluginapi.FacilityAccessPolicyRef Restricted() colonycore/pkg/pluginapi.FacilityAccessPolicyRef StaffOnly() colonycore/pkg/pluginapi.FacilityAccessPolicyRef }
+TYPE FacilityAccessPolicyRef interface { AllowsVisitors() bool Equals(colonycore/pkg/pluginapi.FacilityAccessPolicyRef) bool IsRestricted() bool String() string }
+TYPE FacilityContext interface { AccessPolicies() colonycore/pkg/pluginapi.FacilityAccessPolicyProvider Zones() colonycore/pkg/pluginapi.FacilityZoneProvider }
+TYPE FacilityView interface { AccessPolicy() string CreatedAt() time.Time EnvironmentBaselines() map[string]any GetAccessPolicy() colonycore/pkg/pluginapi.FacilityAccessPolicyRef GetZone() colonycore/pkg/pluginapi.FacilityZoneRef HousingUnitIDs() []string ID() string Name() string ProjectIDs() []string SupportsHousingUnit(string) bool UpdatedAt() time.Time Zone() string }
+TYPE FacilityZoneProvider interface { Biosecure() colonycore/pkg/pluginapi.FacilityZoneRef General() colonycore/pkg/pluginapi.FacilityZoneRef Quarantine() colonycore/pkg/pluginapi.FacilityZoneRef }
+TYPE FacilityZoneRef interface { Equals(colonycore/pkg/pluginapi.FacilityZoneRef) bool IsBiosecure() bool IsQuarantine() bool String() string }
 TYPE HousingContext interface { Aquatic() colonycore/pkg/pluginapi.EnvironmentTypeRef Arboreal() colonycore/pkg/pluginapi.EnvironmentTypeRef Humid() colonycore/pkg/pluginapi.EnvironmentTypeRef Terrestrial() colonycore/pkg/pluginapi.EnvironmentTypeRef }
 TYPE HousingUnitView interface { Capacity() int CreatedAt() time.Time Environment() string FacilityID() string GetEnvironmentType() colonycore/pkg/pluginapi.EnvironmentTypeRef ID() string IsAquaticEnvironment() bool IsHumidEnvironment() bool Name() string SupportsSpecies(string) bool UpdatedAt() time.Time }
 TYPE LifecycleStage (string)
 TYPE LifecycleStageContext interface { Adult() colonycore/pkg/pluginapi.LifecycleStageRef Deceased() colonycore/pkg/pluginapi.LifecycleStageRef Juvenile() colonycore/pkg/pluginapi.LifecycleStageRef Larva() colonycore/pkg/pluginapi.LifecycleStageRef Planned() colonycore/pkg/pluginapi.LifecycleStageRef Retired() colonycore/pkg/pluginapi.LifecycleStageRef }
 TYPE LifecycleStageRef interface { Equals(colonycore/pkg/pluginapi.LifecycleStageRef) bool IsActive() bool String() string Value() colonycore/pkg/pluginapi.LifecycleStage }
+TYPE ObservationContext interface { Shapes() colonycore/pkg/pluginapi.ObservationShapeProvider }
+TYPE ObservationShapeProvider interface { Mixed() colonycore/pkg/pluginapi.ObservationShapeRef Narrative() colonycore/pkg/pluginapi.ObservationShapeRef Structured() colonycore/pkg/pluginapi.ObservationShapeRef }
+TYPE ObservationShapeRef interface { Equals(colonycore/pkg/pluginapi.ObservationShapeRef) bool HasNarrativeNotes() bool HasStructuredPayload() bool String() string }
+TYPE ObservationView interface { CohortID() (string,bool) CreatedAt() time.Time Data() map[string]any GetDataShape() colonycore/pkg/pluginapi.ObservationShapeRef HasNarrativeNotes() bool HasStructuredPayload() bool ID() string Notes() string Observer() string OrganismID() (string,bool) ProcedureID() (string,bool) RecordedAt() time.Time UpdatedAt() time.Time }
 TYPE OrganismView interface { Attributes() map[string]any CohortID() (string,bool) CreatedAt() time.Time GetCurrentStage() colonycore/pkg/pluginapi.LifecycleStageRef HousingID() (string,bool) ID() string IsActive() bool IsDeceased() bool IsRetired() bool Line() string Name() string ProjectID() (string,bool) ProtocolID() (string,bool) Species() string Stage() colonycore/pkg/pluginapi.LifecycleStage UpdatedAt() time.Time }
+TYPE PermitContext interface { Statuses() colonycore/pkg/pluginapi.PermitStatusProvider }
+TYPE PermitStatusProvider interface { Active() colonycore/pkg/pluginapi.PermitStatusRef Expired() colonycore/pkg/pluginapi.PermitStatusRef Pending() colonycore/pkg/pluginapi.PermitStatusRef }
+TYPE PermitStatusRef interface { Equals(colonycore/pkg/pluginapi.PermitStatusRef) bool IsActive() bool IsExpired() bool String() string }
+TYPE PermitView interface { AllowedActivities() []string Authority() string CreatedAt() time.Time FacilityIDs() []string GetStatus(time.Time) colonycore/pkg/pluginapi.PermitStatusRef ID() string IsActive(time.Time) bool IsExpired(time.Time) bool Notes() string PermitNumber() string ProtocolIDs() []string UpdatedAt() time.Time ValidFrom() time.Time ValidUntil() time.Time }
 TYPE Plugin interface { Name() string Register(colonycore/pkg/pluginapi.Registry) error Version() string }
+TYPE ProjectView interface { Code() string CreatedAt() time.Time Description() string FacilityIDs() []string ID() string Title() string UpdatedAt() time.Time }
 TYPE ProtocolContext interface { Active() colonycore/pkg/pluginapi.ProtocolStatusRef Cancelled() colonycore/pkg/pluginapi.ProtocolStatusRef Completed() colonycore/pkg/pluginapi.ProtocolStatusRef Draft() colonycore/pkg/pluginapi.ProtocolStatusRef Suspended() colonycore/pkg/pluginapi.ProtocolStatusRef }
 TYPE ProtocolStatusRef interface { Equals(colonycore/pkg/pluginapi.ProtocolStatusRef) bool IsActive() bool IsTerminal() bool String() string }
 TYPE ProtocolView interface { CanAcceptNewSubjects() bool Code() string CreatedAt() time.Time Description() string GetCurrentStatus() colonycore/pkg/pluginapi.ProtocolStatusRef ID() string IsActiveProtocol() bool IsTerminalStatus() bool MaxSubjects() int Title() string UpdatedAt() time.Time }
@@ -43,11 +64,25 @@ TYPE Registry interface { RegisterDatasetTemplate(colonycore/pkg/datasetapi.Temp
 TYPE Result struct { unexported }
 TYPE ResultBuilder struct { unexported }
 TYPE Rule interface { Evaluate(context.Context,colonycore/pkg/pluginapi.RuleView,[]colonycore/pkg/pluginapi.Change) (colonycore/pkg/pluginapi.Result,error) Name() string }
-TYPE RuleView interface { FindHousingUnit(string) (colonycore/pkg/pluginapi.HousingUnitView,bool) FindOrganism(string) (colonycore/pkg/pluginapi.OrganismView,bool) ListHousingUnits() []colonycore/pkg/pluginapi.HousingUnitView ListOrganisms() []colonycore/pkg/pluginapi.OrganismView ListProtocols() []colonycore/pkg/pluginapi.ProtocolView }
+TYPE RuleView interface { FindFacility(string) (colonycore/pkg/pluginapi.FacilityView,bool) FindHousingUnit(string) (colonycore/pkg/pluginapi.HousingUnitView,bool) FindObservation(string) (colonycore/pkg/pluginapi.ObservationView,bool) FindOrganism(string) (colonycore/pkg/pluginapi.OrganismView,bool) FindPermit(string) (colonycore/pkg/pluginapi.PermitView,bool) FindSample(string) (colonycore/pkg/pluginapi.SampleView,bool) FindSupplyItem(string) (colonycore/pkg/pluginapi.SupplyItemView,bool) FindTreatment(string) (colonycore/pkg/pluginapi.TreatmentView,bool) ListFacilities() []colonycore/pkg/pluginapi.FacilityView ListHousingUnits() []colonycore/pkg/pluginapi.HousingUnitView ListObservations() []colonycore/pkg/pluginapi.ObservationView ListOrganisms() []colonycore/pkg/pluginapi.OrganismView ListPermits() []colonycore/pkg/pluginapi.PermitView ListProjects() []colonycore/pkg/pluginapi.ProjectView ListProtocols() []colonycore/pkg/pluginapi.ProtocolView ListSamples() []colonycore/pkg/pluginapi.SampleView ListSupplyItems() []colonycore/pkg/pluginapi.SupplyItemView ListTreatments() []colonycore/pkg/pluginapi.TreatmentView }
 TYPE RuleViolationError struct { unexported }
+TYPE SampleContext interface { Sources() colonycore/pkg/pluginapi.SampleSourceProvider Statuses() colonycore/pkg/pluginapi.SampleStatusProvider }
+TYPE SampleSourceProvider interface { Cohort() colonycore/pkg/pluginapi.SampleSourceRef Environmental() colonycore/pkg/pluginapi.SampleSourceRef Organism() colonycore/pkg/pluginapi.SampleSourceRef Unknown() colonycore/pkg/pluginapi.SampleSourceRef }
+TYPE SampleSourceRef interface { Equals(colonycore/pkg/pluginapi.SampleSourceRef) bool IsCohortDerived() bool IsEnvironmental() bool IsOrganismDerived() bool String() string }
+TYPE SampleStatusProvider interface { Consumed() colonycore/pkg/pluginapi.SampleStatusRef Disposed() colonycore/pkg/pluginapi.SampleStatusRef InTransit() colonycore/pkg/pluginapi.SampleStatusRef Stored() colonycore/pkg/pluginapi.SampleStatusRef }
+TYPE SampleStatusRef interface { Equals(colonycore/pkg/pluginapi.SampleStatusRef) bool IsAvailable() bool IsTerminal() bool String() string }
+TYPE SampleView interface { AssayType() string Attributes() map[string]any ChainOfCustody() []map[string]any CohortID() (string,bool) CollectedAt() time.Time CreatedAt() time.Time FacilityID() string GetSource() colonycore/pkg/pluginapi.SampleSourceRef GetStatus() colonycore/pkg/pluginapi.SampleStatusRef ID() string Identifier() string IsAvailable() bool OrganismID() (string,bool) SourceType() string Status() string StorageLocation() string UpdatedAt() time.Time }
 TYPE Severity (string)
 TYPE SeverityContext interface { Block() colonycore/pkg/pluginapi.SeverityRef Log() colonycore/pkg/pluginapi.SeverityRef Warn() colonycore/pkg/pluginapi.SeverityRef }
 TYPE SeverityRef interface { Equals(colonycore/pkg/pluginapi.SeverityRef) bool IsBlocking() bool String() string }
+TYPE SupplyContext interface { Statuses() colonycore/pkg/pluginapi.SupplyStatusProvider }
+TYPE SupplyItemView interface { Attributes() map[string]any CreatedAt() time.Time Description() string ExpiresAt() (*time.Time,bool) FacilityIDs() []string GetInventoryStatus(time.Time) colonycore/pkg/pluginapi.SupplyStatusRef ID() string IsExpired(time.Time) bool LotNumber() string Name() string ProjectIDs() []string QuantityOnHand() int ReorderLevel() int RequiresReorder(time.Time) bool SKU() string Unit() string UpdatedAt() time.Time }
+TYPE SupplyStatusProvider interface { Critical() colonycore/pkg/pluginapi.SupplyStatusRef Expired() colonycore/pkg/pluginapi.SupplyStatusRef Healthy() colonycore/pkg/pluginapi.SupplyStatusRef Reorder() colonycore/pkg/pluginapi.SupplyStatusRef }
+TYPE SupplyStatusRef interface { Equals(colonycore/pkg/pluginapi.SupplyStatusRef) bool IsExpired() bool RequiresReorder() bool String() string }
+TYPE TreatmentContext interface { Statuses() colonycore/pkg/pluginapi.TreatmentStatusProvider }
+TYPE TreatmentStatusProvider interface { Completed() colonycore/pkg/pluginapi.TreatmentStatusRef Flagged() colonycore/pkg/pluginapi.TreatmentStatusRef InProgress() colonycore/pkg/pluginapi.TreatmentStatusRef Planned() colonycore/pkg/pluginapi.TreatmentStatusRef }
+TYPE TreatmentStatusRef interface { Equals(colonycore/pkg/pluginapi.TreatmentStatusRef) bool IsActive() bool IsCompleted() bool IsFlagged() bool String() string }
+TYPE TreatmentView interface { AdministrationLog() []string AdverseEvents() []string CohortIDs() []string CreatedAt() time.Time DosagePlan() string GetCurrentStatus() colonycore/pkg/pluginapi.TreatmentStatusRef HasAdverseEvents() bool ID() string IsCompleted() bool Name() string OrganismIDs() []string ProcedureID() string UpdatedAt() time.Time }
 TYPE VersionProvider interface { APIVersion() string }
 TYPE Violation struct { unexported }
 TYPE ViolationBuilder struct { unexported }

--- a/internal/core/dataset_adapter_test.go
+++ b/internal/core/dataset_adapter_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 const testAdultStage = "adult"
+const demoTemplateKey = "demo"
 
 func TestNewDatasetTemplateFromAPI(t *testing.T) {
 	dialectProvider := datasetapi.GetDialectProvider()
@@ -16,10 +17,10 @@ func TestNewDatasetTemplateFromAPI(t *testing.T) {
 
 	now := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
 	apiTemplate := datasetapi.Template{
-		Key:         "demo",
+		Key:         demoTemplateKey,
 		Version:     "1.0.0",
 		Title:       "Demo",
-		Description: "demo",
+		Description: demoTemplateKey,
 		Dialect:     dialectProvider.SQL(),
 		Query:       "SELECT 1",
 		Parameters: []datasetapi.Parameter{{
@@ -48,7 +49,7 @@ func TestNewDatasetTemplateFromAPI(t *testing.T) {
 			t.Fatalf("expected env.Now to be propagated")
 		}
 		return func(_ context.Context, req datasetapi.RunRequest) (datasetapi.RunResult, error) {
-			if req.Template.Key != "demo" {
+			if req.Template.Key != demoTemplateKey {
 				t.Fatalf("unexpected template key: %s", req.Template.Key)
 			}
 			if req.Scope.Requestor != "analyst" {

--- a/internal/core/dataset_facade_mapper.go
+++ b/internal/core/dataset_facade_mapper.go
@@ -67,6 +67,7 @@ func facadeProtocolFromDomain(protocol domain.Protocol) datasetapi.Protocol {
 		Title:       protocol.Title,
 		Description: protocol.Description,
 		MaxSubjects: protocol.MaxSubjects,
+		Status:      protocol.Status,
 	})
 }
 
@@ -87,6 +88,7 @@ func facadeProjectFromDomain(project domain.Project) datasetapi.Project {
 		Code:        project.Code,
 		Title:       project.Title,
 		Description: project.Description,
+		FacilityIDs: project.FacilityIDs,
 	})
 }
 
@@ -165,6 +167,174 @@ func facadeProceduresFromDomain(procs []domain.Procedure) []datasetapi.Procedure
 	out := make([]datasetapi.Procedure, len(procs))
 	for i := range procs {
 		out[i] = facadeProcedureFromDomain(procs[i])
+	}
+	return out
+}
+
+func facadeFacilityFromDomain(facility domain.Facility) datasetapi.Facility {
+	return datasetapi.NewFacility(datasetapi.FacilityData{
+		Base:                 baseDataFromDomain(facility.Base),
+		Name:                 facility.Name,
+		Zone:                 facility.Zone,
+		AccessPolicy:         facility.AccessPolicy,
+		EnvironmentBaselines: facility.EnvironmentBaselines,
+		HousingUnitIDs:       facility.HousingUnitIDs,
+		ProjectIDs:           facility.ProjectIDs,
+	})
+}
+
+func facadeFacilitiesFromDomain(facilities []domain.Facility) []datasetapi.Facility {
+	if len(facilities) == 0 {
+		return nil
+	}
+	out := make([]datasetapi.Facility, len(facilities))
+	for i := range facilities {
+		out[i] = facadeFacilityFromDomain(facilities[i])
+	}
+	return out
+}
+
+func facadeTreatmentFromDomain(treatment domain.Treatment) datasetapi.Treatment {
+	return datasetapi.NewTreatment(datasetapi.TreatmentData{
+		Base:              baseDataFromDomain(treatment.Base),
+		Name:              treatment.Name,
+		ProcedureID:       treatment.ProcedureID,
+		OrganismIDs:       treatment.OrganismIDs,
+		CohortIDs:         treatment.CohortIDs,
+		DosagePlan:        treatment.DosagePlan,
+		AdministrationLog: treatment.AdministrationLog,
+		AdverseEvents:     treatment.AdverseEvents,
+	})
+}
+
+func facadeTreatmentsFromDomain(treatments []domain.Treatment) []datasetapi.Treatment {
+	if len(treatments) == 0 {
+		return nil
+	}
+	out := make([]datasetapi.Treatment, len(treatments))
+	for i := range treatments {
+		out[i] = facadeTreatmentFromDomain(treatments[i])
+	}
+	return out
+}
+
+func facadeObservationFromDomain(observation domain.Observation) datasetapi.Observation {
+	return datasetapi.NewObservation(datasetapi.ObservationData{
+		Base:        baseDataFromDomain(observation.Base),
+		ProcedureID: observation.ProcedureID,
+		OrganismID:  observation.OrganismID,
+		CohortID:    observation.CohortID,
+		RecordedAt:  observation.RecordedAt,
+		Observer:    observation.Observer,
+		Data:        observation.Data,
+		Notes:       observation.Notes,
+	})
+}
+
+func facadeObservationsFromDomain(observations []domain.Observation) []datasetapi.Observation {
+	if len(observations) == 0 {
+		return nil
+	}
+	out := make([]datasetapi.Observation, len(observations))
+	for i := range observations {
+		out[i] = facadeObservationFromDomain(observations[i])
+	}
+	return out
+}
+
+func facadeSampleFromDomain(sample domain.Sample) datasetapi.Sample {
+	return datasetapi.NewSample(datasetapi.SampleData{
+		Base:            baseDataFromDomain(sample.Base),
+		Identifier:      sample.Identifier,
+		SourceType:      sample.SourceType,
+		OrganismID:      sample.OrganismID,
+		CohortID:        sample.CohortID,
+		FacilityID:      sample.FacilityID,
+		CollectedAt:     sample.CollectedAt,
+		Status:          sample.Status,
+		StorageLocation: sample.StorageLocation,
+		AssayType:       sample.AssayType,
+		ChainOfCustody:  custodyEventsToData(sample.ChainOfCustody),
+		Attributes:      sample.Attributes,
+	})
+}
+
+func facadeSamplesFromDomain(samples []domain.Sample) []datasetapi.Sample {
+	if len(samples) == 0 {
+		return nil
+	}
+	out := make([]datasetapi.Sample, len(samples))
+	for i := range samples {
+		out[i] = facadeSampleFromDomain(samples[i])
+	}
+	return out
+}
+
+func facadePermitFromDomain(permit domain.Permit) datasetapi.Permit {
+	return datasetapi.NewPermit(datasetapi.PermitData{
+		Base:              baseDataFromDomain(permit.Base),
+		PermitNumber:      permit.PermitNumber,
+		Authority:         permit.Authority,
+		ValidFrom:         permit.ValidFrom,
+		ValidUntil:        permit.ValidUntil,
+		AllowedActivities: permit.AllowedActivities,
+		FacilityIDs:       permit.FacilityIDs,
+		ProtocolIDs:       permit.ProtocolIDs,
+		Notes:             permit.Notes,
+	})
+}
+
+func facadePermitsFromDomain(permits []domain.Permit) []datasetapi.Permit {
+	if len(permits) == 0 {
+		return nil
+	}
+	out := make([]datasetapi.Permit, len(permits))
+	for i := range permits {
+		out[i] = facadePermitFromDomain(permits[i])
+	}
+	return out
+}
+
+func facadeSupplyItemFromDomain(item domain.SupplyItem) datasetapi.SupplyItem {
+	return datasetapi.NewSupplyItem(datasetapi.SupplyItemData{
+		Base:           baseDataFromDomain(item.Base),
+		SKU:            item.SKU,
+		Name:           item.Name,
+		Description:    item.Description,
+		QuantityOnHand: item.QuantityOnHand,
+		Unit:           item.Unit,
+		LotNumber:      item.LotNumber,
+		ExpiresAt:      item.ExpiresAt,
+		FacilityIDs:    item.FacilityIDs,
+		ProjectIDs:     item.ProjectIDs,
+		ReorderLevel:   item.ReorderLevel,
+		Attributes:     item.Attributes,
+	})
+}
+
+func facadeSupplyItemsFromDomain(items []domain.SupplyItem) []datasetapi.SupplyItem {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]datasetapi.SupplyItem, len(items))
+	for i := range items {
+		out[i] = facadeSupplyItemFromDomain(items[i])
+	}
+	return out
+}
+
+func custodyEventsToData(events []domain.SampleCustodyEvent) []datasetapi.SampleCustodyEventData {
+	if len(events) == 0 {
+		return nil
+	}
+	out := make([]datasetapi.SampleCustodyEventData, len(events))
+	for i, event := range events {
+		out[i] = datasetapi.SampleCustodyEventData{
+			Actor:     event.Actor,
+			Location:  event.Location,
+			Timestamp: event.Timestamp,
+			Notes:     event.Notes,
+		}
 	}
 	return out
 }

--- a/internal/core/dataset_store_adapter.go
+++ b/internal/core/dataset_store_adapter.go
@@ -53,12 +53,48 @@ func (a datasetPersistentStoreAdapter) ListHousingUnits() []datasetapi.HousingUn
 	return facadeHousingUnitsFromDomain(a.store.ListHousingUnits())
 }
 
+func (a datasetPersistentStoreAdapter) GetFacility(id string) (datasetapi.Facility, bool) {
+	facility, ok := a.store.GetFacility(id)
+	if !ok {
+		return nil, false
+	}
+	return facadeFacilityFromDomain(facility), true
+}
+
+func (a datasetPersistentStoreAdapter) ListFacilities() []datasetapi.Facility {
+	return facadeFacilitiesFromDomain(a.store.ListFacilities())
+}
+
 func (a datasetPersistentStoreAdapter) ListCohorts() []datasetapi.Cohort {
 	return facadeCohortsFromDomain(a.store.ListCohorts())
 }
 
+func (a datasetPersistentStoreAdapter) ListTreatments() []datasetapi.Treatment {
+	return facadeTreatmentsFromDomain(a.store.ListTreatments())
+}
+
+func (a datasetPersistentStoreAdapter) ListObservations() []datasetapi.Observation {
+	return facadeObservationsFromDomain(a.store.ListObservations())
+}
+
+func (a datasetPersistentStoreAdapter) ListSamples() []datasetapi.Sample {
+	return facadeSamplesFromDomain(a.store.ListSamples())
+}
+
 func (a datasetPersistentStoreAdapter) ListProtocols() []datasetapi.Protocol {
 	return facadeProtocolsFromDomain(a.store.ListProtocols())
+}
+
+func (a datasetPersistentStoreAdapter) GetPermit(id string) (datasetapi.Permit, bool) {
+	permit, ok := a.store.GetPermit(id)
+	if !ok {
+		return nil, false
+	}
+	return facadePermitFromDomain(permit), true
+}
+
+func (a datasetPersistentStoreAdapter) ListPermits() []datasetapi.Permit {
+	return facadePermitsFromDomain(a.store.ListPermits())
 }
 
 func (a datasetPersistentStoreAdapter) ListProjects() []datasetapi.Project {
@@ -71,6 +107,10 @@ func (a datasetPersistentStoreAdapter) ListBreedingUnits() []datasetapi.Breeding
 
 func (a datasetPersistentStoreAdapter) ListProcedures() []datasetapi.Procedure {
 	return facadeProceduresFromDomain(a.store.ListProcedures())
+}
+
+func (a datasetPersistentStoreAdapter) ListSupplyItems() []datasetapi.SupplyItem {
+	return facadeSupplyItemsFromDomain(a.store.ListSupplyItems())
 }
 
 type datasetTransactionViewAdapter struct {
@@ -87,8 +127,36 @@ func (a datasetTransactionViewAdapter) ListHousingUnits() []datasetapi.HousingUn
 	return facadeHousingUnitsFromDomain(a.view.ListHousingUnits())
 }
 
+func (a datasetTransactionViewAdapter) ListFacilities() []datasetapi.Facility {
+	return facadeFacilitiesFromDomain(a.view.ListFacilities())
+}
+
+func (a datasetTransactionViewAdapter) ListTreatments() []datasetapi.Treatment {
+	return facadeTreatmentsFromDomain(a.view.ListTreatments())
+}
+
+func (a datasetTransactionViewAdapter) ListObservations() []datasetapi.Observation {
+	return facadeObservationsFromDomain(a.view.ListObservations())
+}
+
+func (a datasetTransactionViewAdapter) ListSamples() []datasetapi.Sample {
+	return facadeSamplesFromDomain(a.view.ListSamples())
+}
+
 func (a datasetTransactionViewAdapter) ListProtocols() []datasetapi.Protocol {
 	return facadeProtocolsFromDomain(a.view.ListProtocols())
+}
+
+func (a datasetTransactionViewAdapter) ListPermits() []datasetapi.Permit {
+	return facadePermitsFromDomain(a.view.ListPermits())
+}
+
+func (a datasetTransactionViewAdapter) ListProjects() []datasetapi.Project {
+	return facadeProjectsFromDomain(a.view.ListProjects())
+}
+
+func (a datasetTransactionViewAdapter) ListSupplyItems() []datasetapi.SupplyItem {
+	return facadeSupplyItemsFromDomain(a.view.ListSupplyItems())
 }
 
 func (a datasetTransactionViewAdapter) FindOrganism(id string) (datasetapi.Organism, bool) {
@@ -105,4 +173,52 @@ func (a datasetTransactionViewAdapter) FindHousingUnit(id string) (datasetapi.Ho
 		return nil, false
 	}
 	return facadeHousingUnitFromDomain(unit), true
+}
+
+func (a datasetTransactionViewAdapter) FindFacility(id string) (datasetapi.Facility, bool) {
+	facility, ok := a.view.FindFacility(id)
+	if !ok {
+		return nil, false
+	}
+	return facadeFacilityFromDomain(facility), true
+}
+
+func (a datasetTransactionViewAdapter) FindTreatment(id string) (datasetapi.Treatment, bool) {
+	treatment, ok := a.view.FindTreatment(id)
+	if !ok {
+		return nil, false
+	}
+	return facadeTreatmentFromDomain(treatment), true
+}
+
+func (a datasetTransactionViewAdapter) FindObservation(id string) (datasetapi.Observation, bool) {
+	observation, ok := a.view.FindObservation(id)
+	if !ok {
+		return nil, false
+	}
+	return facadeObservationFromDomain(observation), true
+}
+
+func (a datasetTransactionViewAdapter) FindSample(id string) (datasetapi.Sample, bool) {
+	sample, ok := a.view.FindSample(id)
+	if !ok {
+		return nil, false
+	}
+	return facadeSampleFromDomain(sample), true
+}
+
+func (a datasetTransactionViewAdapter) FindPermit(id string) (datasetapi.Permit, bool) {
+	permit, ok := a.view.FindPermit(id)
+	if !ok {
+		return nil, false
+	}
+	return facadePermitFromDomain(permit), true
+}
+
+func (a datasetTransactionViewAdapter) FindSupplyItem(id string) (datasetapi.SupplyItem, bool) {
+	item, ok := a.view.FindSupplyItem(id)
+	if !ok {
+		return nil, false
+	}
+	return facadeSupplyItemFromDomain(item), true
 }

--- a/internal/core/dataset_test.go
+++ b/internal/core/dataset_test.go
@@ -271,6 +271,40 @@ func TestDatasetTemplateSlugVariants(t *testing.T) {
 	}
 }
 
+func TestDatasetTemplateDescriptorAndFormats(t *testing.T) {
+	formatProvider := datasetapi.GetFormatProvider()
+	template := DatasetTemplate{
+		Plugin: "demo",
+		Template: datasetapi.Template{
+			Key:           "demo",
+			Version:       "1.0.0",
+			Title:         "Demo",
+			Description:   "desc",
+			Dialect:       datasetapi.GetDialectProvider().SQL(),
+			Query:         "SELECT 1",
+			Parameters:    []datasetapi.Parameter{{Name: "limit", Type: "integer", Required: true}},
+			Columns:       []datasetapi.Column{{Name: "value", Type: "integer"}},
+			Metadata:      datasetapi.Metadata{Tags: []string{"tag"}},
+			OutputFormats: []datasetapi.Format{formatProvider.JSON()},
+		},
+	}
+
+	desc := template.Descriptor()
+	if desc.Key != demoTemplateKey || desc.Plugin != demoTemplateKey || len(desc.Columns) != 1 || len(desc.Parameters) != 1 {
+		t.Fatalf("unexpected descriptor: %+v", desc)
+	}
+	if desc.Columns[0].Name == "" || desc.Parameters[0].Name == "" {
+		t.Fatal("descriptor should clone column/parameter definitions")
+	}
+
+	if !template.SupportsFormat(formatProvider.JSON()) {
+		t.Fatal("template should support declared format")
+	}
+	if template.SupportsFormat(formatProvider.CSV()) {
+		t.Fatal("template should not support undeclared format")
+	}
+}
+
 func TestDatasetTemplateValidateFailures(t *testing.T) {
 	dialectProvider := datasetapi.GetDialectProvider()
 	formatProvider := datasetapi.GetFormatProvider()

--- a/internal/core/noop_logger_test.go
+++ b/internal/core/noop_logger_test.go
@@ -1,0 +1,16 @@
+package core
+
+import (
+	"testing"
+)
+
+// TestNoopLoggerCoverageExtra tests all noop logger methods to increase coverage
+func TestNoopLoggerCoverageExtra(_ *testing.T) {
+	logger := noopLogger{}
+
+	// Test all logger methods - they should not panic
+	logger.Debug("test debug message", "key", "value")
+	logger.Info("test info message", "key", "value")
+	logger.Warn("test warn message", "key", "value")
+	logger.Error("test error message", "key", "value")
+}

--- a/internal/core/plugin_registry_test.go
+++ b/internal/core/plugin_registry_test.go
@@ -116,11 +116,30 @@ type emptyView struct{}
 
 func (emptyView) ListOrganisms() []domain.Organism            { return nil }
 func (emptyView) ListHousingUnits() []domain.HousingUnit      { return nil }
+func (emptyView) ListFacilities() []domain.Facility           { return nil }
+func (emptyView) ListTreatments() []domain.Treatment          { return nil }
+func (emptyView) ListObservations() []domain.Observation      { return nil }
+func (emptyView) ListSamples() []domain.Sample                { return nil }
 func (emptyView) FindOrganism(string) (domain.Organism, bool) { return domain.Organism{}, false }
 func (emptyView) FindHousingUnit(string) (domain.HousingUnit, bool) {
 	return domain.HousingUnit{}, false
 }
-func (emptyView) ListProtocols() []domain.Protocol { return nil }
+func (emptyView) FindFacility(string) (domain.Facility, bool) { return domain.Facility{}, false }
+func (emptyView) FindTreatment(string) (domain.Treatment, bool) {
+	return domain.Treatment{}, false
+}
+func (emptyView) FindObservation(string) (domain.Observation, bool) {
+	return domain.Observation{}, false
+}
+func (emptyView) FindSample(string) (domain.Sample, bool) { return domain.Sample{}, false }
+func (emptyView) ListProtocols() []domain.Protocol        { return nil }
+func (emptyView) ListPermits() []domain.Permit            { return nil }
+func (emptyView) ListProjects() []domain.Project          { return nil }
+func (emptyView) ListSupplyItems() []domain.SupplyItem    { return nil }
+func (emptyView) FindPermit(string) (domain.Permit, bool) { return domain.Permit{}, false }
+func (emptyView) FindSupplyItem(string) (domain.SupplyItem, bool) {
+	return domain.SupplyItem{}, false
+}
 
 func TestRulesEngineEvaluateDirect(t *testing.T) {
 	engine := NewRulesEngine()

--- a/internal/core/plugin_rule_adapter_coverage_test.go
+++ b/internal/core/plugin_rule_adapter_coverage_test.go
@@ -1,0 +1,235 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"colonycore/pkg/domain"
+)
+
+// TestFacilityViewSupportsHousingUnit tests the SupportsHousingUnit method with 0% coverage
+func TestFacilityViewSupportsHousingUnit(t *testing.T) {
+	facility := domain.Facility{
+		Base: domain.Base{
+			ID: "facility-1",
+		},
+		Name:           "Test Facility",
+		Zone:           "Zone A",
+		AccessPolicy:   "restricted",
+		HousingUnitIDs: []string{"housing-1", "housing-2"},
+		ProjectIDs:     []string{"project-1"},
+	}
+
+	view := newFacilityView(facility)
+
+	// Test existing housing unit
+	if !view.SupportsHousingUnit("housing-1") {
+		t.Errorf("Expected facility to support housing unit 'housing-1'")
+	}
+
+	if !view.SupportsHousingUnit("housing-2") {
+		t.Errorf("Expected facility to support housing unit 'housing-2'")
+	}
+
+	// Test non-existing housing unit
+	if view.SupportsHousingUnit("housing-3") {
+		t.Errorf("Expected facility to not support housing unit 'housing-3'")
+	}
+}
+
+// TestTreatmentViewAdministrationLog tests the AdministrationLog method with 0% coverage
+func TestTreatmentViewAdministrationLog(t *testing.T) {
+	treatment := domain.Treatment{
+		Base: domain.Base{
+			ID: "treatment-1",
+		},
+		Name:              "Test Treatment",
+		AdministrationLog: []string{"admin-1", "admin-2"},
+	}
+
+	view := newTreatmentView(treatment)
+	log := view.AdministrationLog()
+
+	if len(log) != 2 {
+		t.Errorf("Expected 2 administration log entries, got %d", len(log))
+	}
+
+	if log[0] != "admin-1" || log[1] != "admin-2" {
+		t.Errorf("Expected administration log entries to match, got %v", log)
+	}
+}
+
+// TestTreatmentViewAdverseEvents tests the AdverseEvents method with 0% coverage
+func TestTreatmentViewAdverseEvents(t *testing.T) {
+	treatment := domain.Treatment{
+		Base: domain.Base{
+			ID: "treatment-1",
+		},
+		Name:          "Test Treatment",
+		AdverseEvents: []string{"event-1", "event-2"},
+	}
+
+	view := newTreatmentView(treatment)
+	events := view.AdverseEvents()
+
+	if len(events) != 2 {
+		t.Errorf("Expected 2 adverse events, got %d", len(events))
+	}
+
+	if events[0] != "event-1" || events[1] != "event-2" {
+		t.Errorf("Expected adverse events to match, got %v", events)
+	}
+}
+
+// TestObservationViewOrganismID tests the OrganismID method with 0% coverage
+func TestObservationViewOrganismID(t *testing.T) {
+	orgID := "organism-123"
+	observation := domain.Observation{
+		Base: domain.Base{
+			ID: "observation-1",
+		},
+		OrganismID: &orgID,
+	}
+
+	view := newObservationView(observation)
+
+	if actualID, ok := view.OrganismID(); !ok || actualID != orgID {
+		t.Errorf("Expected OrganismID to be %s, got %v", orgID, actualID)
+	}
+}
+
+// TestObservationViewCohortID tests the CohortID method with 0% coverage
+func TestObservationViewCohortID(t *testing.T) {
+	cohortID := "cohort-123"
+	observation := domain.Observation{
+		Base: domain.Base{
+			ID: "observation-1",
+		},
+		CohortID: &cohortID,
+	}
+
+	view := newObservationView(observation)
+
+	if actualID, ok := view.CohortID(); !ok || actualID != cohortID {
+		t.Errorf("Expected CohortID to be %s, got %v", cohortID, actualID)
+	}
+}
+
+// TestObservationViewRecordedAt tests the RecordedAt method with 0% coverage
+func TestObservationViewRecordedAt(t *testing.T) {
+	recordedTime := time.Now()
+	observation := domain.Observation{
+		Base: domain.Base{
+			ID: "observation-1",
+		},
+		RecordedAt: recordedTime,
+	}
+
+	view := newObservationView(observation)
+
+	if actualTime := view.RecordedAt(); !actualTime.Equal(recordedTime) {
+		t.Errorf("Expected RecordedAt to be %v, got %v", recordedTime, actualTime)
+	}
+}
+
+// TestObservationViewData tests the Data method with 0% coverage
+func TestObservationViewData(t *testing.T) {
+	data := map[string]interface{}{
+		"temperature": 25.5,
+		"notes":       "test observation",
+	}
+	observation := domain.Observation{
+		Base: domain.Base{
+			ID: "observation-1",
+		},
+		Data: data,
+	}
+
+	view := newObservationView(observation)
+
+	actualData := view.Data()
+	if actualData == nil {
+		t.Fatal("Expected Data to return non-nil map")
+	}
+
+	if actualData["temperature"] != 25.5 {
+		t.Errorf("Expected temperature to be 25.5, got %v", actualData["temperature"])
+	}
+}
+
+// TestObservationViewHasStructuredPayload tests the HasStructuredPayload method with 0% coverage
+func TestObservationViewHasStructuredPayload(t *testing.T) {
+	// Test with structured data
+	dataWithStructure := map[string]interface{}{
+		"temperature": 25.5,
+		"notes":       "test observation",
+	}
+	observation := domain.Observation{
+		Base: domain.Base{
+			ID: "observation-1",
+		},
+		Data: dataWithStructure,
+	}
+
+	view := newObservationView(observation)
+	if !view.HasStructuredPayload() {
+		t.Errorf("Expected HasStructuredPayload to be true for non-empty data")
+	}
+
+	// Test with nil data
+	observationEmpty := domain.Observation{
+		Base: domain.Base{
+			ID: "observation-2",
+		},
+		Data: nil,
+	}
+	viewEmpty := newObservationView(observationEmpty)
+	if viewEmpty.HasStructuredPayload() {
+		t.Errorf("Expected HasStructuredPayload to be false for nil data")
+	}
+}
+
+// TestObservationViewHasNarrativeNotes tests the HasNarrativeNotes method with 0% coverage
+func TestObservationViewHasNarrativeNotes(t *testing.T) {
+	// Test with notes
+	observation := domain.Observation{
+		Base: domain.Base{
+			ID: "observation-1",
+		},
+		Notes: "These are some notes",
+	}
+
+	view := newObservationView(observation)
+	if !view.HasNarrativeNotes() {
+		t.Errorf("Expected HasNarrativeNotes to be true for non-empty notes")
+	}
+
+	// Test without notes
+	observationEmpty := domain.Observation{
+		Base: domain.Base{
+			ID: "observation-2",
+		},
+		Notes: "",
+	}
+	viewEmpty := newObservationView(observationEmpty)
+	if !viewEmpty.HasNarrativeNotes() {
+		t.Errorf("Expected HasNarrativeNotes to be true even for empty notes (narrative capability)")
+	}
+}
+
+// TestDerefTime tests the derefTime function with 0% coverage
+func TestDerefTime(t *testing.T) {
+	testTime := time.Now()
+
+	// Test with non-nil pointer
+	result, ok := derefTime(&testTime)
+	if !ok || result == nil || !result.Equal(testTime) {
+		t.Errorf("Expected derefTime to return %v, got %v", testTime, result)
+	}
+
+	// Test with nil pointer
+	zeroTime, ok2 := derefTime(nil)
+	if ok2 || zeroTime != nil {
+		t.Errorf("Expected derefTime to return nil for nil pointer, got %v", zeroTime)
+	}
+}

--- a/internal/core/plugin_rule_adapter_test.go
+++ b/internal/core/plugin_rule_adapter_test.go
@@ -14,6 +14,13 @@ type capturingRule struct {
 	seenHousing      string
 	seenHousingCount int
 	seenProtocols    int
+	seenFacilities   int
+	seenTreatments   int
+	seenObservations int
+	seenSamples      int
+	seenPermits      int
+	seenProjects     int
+	seenSupplyItems  int
 	seenChanges      int
 }
 
@@ -31,6 +38,19 @@ func (r *capturingRule) Evaluate(_ context.Context, view pluginapi.RuleView, cha
 			r.seenHousing = housing.ID()
 		}
 		r.seenProtocols = len(view.ListProtocols())
+		r.seenFacilities = len(view.ListFacilities())
+		r.seenTreatments = len(view.ListTreatments())
+		r.seenObservations = len(view.ListObservations())
+		r.seenSamples = len(view.ListSamples())
+		r.seenPermits = len(view.ListPermits())
+		r.seenProjects = len(view.ListProjects())
+		r.seenSupplyItems = len(view.ListSupplyItems())
+		view.FindFacility("facility-1")
+		view.FindTreatment("treatment-1")
+		view.FindObservation("observation-1")
+		view.FindSample("sample-1")
+		view.FindPermit("permit-1")
+		view.FindSupplyItem("supply-1")
 	}
 	r.seenChanges = len(changes)
 	entities := pluginapi.NewEntityContext()
@@ -49,14 +69,28 @@ func (r *capturingRule) Evaluate(_ context.Context, view pluginapi.RuleView, cha
 }
 
 type stubDomainView struct {
-	organisms []domain.Organism
-	housing   []domain.HousingUnit
-	protocols []domain.Protocol
+	organisms    []domain.Organism
+	housing      []domain.HousingUnit
+	protocols    []domain.Protocol
+	facilities   []domain.Facility
+	treatments   []domain.Treatment
+	observations []domain.Observation
+	samples      []domain.Sample
+	permits      []domain.Permit
+	projects     []domain.Project
+	supply       []domain.SupplyItem
 }
 
 func (v stubDomainView) ListOrganisms() []domain.Organism       { return v.organisms }
 func (v stubDomainView) ListHousingUnits() []domain.HousingUnit { return v.housing }
 func (v stubDomainView) ListProtocols() []domain.Protocol       { return v.protocols }
+func (v stubDomainView) ListFacilities() []domain.Facility      { return v.facilities }
+func (v stubDomainView) ListTreatments() []domain.Treatment     { return v.treatments }
+func (v stubDomainView) ListObservations() []domain.Observation { return v.observations }
+func (v stubDomainView) ListSamples() []domain.Sample           { return v.samples }
+func (v stubDomainView) ListPermits() []domain.Permit           { return v.permits }
+func (v stubDomainView) ListProjects() []domain.Project         { return v.projects }
+func (v stubDomainView) ListSupplyItems() []domain.SupplyItem   { return v.supply }
 
 func (v stubDomainView) FindOrganism(id string) (domain.Organism, bool) {
 	for _, organism := range v.organisms {
@@ -76,14 +110,81 @@ func (v stubDomainView) FindHousingUnit(id string) (domain.HousingUnit, bool) {
 	return domain.HousingUnit{}, false
 }
 
+func (v stubDomainView) FindFacility(id string) (domain.Facility, bool) {
+	for _, facility := range v.facilities {
+		if facility.ID == id {
+			return facility, true
+		}
+	}
+	return domain.Facility{}, false
+}
+
+func (v stubDomainView) FindTreatment(id string) (domain.Treatment, bool) {
+	for _, treatment := range v.treatments {
+		if treatment.ID == id {
+			return treatment, true
+		}
+	}
+	return domain.Treatment{}, false
+}
+
+func (v stubDomainView) FindObservation(id string) (domain.Observation, bool) {
+	for _, observation := range v.observations {
+		if observation.ID == id {
+			return observation, true
+		}
+	}
+	return domain.Observation{}, false
+}
+
+func (v stubDomainView) FindSample(id string) (domain.Sample, bool) {
+	for _, sample := range v.samples {
+		if sample.ID == id {
+			return sample, true
+		}
+	}
+	return domain.Sample{}, false
+}
+
+func (v stubDomainView) FindPermit(id string) (domain.Permit, bool) {
+	for _, permit := range v.permits {
+		if permit.ID == id {
+			return permit, true
+		}
+	}
+	return domain.Permit{}, false
+}
+
+func (v stubDomainView) FindSupplyItem(id string) (domain.SupplyItem, bool) {
+	for _, item := range v.supply {
+		if item.ID == id {
+			return item, true
+		}
+	}
+	return domain.SupplyItem{}, false
+}
+
 func TestAdaptPluginRuleBridgesDomainInterfaces(t *testing.T) {
 	housingID := "housing-1"
 	organismID := "organism-1"
 	protocolID := "protocol-1"
+	facilityID := "facility-1"
+	treatmentID := "treatment-1"
+	observationID := "observation-1"
+	sampleID := "sample-1"
+	permitID := "permit-1"
+	supplyID := "supply-1"
 	view := stubDomainView{
-		organisms: []domain.Organism{{Base: domain.Base{ID: organismID}, HousingID: &housingID}},
-		housing:   []domain.HousingUnit{{Base: domain.Base{ID: housingID}}},
-		protocols: []domain.Protocol{{Base: domain.Base{ID: protocolID}}},
+		organisms:    []domain.Organism{{Base: domain.Base{ID: organismID}, HousingID: &housingID}},
+		housing:      []domain.HousingUnit{{Base: domain.Base{ID: housingID}}},
+		protocols:    []domain.Protocol{{Base: domain.Base{ID: protocolID}}},
+		facilities:   []domain.Facility{{Base: domain.Base{ID: facilityID}}},
+		treatments:   []domain.Treatment{{Base: domain.Base{ID: treatmentID}, ProcedureID: "proc"}},
+		observations: []domain.Observation{{Base: domain.Base{ID: observationID}}},
+		samples:      []domain.Sample{{Base: domain.Base{ID: sampleID}, FacilityID: facilityID}},
+		permits:      []domain.Permit{{Base: domain.Base{ID: permitID}}},
+		projects:     []domain.Project{{Base: domain.Base{ID: "project-1"}}},
+		supply:       []domain.SupplyItem{{Base: domain.Base{ID: supplyID}}},
 	}
 	rule := &capturingRule{}
 	adapted := adaptPluginRule(rule)
@@ -113,6 +214,27 @@ func TestAdaptPluginRuleBridgesDomainInterfaces(t *testing.T) {
 	if rule.seenProtocols != len(view.protocols) {
 		t.Fatalf("expected plugin rule to observe %d protocols, got %d", len(view.protocols), rule.seenProtocols)
 	}
+	if rule.seenFacilities != len(view.facilities) {
+		t.Fatalf("expected plugin rule to observe %d facilities, got %d", len(view.facilities), rule.seenFacilities)
+	}
+	if rule.seenTreatments != len(view.treatments) {
+		t.Fatalf("expected plugin rule to observe %d treatments, got %d", len(view.treatments), rule.seenTreatments)
+	}
+	if rule.seenObservations != len(view.observations) {
+		t.Fatalf("expected plugin rule to observe %d observations, got %d", len(view.observations), rule.seenObservations)
+	}
+	if rule.seenSamples != len(view.samples) {
+		t.Fatalf("expected plugin rule to observe %d samples, got %d", len(view.samples), rule.seenSamples)
+	}
+	if rule.seenPermits != len(view.permits) {
+		t.Fatalf("expected plugin rule to observe %d permits, got %d", len(view.permits), rule.seenPermits)
+	}
+	if rule.seenProjects != len(view.projects) {
+		t.Fatalf("expected plugin rule to observe %d projects, got %d", len(view.projects), rule.seenProjects)
+	}
+	if rule.seenSupplyItems != len(view.supply) {
+		t.Fatalf("expected plugin rule to observe %d supply items, got %d", len(view.supply), rule.seenSupplyItems)
+	}
 	if rule.seenChanges != len(changes) {
 		t.Fatalf("expected plugin rule to observe %d changes, got %d", len(changes), rule.seenChanges)
 	}
@@ -127,6 +249,155 @@ func (r *nilViewRule) Name() string { return "nil" }
 func (r *nilViewRule) Evaluate(_ context.Context, view pluginapi.RuleView, _ []pluginapi.Change) (pluginapi.Result, error) {
 	r.gotNil = view == nil
 	return pluginapi.Result{}, nil
+}
+
+func TestNewViewAccessors(t *testing.T) {
+	now := time.Now()
+	facility := newFacilityView(domain.Facility{
+		Base:                 domain.Base{ID: "facility", CreatedAt: now, UpdatedAt: now},
+		Name:                 "Facility",
+		Zone:                 "Quarantine Zone",
+		AccessPolicy:         "Restricted",
+		EnvironmentBaselines: map[string]any{"temp": 21},
+		HousingUnitIDs:       []string{"H1"},
+		ProjectIDs:           []string{"P1"},
+	})
+	if facility.Name() == "" || facility.Zone() == "" || facility.AccessPolicy() == "" {
+		t.Fatal("facility view should expose base fields")
+	}
+	if len(facility.HousingUnitIDs()) != 1 || len(facility.ProjectIDs()) != 1 {
+		t.Fatal("facility view should expose related ids")
+	}
+	if facility.EnvironmentBaselines()["temp"] != 21 {
+		t.Fatal("facility baselines should round-trip")
+	}
+	if !facility.GetZone().IsQuarantine() {
+		t.Fatal("facility zone contextual accessor should report quarantine")
+	}
+	if !facility.GetAccessPolicy().IsRestricted() {
+		t.Fatal("facility access policy should report restricted")
+	}
+
+	treatment := newTreatmentView(domain.Treatment{
+		Base:              domain.Base{ID: "treatment", CreatedAt: now},
+		Name:              "Treatment",
+		ProcedureID:       "proc",
+		OrganismIDs:       []string{"org"},
+		CohortIDs:         []string{"cohort"},
+		DosagePlan:        "dose plan",
+		AdministrationLog: []string{"dose"},
+		AdverseEvents:     []string{"note"},
+	})
+	if treatment.Name() == "" || treatment.ProcedureID() == "" {
+		t.Fatal("treatment view should expose base fields")
+	}
+	if len(treatment.OrganismIDs()) != 1 || len(treatment.CohortIDs()) != 1 {
+		t.Fatal("treatment view should expose related ids")
+	}
+	if treatment.DosagePlan() == "" {
+		t.Fatal("treatment should expose dosage plan")
+	}
+	if !treatment.HasAdverseEvents() || !treatment.IsCompleted() {
+		t.Fatal("treatment view helpers should reflect log state")
+	}
+
+	procID := "proc"
+	observation := newObservationView(domain.Observation{
+		Base:        domain.Base{ID: "observation", CreatedAt: now},
+		RecordedAt:  now,
+		Observer:    "tech",
+		ProcedureID: &procID,
+		Data:        map[string]any{"score": 1},
+		Notes:       "text",
+	})
+	if observation.Observer() == "" || observation.Notes() == "" {
+		t.Fatal("observation view should expose observer")
+	}
+	if _, ok := observation.ProcedureID(); !ok {
+		t.Fatal("observation should expose procedure id when set")
+	}
+	if !observation.GetDataShape().HasNarrativeNotes() {
+		t.Fatal("observation data shape should report narrative notes")
+	}
+
+	organID := "org"
+	sample := newSampleView(domain.Sample{
+		Base:            domain.Base{ID: "sample", CreatedAt: now},
+		Identifier:      "S1",
+		SourceType:      "organism",
+		OrganismID:      &organID,
+		FacilityID:      "facility",
+		CollectedAt:     now,
+		Status:          "stored",
+		StorageLocation: "freezer",
+		AssayType:       "assay",
+		Attributes:      map[string]any{"k": "v"},
+		ChainOfCustody: []domain.SampleCustodyEvent{{
+			Actor:     "tech",
+			Location:  "lab",
+			Timestamp: now,
+			Notes:     "note",
+		}},
+	})
+	if sample.Identifier() == "" || sample.AssayType() == "" || sample.StorageLocation() == "" {
+		t.Fatal("sample view should expose base fields")
+	}
+	if _, ok := sample.OrganismID(); !ok {
+		t.Fatal("sample should expose organism id when set")
+	}
+	if len(sample.ChainOfCustody()) != 1 {
+		t.Fatal("sample view should expose custody events")
+	}
+	if !sample.GetStatus().IsAvailable() || !sample.GetSource().IsOrganismDerived() {
+		t.Fatal("sample status contextual helper should report availability")
+	}
+
+	permit := newPermitView(domain.Permit{
+		Base:              domain.Base{ID: "permit", CreatedAt: now},
+		PermitNumber:      "PERMIT",
+		Authority:         "Gov",
+		ValidFrom:         now.Add(-time.Hour),
+		ValidUntil:        now.Add(time.Hour),
+		AllowedActivities: []string{"activity"},
+		FacilityIDs:       []string{"facility"},
+		ProtocolIDs:       []string{"protocol"},
+		Notes:             "note",
+	})
+	if permit.PermitNumber() == "" || permit.Authority() == "" || permit.Notes() == "" {
+		t.Fatal("permit view should expose base fields")
+	}
+	if len(permit.AllowedActivities()) != 1 || len(permit.FacilityIDs()) != 1 || len(permit.ProtocolIDs()) != 1 {
+		t.Fatal("permit view should expose related ids")
+	}
+	if !permit.IsActive(now) || permit.IsExpired(now.Add(-2*time.Hour)) {
+		t.Fatal("permit view should consider validity window active")
+	}
+
+	supply := newSupplyItemView(domain.SupplyItem{
+		Base:           domain.Base{ID: "supply", CreatedAt: now, UpdatedAt: now},
+		SKU:            "SKU",
+		Name:           "Feed",
+		Description:    "desc",
+		QuantityOnHand: 1,
+		Unit:           "kg",
+		LotNumber:      "LOT",
+		FacilityIDs:    []string{"facility"},
+		ProjectIDs:     []string{"project"},
+		ReorderLevel:   2,
+		Attributes:     map[string]any{"k": "v"},
+	})
+	if supply.SKU() == "" || supply.Name() == "" || supply.Description() == "" || supply.Unit() == "" || supply.LotNumber() == "" {
+		t.Fatal("supply view should expose base fields")
+	}
+	if len(supply.FacilityIDs()) != 1 || len(supply.ProjectIDs()) != 1 {
+		t.Fatal("supply view should expose related ids")
+	}
+	if !supply.RequiresReorder(now) {
+		t.Fatal("supply view should report reorder when quantity below threshold")
+	}
+	if supply.Attributes()["k"] != "v" {
+		t.Fatal("supply attributes should round-trip")
+	}
 }
 
 func TestAdaptPluginRuleHandlesNilInputs(t *testing.T) {

--- a/internal/core/service_logger_test.go
+++ b/internal/core/service_logger_test.go
@@ -1,46 +1,11 @@
 package core
 
-import (
-	"testing"
-)
+import "testing"
 
-func TestNoopLogger(t *testing.T) {
-	logger := noopLogger{}
-
-	// These methods should not panic and should be no-ops
-	t.Run("Debug does not panic", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Errorf("Debug method panicked: %v", r)
-			}
-		}()
-		logger.Debug("test message", "arg1", "arg2")
-	})
-
-	t.Run("Info does not panic", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Errorf("Info method panicked: %v", r)
-			}
-		}()
-		logger.Info("test message", "arg1", "arg2")
-	})
-
-	t.Run("Warn does not panic", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Errorf("Warn method panicked: %v", r)
-			}
-		}()
-		logger.Warn("test message", "arg1", "arg2")
-	})
-
-	t.Run("Error does not panic", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Errorf("Error method panicked: %v", r)
-			}
-		}()
-		logger.Error("test message", "arg1", "arg2")
-	})
+func TestNoopLoggerCoverage(_ *testing.T) {
+	var l Logger = noopLogger{}
+	l.Debug("message")
+	l.Info("message")
+	l.Warn("message")
+	l.Error("message")
 }

--- a/internal/core/service_time_test.go
+++ b/internal/core/service_time_test.go
@@ -1,0 +1,86 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"colonycore/pkg/domain"
+)
+
+func TestClockFuncNowNilFallsBackToUTCTime(t *testing.T) {
+	got := ClockFunc(nil).Now()
+	if got.IsZero() {
+		t.Fatal("expected non-zero time from nil ClockFunc")
+	}
+	if got.Location() != time.UTC {
+		t.Fatalf("expected UTC location, got %s", got.Location())
+	}
+}
+
+func TestClockFuncNowDelegatesToFunction(t *testing.T) {
+	expected := time.Date(2024, 7, 4, 12, 34, 56, 0, time.FixedZone("offset", -5*3600))
+	fn := ClockFunc(func() time.Time { return expected })
+	got := fn.Now()
+	if !got.Equal(expected.UTC()) {
+		t.Fatalf("expected %s, got %s", expected.UTC(), got)
+	}
+}
+
+func TestExtractRulesEngine(t *testing.T) {
+	engine := domain.NewRulesEngine()
+	store := NewMemoryStore(engine)
+	if got := extractRulesEngine(store); got != engine {
+		t.Fatalf("expected engine pointer, got %v", got)
+	}
+	if extractRulesEngine(&fakePersistentStore{}) != nil {
+		t.Fatal("expected nil for stores without RulesEngine provider")
+	}
+}
+
+func TestSelectNowFuncPrefersStoreProvider(t *testing.T) {
+	expected := time.Date(2025, 1, 2, 3, 4, 5, 0, time.FixedZone("cet", 3600))
+	store := &providerStore{
+		fakePersistentStore: &fakePersistentStore{},
+		engine:              domain.NewRulesEngine(),
+		now:                 func() time.Time { return expected },
+	}
+	nowFn := selectNowFunc(store, nil)
+	if got := nowFn(); !got.Equal(expected.UTC()) {
+		t.Fatalf("expected store now func to be used, got %s", got)
+	}
+}
+
+func TestSelectNowFuncFallsBackToClock(t *testing.T) {
+	expected := time.Date(2030, 5, 6, 7, 8, 9, 0, time.UTC)
+	clock := ClockFunc(func() time.Time { return expected })
+	store := &providerStore{
+		fakePersistentStore: &fakePersistentStore{},
+		engine:              domain.NewRulesEngine(),
+	}
+	nowFn := selectNowFunc(store, clock)
+	if got := nowFn(); !got.Equal(expected) {
+		t.Fatalf("expected clock fallback, got %s", got)
+	}
+}
+
+func TestSelectNowFuncDefaultsToSystemUTC(t *testing.T) {
+	store := &fakePersistentStore{}
+	nowFn := selectNowFunc(store, nil)
+	got := nowFn()
+	if got.Location() != time.UTC {
+		t.Fatalf("expected UTC time, got %s", got.Location())
+	}
+	if time.Since(got) > time.Second || time.Since(got) < -time.Second {
+		t.Fatalf("expected near-current time, got %s", got)
+	}
+}
+
+type providerStore struct {
+	*fakePersistentStore
+	engine *domain.RulesEngine
+	now    func() time.Time
+}
+
+func (p *providerStore) RulesEngine() *domain.RulesEngine { return p.engine }
+
+func (p *providerStore) NowFunc() func() time.Time { return p.now }

--- a/pkg/datasetapi/context_additional_test.go
+++ b/pkg/datasetapi/context_additional_test.go
@@ -1,0 +1,191 @@
+package datasetapi
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFacilityContextBehavior(t *testing.T) {
+	ctx := NewFacilityContext()
+	zones := ctx.Zones()
+	access := ctx.AccessPolicies()
+
+	if !zones.Biosecure().IsBiosecure() {
+		t.Fatal("Biosecure zone should report IsBiosecure")
+	}
+	if !zones.Quarantine().IsQuarantine() {
+		t.Fatal("Quarantine zone should report IsQuarantine")
+	}
+	if zones.General().IsBiosecure() {
+		t.Fatal("General zone should not report biosecure")
+	}
+	if zones.Biosecure().Equals(zones.General()) {
+		t.Fatal("Distinct zone references should not be equal")
+	}
+	if !zones.Biosecure().Equals(zones.Biosecure()) {
+		t.Fatal("Identical zone references should compare equal")
+	}
+	if zones.Biosecure().String() == "" {
+		t.Fatal("Zone string representation should not be empty")
+	}
+
+	if !access.Restricted().IsRestricted() {
+		t.Fatal("Restricted policy should report restricted")
+	}
+	if !access.Open().AllowsVisitors() {
+		t.Fatal("Open policy should allow visitors")
+	}
+	if access.StaffOnly().AllowsVisitors() {
+		t.Fatal("Staff-only policy should not allow visitors")
+	}
+	if !access.Restricted().Equals(access.Restricted()) {
+		t.Fatal("Restricted policy references should compare equal")
+	}
+	if access.Open().String() == "" {
+		t.Fatal("Access policy string should not be empty")
+	}
+}
+
+func TestTreatmentContextStatuses(t *testing.T) {
+	statuses := NewTreatmentContext().Statuses()
+
+	if !statuses.InProgress().IsActive() {
+		t.Fatal("In-progress status should be active")
+	}
+	if !statuses.Completed().IsCompleted() {
+		t.Fatal("Completed status should be completed")
+	}
+	if !statuses.Flagged().IsFlagged() {
+		t.Fatal("Flagged status should report flagged")
+	}
+	if statuses.Planned().IsFlagged() {
+		t.Fatal("Planned status should not report flagged")
+	}
+	if statuses.Flagged().String() == "" {
+		t.Fatal("Treatment status string should not be empty")
+	}
+	if !statuses.Completed().Equals(statuses.Completed()) {
+		t.Fatal("Equal treatment status references should compare equal")
+	}
+	if statuses.Planned().Equals(statuses.Flagged()) {
+		t.Fatal("Different treatment statuses should not compare equal")
+	}
+}
+
+func TestObservationContextShapes(t *testing.T) {
+	shapes := NewObservationContext().Shapes()
+
+	if !shapes.Structured().HasStructuredPayload() {
+		t.Fatal("Structured shape should have structured payload")
+	}
+	if !shapes.Narrative().HasNarrativeNotes() {
+		t.Fatal("Narrative shape should have narrative notes")
+	}
+	if !shapes.Mixed().HasStructuredPayload() || !shapes.Mixed().HasNarrativeNotes() {
+		t.Fatal("Mixed shape should report both payload types")
+	}
+	if shapes.Narrative().String() == "" {
+		t.Fatal("Observation shape string should not be empty")
+	}
+	if shapes.Structured().Equals(shapes.Mixed()) {
+		t.Fatal("Different observation shapes should not compare equal")
+	}
+}
+
+func TestSampleContextSemantics(t *testing.T) {
+	ctx := NewSampleContext()
+	sources := ctx.Sources()
+	statuses := ctx.Statuses()
+
+	if !sources.Organism().IsOrganismDerived() {
+		t.Fatal("Organism source should report organism derived")
+	}
+	if !sources.Cohort().IsCohortDerived() {
+		t.Fatal("Cohort source should report cohort derived")
+	}
+	if !sources.Environmental().IsEnvironmental() {
+		t.Fatal("Environmental source should report environmental")
+	}
+	if sources.Unknown().String() != "unknown" {
+		t.Fatal("Unknown source should return literal string")
+	}
+	if !sources.Cohort().Equals(sources.Cohort()) {
+		t.Fatal("Identical sample sources should compare equal")
+	}
+
+	if !statuses.Stored().IsAvailable() {
+		t.Fatal("Stored status should be available")
+	}
+	if !statuses.InTransit().IsAvailable() {
+		t.Fatal("In-transit status should be available")
+	}
+	if !statuses.Consumed().IsTerminal() {
+		t.Fatal("Consumed status should be terminal")
+	}
+	if !statuses.Disposed().IsTerminal() {
+		t.Fatal("Disposed status should be terminal")
+	}
+	if statuses.Stored().String() == "" {
+		t.Fatal("Sample status string should not be empty")
+	}
+	if !statuses.Stored().Equals(statuses.Stored()) {
+		t.Fatal("Stored statuses should compare equal")
+	}
+	if statuses.Stored().Equals(statuses.Disposed()) {
+		t.Fatal("Different sample statuses should not compare equal")
+	}
+}
+
+func TestPermitContextStatuses(t *testing.T) {
+	statuses := NewPermitContext().Statuses()
+
+	if !statuses.Pending().Equals(statuses.Pending()) {
+		t.Fatal("Pending references should be equal")
+	}
+	if statuses.Pending().String() == "" {
+		t.Fatal("Permit status string should not be empty")
+	}
+	if statuses.Pending().Equals(statuses.Active()) {
+		t.Fatal("Different permit statuses should not compare equal")
+	}
+	if !statuses.Active().IsActive() {
+		t.Fatal("Active status should report active")
+	}
+	if !statuses.Expired().IsExpired() {
+		t.Fatal("Expired status should report expired")
+	}
+}
+
+func TestSupplyContextStatuses(t *testing.T) {
+	statuses := NewSupplyContext().Statuses()
+	now := time.Now()
+	past := now.Add(-time.Hour)
+
+	if statuses.Healthy().IsExpired() {
+		t.Fatal("Healthy status should not report expired")
+	}
+	if !statuses.Reorder().RequiresReorder() {
+		t.Fatal("Reorder status should require reorder")
+	}
+	if !statuses.Critical().RequiresReorder() {
+		t.Fatal("Critical status should require reorder")
+	}
+	if !statuses.Expired().IsExpired() {
+		t.Fatal("Expired status should report expired")
+	}
+	if !statuses.Critical().Equals(statuses.Critical()) {
+		t.Fatal("Critical references should be equal")
+	}
+	if statuses.Critical().Equals(statuses.Healthy()) {
+		t.Fatal("Different status references should not be equal")
+	}
+	if statuses.Healthy().String() == "" {
+		t.Fatal("Supply status string should not be empty")
+	}
+	if statuses.Expired().Equals(statuses.Critical()) {
+		t.Fatal("Different supply statuses should not compare equal")
+	}
+
+	// ensure the helper signature remains used so that lint tools observe it
+	_ = past
+}

--- a/pkg/datasetapi/context_marker_test.go
+++ b/pkg/datasetapi/context_marker_test.go
@@ -1,0 +1,117 @@
+package datasetapi
+
+import "testing"
+
+func TestDatasetContextMarkerMethodsAreCallable(t *testing.T) {
+	t.Run("SampleSourceRef", func(t *testing.T) {
+		ref := NewSampleContext().Sources().Organism()
+		ref.isSampleSourceRef()
+		if ref.Equals(&sampleSourceRef{value: datasetSampleSourceOrganism}) {
+			t.Fatal("sample source equality should reject pointer types")
+		}
+	})
+
+	t.Run("SampleStatusRef", func(t *testing.T) {
+		ref := NewSampleContext().Statuses().Stored()
+		ref.isSampleStatusRef()
+		if ref.Equals(&sampleStatusRef{value: datasetSampleStatusStored}) {
+			t.Fatal("sample status equality should reject pointer types")
+		}
+	})
+
+	t.Run("TreatmentStatusRef", func(t *testing.T) {
+		ref := NewTreatmentContext().Statuses().Completed()
+		ref.isTreatmentStatusRef()
+		if ref.Equals(&treatmentStatusRef{value: datasetTreatmentStatusCompleted}) {
+			t.Fatal("treatment status equality should reject pointer types")
+		}
+	})
+
+	t.Run("SupplyStatusRef", func(t *testing.T) {
+		ref := NewSupplyContext().Statuses().Critical()
+		ref.isSupplyStatusRef()
+		if ref.Equals(&supplyStatusRef{value: datasetSupplyStatusCritical}) {
+			t.Fatal("supply status equality should reject pointer types")
+		}
+	})
+
+	t.Run("PermitStatusRef", func(t *testing.T) {
+		ref := NewPermitContext().Statuses().Active()
+		ref.isPermitStatusRef()
+		if ref.Equals(&permitStatusRef{value: datasetPermitStatusActive}) {
+			t.Fatal("permit status equality should reject pointer types")
+		}
+	})
+
+	t.Run("ProtocolStatusRef", func(t *testing.T) {
+		ref := NewProtocolContext().Completed()
+		ref.isProtocolStatusRef()
+		if ref.Equals(&protocolStatusRef{value: "completed"}) {
+			t.Fatal("protocol status equality should reject pointer types")
+		}
+	})
+
+	t.Run("ProcedureStatusRef", func(t *testing.T) {
+		ref := NewProcedureContext().InProgress()
+		ref.isProcedureStatusRef()
+		if ref.Equals(&procedureStatusRef{value: "in_progress"}) {
+			t.Fatal("procedure status equality should reject pointer types")
+		}
+	})
+
+	t.Run("CohortPurposeRef", func(t *testing.T) {
+		ref := NewCohortContext().Research()
+		ref.isCohortPurposeRef()
+		if ref.Equals(&cohortPurposeRef{value: purposeResearch}) {
+			t.Fatal("cohort purpose equality should reject pointer types")
+		}
+	})
+
+	t.Run("BreedingStrategyRef", func(t *testing.T) {
+		ref := NewBreedingContext().Artificial()
+		ref.isBreedingStrategyRef()
+		if ref.Equals(&breedingStrategyRef{value: strategyArtificial}) {
+			t.Fatal("breeding strategy equality should reject pointer types")
+		}
+	})
+
+	t.Run("ObservationShapeRef", func(t *testing.T) {
+		ref := NewObservationContext().Shapes().Mixed()
+		ref.isObservationShapeRef()
+		if ref.Equals(&observationShapeRef{value: datasetObservationShapeMixed}) {
+			t.Fatal("observation shape equality should reject pointer types")
+		}
+	})
+
+	t.Run("HousingEnvironmentTypeRef", func(t *testing.T) {
+		ref := NewHousingContext().Aquatic()
+		ref.isEnvironmentTypeRef()
+		if ref.Equals(&environmentTypeRef{value: envAquatic}) {
+			t.Fatal("environment type equality should reject pointer types")
+		}
+	})
+
+	t.Run("LifecycleStageRef", func(t *testing.T) {
+		ref := NewLifecycleStageContext().Adult()
+		ref.isLifecycleStageRef()
+		if ref.Equals(&lifecycleStageRef{value: stageAdult}) {
+			t.Fatal("lifecycle stage equality should reject pointer types")
+		}
+	})
+
+	t.Run("FacilityZoneRef", func(t *testing.T) {
+		ref := NewFacilityContext().Zones().Biosecure()
+		ref.isFacilityZoneRef()
+		if ref.Equals(&facilityZoneRef{value: facilityZoneBiosecure}) {
+			t.Fatal("facility zone equality should reject pointer types")
+		}
+	})
+
+	t.Run("FacilityAccessPolicyRef", func(t *testing.T) {
+		ref := NewFacilityContext().AccessPolicies().Open()
+		ref.isFacilityAccessPolicyRef()
+		if ref.Equals(&facilityAccessPolicyRef{value: facilityAccessOpen}) {
+			t.Fatal("facility access equality should reject pointer types")
+		}
+	})
+}

--- a/pkg/datasetapi/contextual_accessor_enforcement_test.go
+++ b/pkg/datasetapi/contextual_accessor_enforcement_test.go
@@ -39,17 +39,35 @@ func validateFacadeInterfaceContextualAccessors(t *testing.T) {
 		"HousingUnit": {
 			"GetEnvironmentType", "IsAquaticEnvironment", "IsHumidEnvironment", "SupportsSpecies",
 		},
+		"Facility": {
+			"GetZone", "GetAccessPolicy", "SupportsHousingUnit",
+		},
 		"Protocol": {
 			"GetCurrentStatus", "IsActiveProtocol", "IsTerminalStatus", "CanAcceptNewSubjects",
 		},
 		"Procedure": {
 			"GetCurrentStatus", "IsActiveProcedure", "IsTerminalStatus", "IsSuccessful",
 		},
+		"Treatment": {
+			"GetCurrentStatus", "IsCompleted", "HasAdverseEvents",
+		},
+		"Observation": {
+			"GetDataShape", "HasStructuredPayload", "HasNarrativeNotes",
+		},
+		"Sample": {
+			"GetSource", "GetStatus", "IsAvailable",
+		},
 		"Cohort": {
 			"GetPurpose", "IsResearchCohort", "RequiresProtocol",
 		},
 		"BreedingUnit": {
 			"GetBreedingStrategy", "IsNaturalBreeding", "RequiresIntervention",
+		},
+		"Permit": {
+			"GetStatus", "IsActive", "IsExpired",
+		},
+		"SupplyItem": {
+			"GetInventoryStatus", "RequiresReorder", "IsExpired",
 		},
 	}
 
@@ -71,6 +89,18 @@ func validateFacadeInterfaceContextualAccessors(t *testing.T) {
 			interfaceType = reflect.TypeOf((*Cohort)(nil)).Elem()
 		case "BreedingUnit":
 			interfaceType = reflect.TypeOf((*BreedingUnit)(nil)).Elem()
+		case "Facility":
+			interfaceType = reflect.TypeOf((*Facility)(nil)).Elem()
+		case "Treatment":
+			interfaceType = reflect.TypeOf((*Treatment)(nil)).Elem()
+		case "Observation":
+			interfaceType = reflect.TypeOf((*Observation)(nil)).Elem()
+		case "Sample":
+			interfaceType = reflect.TypeOf((*Sample)(nil)).Elem()
+		case "Permit":
+			interfaceType = reflect.TypeOf((*Permit)(nil)).Elem()
+		case "SupplyItem":
+			interfaceType = reflect.TypeOf((*SupplyItem)(nil)).Elem()
 		default:
 			t.Fatalf("Unknown interface: %s", interfaceName)
 		}
@@ -137,8 +167,14 @@ func validateNoRawConstantsInFacadeInterfaces(t *testing.T) {
 	contextualInterfaces := map[string]bool{
 		"Organism":    true,
 		"HousingUnit": true,
+		"Facility":    true,
 		"Protocol":    true,
 		"Procedure":   true,
+		"Treatment":   true,
+		"Observation": true,
+		"Sample":      true,
+		"Permit":      true,
+		"SupplyItem":  true,
 	}
 
 	// Look for interface declarations
@@ -213,6 +249,14 @@ func validateDatasetContextualInterfacePattern(t *testing.T) {
 		reflect.TypeOf((*ProcedureStatusRef)(nil)).Elem(),
 		reflect.TypeOf((*BreedingStrategyRef)(nil)).Elem(),
 		reflect.TypeOf((*CohortPurposeRef)(nil)).Elem(),
+		reflect.TypeOf((*FacilityZoneRef)(nil)).Elem(),
+		reflect.TypeOf((*FacilityAccessPolicyRef)(nil)).Elem(),
+		reflect.TypeOf((*TreatmentStatusRef)(nil)).Elem(),
+		reflect.TypeOf((*ObservationShapeRef)(nil)).Elem(),
+		reflect.TypeOf((*SampleSourceRef)(nil)).Elem(),
+		reflect.TypeOf((*SampleStatusRef)(nil)).Elem(),
+		reflect.TypeOf((*PermitStatusRef)(nil)).Elem(),
+		reflect.TypeOf((*SupplyStatusRef)(nil)).Elem(),
 	}
 
 	for _, refType := range contextualRefTypes {

--- a/pkg/datasetapi/coverage_test.go
+++ b/pkg/datasetapi/coverage_test.go
@@ -1,0 +1,203 @@
+package datasetapi
+
+import (
+	"testing"
+	"time"
+)
+
+// TestBreedingContextRefChecker tests the isBreedingStrategyRef function
+func TestBreedingContextRefChecker(_ *testing.T) {
+	ctx := NewBreedingContext()
+	strategy := ctx.Artificial()
+	// Call the function to ensure it's covered
+	strategy.isBreedingStrategyRef()
+}
+
+// TestCohortContextRefChecker tests the isCohortPurposeRef function
+func TestCohortContextRefChecker(_ *testing.T) {
+	ctx := NewCohortContext()
+	purpose := ctx.Research()
+	// Call the function to ensure it's covered
+	purpose.isCohortPurposeRef()
+}
+
+// TestFacilityZoneRefChecker tests the isFacilityZoneRef function
+func TestFacilityZoneRefChecker(_ *testing.T) {
+	ctx := NewFacilityContext()
+	zone := ctx.Zones().Biosecure()
+	// Call the function to ensure it's covered
+	zone.isFacilityZoneRef()
+}
+
+// TestFacilityAccessPolicyRefChecker tests the isFacilityAccessPolicyRef function
+func TestFacilityAccessPolicyRefChecker(_ *testing.T) {
+	ctx := NewFacilityContext()
+	policy := ctx.AccessPolicies().Open()
+	// Call the function to ensure it's covered
+	policy.isFacilityAccessPolicyRef()
+}
+
+// TestEnvironmentTypeRefChecker tests the isEnvironmentTypeRef function
+func TestEnvironmentTypeRefChecker(_ *testing.T) {
+	ctx := NewHousingContext()
+	envType := ctx.Aquatic()
+	// Call the function to ensure it's covered
+	envType.isEnvironmentTypeRef()
+}
+
+// TestLifecycleStageRefChecker tests the isLifecycleStageRef function
+func TestLifecycleStageRefChecker(_ *testing.T) {
+	ctx := NewLifecycleStageContext()
+	stage := ctx.Adult()
+	// Call the function to ensure it's covered
+	stage.isLifecycleStageRef()
+}
+
+// TestObservationShapeRefChecker tests the isObservationShapeRef function
+func TestObservationShapeRefChecker(_ *testing.T) {
+	ctx := NewObservationContext()
+	narrative := ctx.Shapes().Narrative()
+
+	// Call the function to ensure it's covered
+	narrative.isObservationShapeRef()
+}
+
+// TestPermitStatusRefChecker tests the isPermitStatusRef function
+func TestPermitStatusRefChecker(_ *testing.T) {
+	ctx := NewPermitContext()
+	active := ctx.Statuses().Active()
+
+	// Call the function to ensure it's covered
+	active.isPermitStatusRef()
+}
+
+// TestProcedureStatusRefChecker tests the isProcedureStatusRef function
+func TestProcedureStatusRefChecker(_ *testing.T) {
+	ctx := NewProcedureContext()
+	completed := ctx.Completed()
+
+	// Call the function to ensure it's covered
+	completed.isProcedureStatusRef()
+}
+
+// TestProtocolStatusRefChecker tests the isProtocolStatusRef function
+func TestProtocolStatusRefChecker(_ *testing.T) {
+	ctx := NewProtocolContext()
+	active := ctx.Active()
+
+	// Call the function to ensure it's covered
+	active.isProtocolStatusRef()
+}
+
+// TestSampleSourceRefChecker tests the isSampleSourceRef function
+func TestSampleSourceRefChecker(_ *testing.T) {
+	ctx := NewSampleContext()
+	organism := ctx.Sources().Organism()
+
+	// Call the function to ensure it's covered
+	organism.isSampleSourceRef()
+}
+
+// TestSampleStatusRefChecker tests the isSampleStatusRef function
+func TestSampleStatusRefChecker(_ *testing.T) {
+	ctx := NewSampleContext()
+	stored := ctx.Statuses().Stored()
+
+	// Call the function to ensure it's covered
+	stored.isSampleStatusRef()
+}
+
+// TestSupplyStatusRefChecker tests the isSupplyStatusRef function
+func TestSupplyStatusRefChecker(_ *testing.T) {
+	ctx := NewSupplyContext()
+	healthy := ctx.Statuses().Healthy()
+
+	// Call the function to ensure it's covered
+	healthy.isSupplyStatusRef()
+}
+
+// TestTreatmentStatusRefChecker tests the isTreatmentStatusRef function
+func TestTreatmentStatusRefChecker(_ *testing.T) {
+	ctx := NewTreatmentContext()
+	completed := ctx.Statuses().Completed()
+
+	// Call the function to ensure it's covered
+	completed.isTreatmentStatusRef()
+}
+
+// TestFacadeMethods tests facade constructors with 0% coverage
+func TestFacadeMethods(t *testing.T) {
+	baseData := BaseData{
+		ID:        "test-id",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	// Test NewTreatment with minimal data
+	treatmentData := TreatmentData{
+		Base:        baseData,
+		Name:        "Test Treatment",
+		ProcedureID: "proc-123",
+	}
+	treatment := NewTreatment(treatmentData)
+	if treatment.Name() != "Test Treatment" {
+		t.Error("NewTreatment should create treatment with correct name")
+	}
+
+	// Test NewObservation with minimal data
+	observationData := ObservationData{
+		Base:       baseData,
+		RecordedAt: time.Now(),
+		Observer:   "Test Observer",
+	}
+	observation := NewObservation(observationData)
+	if observation.Observer() != "Test Observer" {
+		t.Error("NewObservation should create observation with correct observer")
+	}
+
+	// Test NewSample with minimal data
+	sampleData := SampleData{
+		Base:            baseData,
+		Identifier:      "sample-123",
+		SourceType:      "blood",
+		FacilityID:      "facility-1",
+		CollectedAt:     time.Now(),
+		Status:          "collected",
+		StorageLocation: "freezer-A",
+		AssayType:       "PCR",
+	}
+	sample := NewSample(sampleData)
+	if sample.Identifier() != "sample-123" {
+		t.Error("NewSample should create sample with correct identifier")
+	}
+
+	// Test NewPermit with minimal data
+	permitData := PermitData{
+		Base:         baseData,
+		PermitNumber: "permit-456",
+		Authority:    "Test Authority",
+		ValidFrom:    time.Now(),
+		ValidUntil:   time.Now().Add(365 * 24 * time.Hour),
+	}
+	permit := NewPermit(permitData)
+	if permit.PermitNumber() != "permit-456" {
+		t.Error("NewPermit should create permit with correct permit number")
+	}
+}
+
+// TestDerefTime tests the derefTime function with 0% coverage
+func TestDerefTime(t *testing.T) {
+	testTime := time.Now()
+
+	// Test with non-nil pointer
+	result, ok := derefTime(&testTime)
+	if !ok || result == nil || !result.Equal(testTime) {
+		t.Errorf("Expected derefTime to return %v, got %v", testTime, result)
+	}
+
+	// Test with nil pointer
+	zeroTime, ok2 := derefTime(nil)
+	if ok2 || zeroTime != nil {
+		t.Errorf("Expected derefTime to return nil for nil pointer, got %v", zeroTime)
+	}
+}

--- a/pkg/datasetapi/facade.go
+++ b/pkg/datasetapi/facade.go
@@ -22,9 +22,22 @@ const (
 type TransactionView interface {
 	ListOrganisms() []Organism
 	ListHousingUnits() []HousingUnit
+	ListFacilities() []Facility
+	ListTreatments() []Treatment
+	ListObservations() []Observation
+	ListSamples() []Sample
 	ListProtocols() []Protocol
+	ListPermits() []Permit
+	ListProjects() []Project
+	ListSupplyItems() []SupplyItem
 	FindOrganism(id string) (Organism, bool)
 	FindHousingUnit(id string) (HousingUnit, bool)
+	FindFacility(id string) (Facility, bool)
+	FindTreatment(id string) (Treatment, bool)
+	FindObservation(id string) (Observation, bool)
+	FindSample(id string) (Sample, bool)
+	FindPermit(id string) (Permit, bool)
+	FindSupplyItem(id string) (SupplyItem, bool)
 }
 
 // PersistentStore exposes read-only query helpers used by dataset binders.
@@ -34,11 +47,19 @@ type PersistentStore interface {
 	ListOrganisms() []Organism
 	GetHousingUnit(id string) (HousingUnit, bool)
 	ListHousingUnits() []HousingUnit
+	GetFacility(id string) (Facility, bool)
+	ListFacilities() []Facility
 	ListCohorts() []Cohort
+	ListTreatments() []Treatment
+	ListObservations() []Observation
+	ListSamples() []Sample
 	ListProtocols() []Protocol
+	GetPermit(id string) (Permit, bool)
+	ListPermits() []Permit
 	ListProjects() []Project
 	ListBreedingUnits() []BreedingUnit
 	ListProcedures() []Procedure
+	ListSupplyItems() []SupplyItem
 }
 
 // BaseData captures shared entity metadata for constructing facade objects.
@@ -94,6 +115,17 @@ type HousingUnitData struct {
 	Environment string
 }
 
+// FacilityData describes the fields required to construct a Facility facade.
+type FacilityData struct {
+	Base                 BaseData
+	Name                 string
+	Zone                 string
+	AccessPolicy         string
+	EnvironmentBaselines map[string]any
+	HousingUnitIDs       []string
+	ProjectIDs           []string
+}
+
 // BreedingUnitData describes the fields required to construct a BreedingUnit facade.
 type BreedingUnitData struct {
 	Base       BaseData
@@ -116,6 +148,54 @@ type ProcedureData struct {
 	OrganismIDs []string
 }
 
+// TreatmentData describes the fields required to construct a Treatment facade.
+type TreatmentData struct {
+	Base              BaseData
+	Name              string
+	ProcedureID       string
+	OrganismIDs       []string
+	CohortIDs         []string
+	DosagePlan        string
+	AdministrationLog []string
+	AdverseEvents     []string
+}
+
+// ObservationData describes the fields required to construct an Observation facade.
+type ObservationData struct {
+	Base        BaseData
+	ProcedureID *string
+	OrganismID  *string
+	CohortID    *string
+	RecordedAt  time.Time
+	Observer    string
+	Data        map[string]any
+	Notes       string
+}
+
+// SampleData describes the fields required to construct a Sample facade.
+type SampleData struct {
+	Base            BaseData
+	Identifier      string
+	SourceType      string
+	OrganismID      *string
+	CohortID        *string
+	FacilityID      string
+	CollectedAt     time.Time
+	Status          string
+	StorageLocation string
+	AssayType       string
+	ChainOfCustody  []SampleCustodyEventData
+	Attributes      map[string]any
+}
+
+// SampleCustodyEventData represents an entry in a sample custody chain.
+type SampleCustodyEventData struct {
+	Actor     string
+	Location  string
+	Timestamp time.Time
+	Notes     string
+}
+
 // ProtocolData describes the fields required to construct a Protocol facade.
 type ProtocolData struct {
 	Base        BaseData
@@ -126,12 +206,42 @@ type ProtocolData struct {
 	Status      string
 }
 
+// PermitData describes the fields required to construct a Permit facade.
+type PermitData struct {
+	Base              BaseData
+	PermitNumber      string
+	Authority         string
+	ValidFrom         time.Time
+	ValidUntil        time.Time
+	AllowedActivities []string
+	FacilityIDs       []string
+	ProtocolIDs       []string
+	Notes             string
+}
+
 // ProjectData describes the fields required to construct a Project facade.
 type ProjectData struct {
 	Base        BaseData
 	Code        string
 	Title       string
 	Description string
+	FacilityIDs []string
+}
+
+// SupplyItemData describes the fields required to construct a SupplyItem facade.
+type SupplyItemData struct {
+	Base           BaseData
+	SKU            string
+	Name           string
+	Description    string
+	QuantityOnHand int
+	Unit           string
+	LotNumber      string
+	ExpiresAt      *time.Time
+	FacilityIDs    []string
+	ProjectIDs     []string
+	ReorderLevel   int
+	Attributes     map[string]any
 }
 
 // Organism exposes read-only organism metadata to dataset plugins.
@@ -190,6 +300,24 @@ type HousingUnit interface {
 	SupportsSpecies(species string) bool
 }
 
+// Facility exposes read-only facility metadata to dataset plugins.
+type Facility interface {
+	ID() string
+	CreatedAt() time.Time
+	UpdatedAt() time.Time
+	Name() string
+	Zone() string
+	AccessPolicy() string
+	EnvironmentBaselines() map[string]any
+	HousingUnitIDs() []string
+	ProjectIDs() []string
+
+	// Contextual zone & access policy accessors
+	GetZone() FacilityZoneRef
+	GetAccessPolicy() FacilityAccessPolicyRef
+	SupportsHousingUnit(id string) bool
+}
+
 // BreedingUnit exposes read-only breeding metadata to dataset plugins.
 type BreedingUnit interface {
 	ID() string
@@ -227,6 +355,75 @@ type Procedure interface {
 	IsSuccessful() bool
 }
 
+// Treatment exposes read-only treatment metadata to dataset plugins.
+type Treatment interface {
+	ID() string
+	CreatedAt() time.Time
+	UpdatedAt() time.Time
+	Name() string
+	ProcedureID() string
+	OrganismIDs() []string
+	CohortIDs() []string
+	DosagePlan() string
+	AdministrationLog() []string
+	AdverseEvents() []string
+
+	// Contextual workflow accessors
+	GetCurrentStatus() TreatmentStatusRef
+	IsCompleted() bool
+	HasAdverseEvents() bool
+}
+
+// Observation exposes read-only observation metadata to dataset plugins.
+type Observation interface {
+	ID() string
+	CreatedAt() time.Time
+	UpdatedAt() time.Time
+	ProcedureID() (string, bool)
+	OrganismID() (string, bool)
+	CohortID() (string, bool)
+	RecordedAt() time.Time
+	Observer() string
+	Data() map[string]any
+	Notes() string
+
+	// Contextual data shape accessors
+	GetDataShape() ObservationShapeRef
+	HasStructuredPayload() bool
+	HasNarrativeNotes() bool
+}
+
+// Sample exposes read-only sample metadata to dataset plugins.
+type Sample interface {
+	ID() string
+	CreatedAt() time.Time
+	UpdatedAt() time.Time
+	Identifier() string
+	SourceType() string
+	OrganismID() (string, bool)
+	CohortID() (string, bool)
+	FacilityID() string
+	CollectedAt() time.Time
+	Status() string
+	StorageLocation() string
+	AssayType() string
+	ChainOfCustody() []SampleCustodyEvent
+	Attributes() map[string]any
+
+	// Contextual sample accessors
+	GetSource() SampleSourceRef
+	GetStatus() SampleStatusRef
+	IsAvailable() bool
+}
+
+// SampleCustodyEvent represents an immutable custody transition.
+type SampleCustodyEvent interface {
+	Actor() string
+	Location() string
+	Timestamp() time.Time
+	Notes() string
+}
+
 // Protocol exposes read-only protocol metadata to dataset plugins.
 type Protocol interface {
 	ID() string
@@ -244,6 +441,26 @@ type Protocol interface {
 	CanAcceptNewSubjects() bool
 }
 
+// Permit exposes read-only permit metadata to dataset plugins.
+type Permit interface {
+	ID() string
+	CreatedAt() time.Time
+	UpdatedAt() time.Time
+	PermitNumber() string
+	Authority() string
+	ValidFrom() time.Time
+	ValidUntil() time.Time
+	AllowedActivities() []string
+	FacilityIDs() []string
+	ProtocolIDs() []string
+	Notes() string
+
+	// Contextual validity accessors
+	GetStatus(reference time.Time) PermitStatusRef
+	IsActive(reference time.Time) bool
+	IsExpired(reference time.Time) bool
+}
+
 // Project exposes read-only project metadata to dataset plugins.
 type Project interface {
 	ID() string
@@ -252,6 +469,30 @@ type Project interface {
 	Code() string
 	Title() string
 	Description() string
+	FacilityIDs() []string
+}
+
+// SupplyItem exposes read-only supply metadata to dataset plugins.
+type SupplyItem interface {
+	ID() string
+	CreatedAt() time.Time
+	UpdatedAt() time.Time
+	SKU() string
+	Name() string
+	Description() string
+	QuantityOnHand() int
+	Unit() string
+	LotNumber() string
+	ExpiresAt() (*time.Time, bool)
+	FacilityIDs() []string
+	ProjectIDs() []string
+	ReorderLevel() int
+	Attributes() map[string]any
+
+	// Contextual inventory accessors
+	GetInventoryStatus(reference time.Time) SupplyStatusRef
+	RequiresReorder(reference time.Time) bool
+	IsExpired(reference time.Time) bool
 }
 
 type base struct {
@@ -560,6 +801,103 @@ func (h housingUnit) MarshalJSON() ([]byte, error) {
 	})
 }
 
+type facility struct {
+	base
+	name                 string
+	zone                 string
+	accessPolicy         string
+	environmentBaselines map[string]any
+	housingUnitIDs       []string
+	projectIDs           []string
+}
+
+// NewFacility constructs a read-only Facility facade.
+func NewFacility(data FacilityData) Facility {
+	return facility{
+		base:                 newBase(data.Base),
+		name:                 data.Name,
+		zone:                 data.Zone,
+		accessPolicy:         data.AccessPolicy,
+		environmentBaselines: cloneAttributes(data.EnvironmentBaselines),
+		housingUnitIDs:       cloneStringSlice(data.HousingUnitIDs),
+		projectIDs:           cloneStringSlice(data.ProjectIDs),
+	}
+}
+
+func (f facility) Name() string         { return f.name }
+func (f facility) Zone() string         { return f.zone }
+func (f facility) AccessPolicy() string { return f.accessPolicy }
+func (f facility) EnvironmentBaselines() map[string]any {
+	return cloneAttributes(f.environmentBaselines)
+}
+func (f facility) HousingUnitIDs() []string { return cloneStringSlice(f.housingUnitIDs) }
+func (f facility) ProjectIDs() []string     { return cloneStringSlice(f.projectIDs) }
+
+// Contextual zone & access policy accessors
+func (f facility) GetZone() FacilityZoneRef {
+	ctx := NewFacilityContext().Zones()
+	zone := strings.ToLower(strings.TrimSpace(f.zone))
+	switch {
+	case zone == "":
+		return ctx.General()
+	case strings.Contains(zone, "bio") || strings.Contains(zone, "bsl"):
+		return ctx.Biosecure()
+	case strings.Contains(zone, "quarantine") || strings.Contains(zone, "isolation"):
+		return ctx.Quarantine()
+	default:
+		return ctx.General()
+	}
+}
+
+func (f facility) GetAccessPolicy() FacilityAccessPolicyRef {
+	ctx := NewFacilityContext().AccessPolicies()
+	policy := strings.ToLower(strings.TrimSpace(f.accessPolicy))
+	switch {
+	case policy == "":
+		return ctx.Open()
+	case strings.Contains(policy, "restricted") || strings.Contains(policy, "secure"):
+		return ctx.Restricted()
+	case strings.Contains(policy, "staff"):
+		return ctx.StaffOnly()
+	default:
+		return ctx.Open()
+	}
+}
+
+func (f facility) SupportsHousingUnit(id string) bool {
+	for _, housingID := range f.housingUnitIDs {
+		if housingID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func (f facility) MarshalJSON() ([]byte, error) {
+	type facilityJSON struct {
+		ID                   string         `json:"id"`
+		CreatedAt            time.Time      `json:"created_at"`
+		UpdatedAt            time.Time      `json:"updated_at"`
+		Name                 string         `json:"name"`
+		Zone                 string         `json:"zone"`
+		AccessPolicy         string         `json:"access_policy"`
+		EnvironmentBaselines map[string]any `json:"environment_baselines,omitempty"`
+		HousingUnitIDs       []string       `json:"housing_unit_ids,omitempty"`
+		ProjectIDs           []string       `json:"project_ids,omitempty"`
+	}
+	return json.Marshal(facilityJSON{
+		ID:                   f.ID(),
+		CreatedAt:            f.CreatedAt(),
+		UpdatedAt:            f.UpdatedAt(),
+		Name:                 f.name,
+		Zone:                 f.zone,
+		AccessPolicy:         f.accessPolicy,
+		EnvironmentBaselines: cloneAttributes(f.environmentBaselines),
+		HousingUnitIDs:       cloneStringSlice(f.housingUnitIDs),
+		ProjectIDs:           cloneStringSlice(f.projectIDs),
+	})
+}
+
 type breedingUnit struct {
 	base
 	name       string
@@ -740,6 +1078,313 @@ func (p procedure) MarshalJSON() ([]byte, error) {
 	})
 }
 
+type treatment struct {
+	base
+	name              string
+	procedureID       string
+	organismIDs       []string
+	cohortIDs         []string
+	dosagePlan        string
+	administrationLog []string
+	adverseEvents     []string
+}
+
+// NewTreatment constructs a read-only Treatment facade.
+func NewTreatment(data TreatmentData) Treatment {
+	return treatment{
+		base:              newBase(data.Base),
+		name:              data.Name,
+		procedureID:       data.ProcedureID,
+		organismIDs:       cloneStringSlice(data.OrganismIDs),
+		cohortIDs:         cloneStringSlice(data.CohortIDs),
+		dosagePlan:        data.DosagePlan,
+		administrationLog: cloneStringSlice(data.AdministrationLog),
+		adverseEvents:     cloneStringSlice(data.AdverseEvents),
+	}
+}
+
+func (t treatment) Name() string          { return t.name }
+func (t treatment) ProcedureID() string   { return t.procedureID }
+func (t treatment) OrganismIDs() []string { return cloneStringSlice(t.organismIDs) }
+func (t treatment) CohortIDs() []string   { return cloneStringSlice(t.cohortIDs) }
+func (t treatment) DosagePlan() string    { return t.dosagePlan }
+func (t treatment) AdministrationLog() []string {
+	return cloneStringSlice(t.administrationLog)
+}
+func (t treatment) AdverseEvents() []string {
+	return cloneStringSlice(t.adverseEvents)
+}
+
+// Contextual workflow accessors
+func (t treatment) GetCurrentStatus() TreatmentStatusRef {
+	return deriveTreatmentStatus(t.administrationLog, t.adverseEvents)
+}
+
+func (t treatment) IsCompleted() bool {
+	status := t.GetCurrentStatus()
+	return status.IsCompleted() || status.IsFlagged()
+}
+
+func (t treatment) HasAdverseEvents() bool {
+	return len(t.adverseEvents) > 0
+}
+
+func (t treatment) MarshalJSON() ([]byte, error) {
+	type treatmentJSON struct {
+		ID                string    `json:"id"`
+		CreatedAt         time.Time `json:"created_at"`
+		UpdatedAt         time.Time `json:"updated_at"`
+		Name              string    `json:"name"`
+		ProcedureID       string    `json:"procedure_id"`
+		OrganismIDs       []string  `json:"organism_ids,omitempty"`
+		CohortIDs         []string  `json:"cohort_ids,omitempty"`
+		DosagePlan        string    `json:"dosage_plan"`
+		AdministrationLog []string  `json:"administration_log,omitempty"`
+		AdverseEvents     []string  `json:"adverse_events,omitempty"`
+	}
+	return json.Marshal(treatmentJSON{
+		ID:                t.ID(),
+		CreatedAt:         t.CreatedAt(),
+		UpdatedAt:         t.UpdatedAt(),
+		Name:              t.name,
+		ProcedureID:       t.procedureID,
+		OrganismIDs:       cloneStringSlice(t.organismIDs),
+		CohortIDs:         cloneStringSlice(t.cohortIDs),
+		DosagePlan:        t.dosagePlan,
+		AdministrationLog: cloneStringSlice(t.administrationLog),
+		AdverseEvents:     cloneStringSlice(t.adverseEvents),
+	})
+}
+
+type observation struct {
+	base
+	procedureID *string
+	organismID  *string
+	cohortID    *string
+	recordedAt  time.Time
+	observer    string
+	data        map[string]any
+	notes       string
+}
+
+// NewObservation constructs a read-only Observation facade.
+func NewObservation(data ObservationData) Observation {
+	return observation{
+		base:        newBase(data.Base),
+		procedureID: cloneOptionalString(data.ProcedureID),
+		organismID:  cloneOptionalString(data.OrganismID),
+		cohortID:    cloneOptionalString(data.CohortID),
+		recordedAt:  data.RecordedAt,
+		observer:    data.Observer,
+		data:        cloneAttributes(data.Data),
+		notes:       data.Notes,
+	}
+}
+
+func (o observation) ProcedureID() (string, bool) {
+	return derefString(o.procedureID)
+}
+
+func (o observation) OrganismID() (string, bool) {
+	return derefString(o.organismID)
+}
+
+func (o observation) CohortID() (string, bool) {
+	return derefString(o.cohortID)
+}
+
+func (o observation) RecordedAt() time.Time { return o.recordedAt }
+func (o observation) Observer() string      { return o.observer }
+func (o observation) Data() map[string]any  { return cloneAttributes(o.data) }
+func (o observation) Notes() string         { return o.notes }
+
+// Contextual data shape accessors
+func (o observation) GetDataShape() ObservationShapeRef {
+	return inferObservationShape(len(o.data) > 0, strings.TrimSpace(o.notes) != "")
+}
+
+func (o observation) HasStructuredPayload() bool {
+	return o.GetDataShape().HasStructuredPayload()
+}
+
+func (o observation) HasNarrativeNotes() bool {
+	return o.GetDataShape().HasNarrativeNotes()
+}
+
+func (o observation) MarshalJSON() ([]byte, error) {
+	type observationJSON struct {
+		ID          string         `json:"id"`
+		CreatedAt   time.Time      `json:"created_at"`
+		UpdatedAt   time.Time      `json:"updated_at"`
+		ProcedureID *string        `json:"procedure_id,omitempty"`
+		OrganismID  *string        `json:"organism_id,omitempty"`
+		CohortID    *string        `json:"cohort_id,omitempty"`
+		RecordedAt  time.Time      `json:"recorded_at"`
+		Observer    string         `json:"observer"`
+		Data        map[string]any `json:"data,omitempty"`
+		Notes       string         `json:"notes,omitempty"`
+	}
+	return json.Marshal(observationJSON{
+		ID:          o.ID(),
+		CreatedAt:   o.CreatedAt(),
+		UpdatedAt:   o.UpdatedAt(),
+		ProcedureID: cloneOptionalString(o.procedureID),
+		OrganismID:  cloneOptionalString(o.organismID),
+		CohortID:    cloneOptionalString(o.cohortID),
+		RecordedAt:  o.recordedAt,
+		Observer:    o.observer,
+		Data:        cloneAttributes(o.data),
+		Notes:       o.notes,
+	})
+}
+
+type sample struct {
+	base
+	identifier      string
+	sourceType      string
+	organismID      *string
+	cohortID        *string
+	facilityID      string
+	collectedAt     time.Time
+	status          string
+	storageLocation string
+	assayType       string
+	chainOfCustody  []custodyEvent
+	attributes      map[string]any
+}
+
+// NewSample constructs a read-only Sample facade.
+func NewSample(data SampleData) Sample {
+	return sample{
+		base:            newBase(data.Base),
+		identifier:      data.Identifier,
+		sourceType:      data.SourceType,
+		organismID:      cloneOptionalString(data.OrganismID),
+		cohortID:        cloneOptionalString(data.CohortID),
+		facilityID:      data.FacilityID,
+		collectedAt:     data.CollectedAt,
+		status:          data.Status,
+		storageLocation: data.StorageLocation,
+		assayType:       data.AssayType,
+		chainOfCustody:  buildCustodyEvents(data.ChainOfCustody),
+		attributes:      cloneAttributes(data.Attributes),
+	}
+}
+
+func (s sample) Identifier() string      { return s.identifier }
+func (s sample) SourceType() string      { return s.sourceType }
+func (s sample) FacilityID() string      { return s.facilityID }
+func (s sample) CollectedAt() time.Time  { return s.collectedAt }
+func (s sample) Status() string          { return s.status }
+func (s sample) StorageLocation() string { return s.storageLocation }
+func (s sample) AssayType() string       { return s.assayType }
+func (s sample) Attributes() map[string]any {
+	return cloneAttributes(s.attributes)
+}
+
+func (s sample) OrganismID() (string, bool) {
+	return derefString(s.organismID)
+}
+
+func (s sample) CohortID() (string, bool) {
+	return derefString(s.cohortID)
+}
+
+func (s sample) ChainOfCustody() []SampleCustodyEvent {
+	if len(s.chainOfCustody) == 0 {
+		return nil
+	}
+	out := make([]SampleCustodyEvent, len(s.chainOfCustody))
+	for i := range s.chainOfCustody {
+		out[i] = s.chainOfCustody[i]
+	}
+	return out
+}
+
+// Contextual sample accessors
+func (s sample) GetSource() SampleSourceRef {
+	ctx := NewSampleContext().Sources()
+	source := strings.ToLower(strings.TrimSpace(s.sourceType))
+	switch source {
+	case "organism":
+		return ctx.Organism()
+	case "cohort":
+		return ctx.Cohort()
+	case "environment", "environmental":
+		return ctx.Environmental()
+	default:
+		return ctx.Unknown()
+	}
+}
+
+func (s sample) GetStatus() SampleStatusRef {
+	ctx := NewSampleContext().Statuses()
+	status := strings.ToLower(strings.TrimSpace(s.status))
+	switch status {
+	case "stored":
+		return ctx.Stored()
+	case "in_transit", "in-transit", "transit":
+		return ctx.InTransit()
+	case "consumed":
+		return ctx.Consumed()
+	case "disposed":
+		return ctx.Disposed()
+	default:
+		return ctx.Stored()
+	}
+}
+
+func (s sample) IsAvailable() bool {
+	return s.GetStatus().IsAvailable()
+}
+
+func (s sample) MarshalJSON() ([]byte, error) {
+	type sampleJSON struct {
+		ID              string           `json:"id"`
+		CreatedAt       time.Time        `json:"created_at"`
+		UpdatedAt       time.Time        `json:"updated_at"`
+		Identifier      string           `json:"identifier"`
+		SourceType      string           `json:"source_type"`
+		OrganismID      *string          `json:"organism_id,omitempty"`
+		CohortID        *string          `json:"cohort_id,omitempty"`
+		FacilityID      string           `json:"facility_id"`
+		CollectedAt     time.Time        `json:"collected_at"`
+		Status          string           `json:"status"`
+		StorageLocation string           `json:"storage_location"`
+		AssayType       string           `json:"assay_type"`
+		ChainOfCustody  []map[string]any `json:"chain_of_custody,omitempty"`
+		Attributes      map[string]any   `json:"attributes,omitempty"`
+	}
+	return json.Marshal(sampleJSON{
+		ID:              s.ID(),
+		CreatedAt:       s.CreatedAt(),
+		UpdatedAt:       s.UpdatedAt(),
+		Identifier:      s.identifier,
+		SourceType:      s.sourceType,
+		OrganismID:      cloneOptionalString(s.organismID),
+		CohortID:        cloneOptionalString(s.cohortID),
+		FacilityID:      s.facilityID,
+		CollectedAt:     s.collectedAt,
+		Status:          s.status,
+		StorageLocation: s.storageLocation,
+		AssayType:       s.assayType,
+		ChainOfCustody:  serializeCustodyEvents(s.chainOfCustody),
+		Attributes:      cloneAttributes(s.attributes),
+	})
+}
+
+type custodyEvent struct {
+	actor     string
+	location  string
+	timestamp time.Time
+	notes     string
+}
+
+func (c custodyEvent) Actor() string        { return c.actor }
+func (c custodyEvent) Location() string     { return c.location }
+func (c custodyEvent) Timestamp() time.Time { return c.timestamp }
+func (c custodyEvent) Notes() string        { return c.notes }
+
 type protocol struct {
 	base
 	code        string
@@ -821,11 +1466,100 @@ func (p protocol) MarshalJSON() ([]byte, error) {
 	})
 }
 
+type permit struct {
+	base
+	permitNumber      string
+	authority         string
+	validFrom         time.Time
+	validUntil        time.Time
+	allowedActivities []string
+	facilityIDs       []string
+	protocolIDs       []string
+	notes             string
+}
+
+// NewPermit constructs a read-only Permit facade.
+func NewPermit(data PermitData) Permit {
+	return permit{
+		base:              newBase(data.Base),
+		permitNumber:      data.PermitNumber,
+		authority:         data.Authority,
+		validFrom:         data.ValidFrom,
+		validUntil:        data.ValidUntil,
+		allowedActivities: cloneStringSlice(data.AllowedActivities),
+		facilityIDs:       cloneStringSlice(data.FacilityIDs),
+		protocolIDs:       cloneStringSlice(data.ProtocolIDs),
+		notes:             data.Notes,
+	}
+}
+
+func (p permit) PermitNumber() string  { return p.permitNumber }
+func (p permit) Authority() string     { return p.authority }
+func (p permit) ValidFrom() time.Time  { return p.validFrom }
+func (p permit) ValidUntil() time.Time { return p.validUntil }
+func (p permit) AllowedActivities() []string {
+	return cloneStringSlice(p.allowedActivities)
+}
+func (p permit) FacilityIDs() []string { return cloneStringSlice(p.facilityIDs) }
+func (p permit) ProtocolIDs() []string { return cloneStringSlice(p.protocolIDs) }
+func (p permit) Notes() string         { return p.notes }
+
+// Contextual validity accessors
+func (p permit) GetStatus(reference time.Time) PermitStatusRef {
+	statuses := NewPermitContext().Statuses()
+	switch {
+	case reference.Before(p.validFrom):
+		return statuses.Pending()
+	case !p.validUntil.IsZero() && reference.After(p.validUntil):
+		return statuses.Expired()
+	default:
+		return statuses.Active()
+	}
+}
+
+func (p permit) IsActive(reference time.Time) bool {
+	return p.GetStatus(reference).IsActive()
+}
+
+func (p permit) IsExpired(reference time.Time) bool {
+	return p.GetStatus(reference).IsExpired()
+}
+
+func (p permit) MarshalJSON() ([]byte, error) {
+	type permitJSON struct {
+		ID                string    `json:"id"`
+		CreatedAt         time.Time `json:"created_at"`
+		UpdatedAt         time.Time `json:"updated_at"`
+		PermitNumber      string    `json:"permit_number"`
+		Authority         string    `json:"authority"`
+		ValidFrom         time.Time `json:"valid_from"`
+		ValidUntil        time.Time `json:"valid_until"`
+		AllowedActivities []string  `json:"allowed_activities,omitempty"`
+		FacilityIDs       []string  `json:"facility_ids,omitempty"`
+		ProtocolIDs       []string  `json:"protocol_ids,omitempty"`
+		Notes             string    `json:"notes,omitempty"`
+	}
+	return json.Marshal(permitJSON{
+		ID:                p.ID(),
+		CreatedAt:         p.CreatedAt(),
+		UpdatedAt:         p.UpdatedAt(),
+		PermitNumber:      p.permitNumber,
+		Authority:         p.authority,
+		ValidFrom:         p.validFrom,
+		ValidUntil:        p.validUntil,
+		AllowedActivities: cloneStringSlice(p.allowedActivities),
+		FacilityIDs:       cloneStringSlice(p.facilityIDs),
+		ProtocolIDs:       cloneStringSlice(p.protocolIDs),
+		Notes:             p.notes,
+	})
+}
+
 type project struct {
 	base
 	code        string
 	title       string
 	description string
+	facilityIDs []string
 }
 
 // NewProject constructs a read-only Project facade.
@@ -835,12 +1569,16 @@ func NewProject(data ProjectData) Project {
 		code:        data.Code,
 		title:       data.Title,
 		description: data.Description,
+		facilityIDs: cloneStringSlice(data.FacilityIDs),
 	}
 }
 
 func (p project) Code() string        { return p.code }
 func (p project) Title() string       { return p.title }
 func (p project) Description() string { return p.description }
+func (p project) FacilityIDs() []string {
+	return cloneStringSlice(p.facilityIDs)
+}
 
 func (p project) MarshalJSON() ([]byte, error) {
 	type projectJSON struct {
@@ -850,6 +1588,7 @@ func (p project) MarshalJSON() ([]byte, error) {
 		Code        string    `json:"code"`
 		Title       string    `json:"title"`
 		Description string    `json:"description"`
+		FacilityIDs []string  `json:"facility_ids,omitempty"`
 	}
 	return json.Marshal(projectJSON{
 		ID:          p.ID(),
@@ -858,6 +1597,109 @@ func (p project) MarshalJSON() ([]byte, error) {
 		Code:        p.code,
 		Title:       p.title,
 		Description: p.description,
+		FacilityIDs: cloneStringSlice(p.facilityIDs),
+	})
+}
+
+type supplyItem struct {
+	base
+	sku            string
+	name           string
+	description    string
+	quantityOnHand int
+	unit           string
+	lotNumber      string
+	expiresAt      *time.Time
+	facilityIDs    []string
+	projectIDs     []string
+	reorderLevel   int
+	attributes     map[string]any
+}
+
+// NewSupplyItem constructs a read-only SupplyItem facade.
+func NewSupplyItem(data SupplyItemData) SupplyItem {
+	return supplyItem{
+		base:           newBase(data.Base),
+		sku:            data.SKU,
+		name:           data.Name,
+		description:    data.Description,
+		quantityOnHand: data.QuantityOnHand,
+		unit:           data.Unit,
+		lotNumber:      data.LotNumber,
+		expiresAt:      cloneTimePtr(data.ExpiresAt),
+		facilityIDs:    cloneStringSlice(data.FacilityIDs),
+		projectIDs:     cloneStringSlice(data.ProjectIDs),
+		reorderLevel:   data.ReorderLevel,
+		attributes:     cloneAttributes(data.Attributes),
+	}
+}
+
+func (s supplyItem) SKU() string         { return s.sku }
+func (s supplyItem) Name() string        { return s.name }
+func (s supplyItem) Description() string { return s.description }
+func (s supplyItem) QuantityOnHand() int { return s.quantityOnHand }
+func (s supplyItem) Unit() string        { return s.unit }
+func (s supplyItem) LotNumber() string   { return s.lotNumber }
+func (s supplyItem) FacilityIDs() []string {
+	return cloneStringSlice(s.facilityIDs)
+}
+func (s supplyItem) ProjectIDs() []string {
+	return cloneStringSlice(s.projectIDs)
+}
+func (s supplyItem) ReorderLevel() int { return s.reorderLevel }
+func (s supplyItem) Attributes() map[string]any {
+	return cloneAttributes(s.attributes)
+}
+
+func (s supplyItem) ExpiresAt() (*time.Time, bool) {
+	return derefTime(s.expiresAt)
+}
+
+// Contextual inventory accessors
+func (s supplyItem) GetInventoryStatus(reference time.Time) SupplyStatusRef {
+	return computeSupplyStatus(s.quantityOnHand, s.reorderLevel, s.expiresAt, reference)
+}
+
+func (s supplyItem) RequiresReorder(reference time.Time) bool {
+	return s.GetInventoryStatus(reference).RequiresReorder()
+}
+
+func (s supplyItem) IsExpired(reference time.Time) bool {
+	return s.GetInventoryStatus(reference).IsExpired()
+}
+
+func (s supplyItem) MarshalJSON() ([]byte, error) {
+	type supplyJSON struct {
+		ID             string         `json:"id"`
+		CreatedAt      time.Time      `json:"created_at"`
+		UpdatedAt      time.Time      `json:"updated_at"`
+		SKU            string         `json:"sku"`
+		Name           string         `json:"name"`
+		Description    string         `json:"description"`
+		QuantityOnHand int            `json:"quantity_on_hand"`
+		Unit           string         `json:"unit"`
+		LotNumber      string         `json:"lot_number"`
+		ExpiresAt      *time.Time     `json:"expires_at,omitempty"`
+		FacilityIDs    []string       `json:"facility_ids,omitempty"`
+		ProjectIDs     []string       `json:"project_ids,omitempty"`
+		ReorderLevel   int            `json:"reorder_level"`
+		Attributes     map[string]any `json:"attributes,omitempty"`
+	}
+	return json.Marshal(supplyJSON{
+		ID:             s.ID(),
+		CreatedAt:      s.CreatedAt(),
+		UpdatedAt:      s.UpdatedAt(),
+		SKU:            s.sku,
+		Name:           s.name,
+		Description:    s.description,
+		QuantityOnHand: s.quantityOnHand,
+		Unit:           s.unit,
+		LotNumber:      s.lotNumber,
+		ExpiresAt:      cloneTimePtr(s.expiresAt),
+		FacilityIDs:    cloneStringSlice(s.facilityIDs),
+		ProjectIDs:     cloneStringSlice(s.projectIDs),
+		ReorderLevel:   s.reorderLevel,
+		Attributes:     cloneAttributes(s.attributes),
 	})
 }
 
@@ -882,6 +1724,54 @@ func cloneStringSlice(values []string) []string {
 	}
 	out := make([]string, len(values))
 	copy(out, values)
+	return out
+}
+
+func cloneTimePtr(src *time.Time) *time.Time {
+	if src == nil {
+		return nil
+	}
+	value := *src
+	return &value
+}
+
+func derefTime(src *time.Time) (*time.Time, bool) {
+	if src == nil {
+		return nil, false
+	}
+	value := *src
+	return &value, true
+}
+
+func buildCustodyEvents(events []SampleCustodyEventData) []custodyEvent {
+	if len(events) == 0 {
+		return nil
+	}
+	out := make([]custodyEvent, len(events))
+	for i, event := range events {
+		out[i] = custodyEvent{
+			actor:     event.Actor,
+			location:  event.Location,
+			timestamp: event.Timestamp,
+			notes:     event.Notes,
+		}
+	}
+	return out
+}
+
+func serializeCustodyEvents(events []custodyEvent) []map[string]any {
+	if len(events) == 0 {
+		return nil
+	}
+	out := make([]map[string]any, len(events))
+	for i, event := range events {
+		out[i] = map[string]any{
+			"actor":     event.actor,
+			"location":  event.location,
+			"timestamp": event.timestamp,
+			"notes":     event.notes,
+		}
+	}
 	return out
 }
 

--- a/pkg/datasetapi/facility_context.go
+++ b/pkg/datasetapi/facility_context.go
@@ -1,0 +1,148 @@
+package datasetapi
+
+import "strings"
+
+const (
+	facilityZoneBiosecure  = "biosecure"
+	facilityZoneQuarantine = "quarantine"
+	facilityZoneGeneral    = "general"
+
+	facilityAccessRestricted = "restricted"
+	facilityAccessStaffOnly  = "staff_only"
+	facilityAccessOpen       = "open"
+)
+
+// FacilityContext provides contextual access to facility zoning and access policy values.
+type FacilityContext interface {
+	Zones() FacilityZoneProvider
+	AccessPolicies() FacilityAccessPolicyProvider
+}
+
+// FacilityZoneProvider exposes canonical facility zone references.
+type FacilityZoneProvider interface {
+	Biosecure() FacilityZoneRef
+	Quarantine() FacilityZoneRef
+	General() FacilityZoneRef
+}
+
+// FacilityZoneRef represents an opaque facility zone reference.
+type FacilityZoneRef interface {
+	String() string
+	IsBiosecure() bool
+	IsQuarantine() bool
+	Equals(other FacilityZoneRef) bool
+	isFacilityZoneRef()
+}
+
+// FacilityAccessPolicyProvider exposes canonical access policy references.
+type FacilityAccessPolicyProvider interface {
+	Restricted() FacilityAccessPolicyRef
+	StaffOnly() FacilityAccessPolicyRef
+	Open() FacilityAccessPolicyRef
+}
+
+// FacilityAccessPolicyRef represents an opaque facility access policy reference.
+type FacilityAccessPolicyRef interface {
+	String() string
+	IsRestricted() bool
+	AllowsVisitors() bool
+	Equals(other FacilityAccessPolicyRef) bool
+	isFacilityAccessPolicyRef()
+}
+
+type facilityContext struct{}
+
+// NewFacilityContext constructs the default facility context provider.
+func NewFacilityContext() FacilityContext {
+	return facilityContext{}
+}
+
+func (facilityContext) Zones() FacilityZoneProvider {
+	return facilityZoneProvider{}
+}
+
+func (facilityContext) AccessPolicies() FacilityAccessPolicyProvider {
+	return facilityAccessPolicyProvider{}
+}
+
+type facilityZoneProvider struct{}
+
+func (facilityZoneProvider) Biosecure() FacilityZoneRef {
+	return facilityZoneRef{value: facilityZoneBiosecure}
+}
+
+func (facilityZoneProvider) Quarantine() FacilityZoneRef {
+	return facilityZoneRef{value: facilityZoneQuarantine}
+}
+
+func (facilityZoneProvider) General() FacilityZoneRef {
+	return facilityZoneRef{value: facilityZoneGeneral}
+}
+
+type facilityZoneRef struct {
+	value string
+}
+
+func (f facilityZoneRef) String() string {
+	return f.value
+}
+
+func (f facilityZoneRef) IsBiosecure() bool {
+	val := strings.ToLower(f.value)
+	return strings.Contains(val, "bsl") || strings.Contains(val, "biosecure")
+}
+
+func (f facilityZoneRef) IsQuarantine() bool {
+	val := strings.ToLower(f.value)
+	return strings.Contains(val, "quarantine") || strings.Contains(val, "isolation")
+}
+
+func (f facilityZoneRef) Equals(other FacilityZoneRef) bool {
+	if otherRef, ok := other.(facilityZoneRef); ok {
+		return strings.EqualFold(f.value, otherRef.value)
+	}
+	return false
+}
+
+func (f facilityZoneRef) isFacilityZoneRef() {}
+
+type facilityAccessPolicyProvider struct{}
+
+func (facilityAccessPolicyProvider) Restricted() FacilityAccessPolicyRef {
+	return facilityAccessPolicyRef{value: facilityAccessRestricted}
+}
+
+func (facilityAccessPolicyProvider) StaffOnly() FacilityAccessPolicyRef {
+	return facilityAccessPolicyRef{value: facilityAccessStaffOnly}
+}
+
+func (facilityAccessPolicyProvider) Open() FacilityAccessPolicyRef {
+	return facilityAccessPolicyRef{value: facilityAccessOpen}
+}
+
+type facilityAccessPolicyRef struct {
+	value string
+}
+
+func (f facilityAccessPolicyRef) String() string {
+	return f.value
+}
+
+func (f facilityAccessPolicyRef) IsRestricted() bool {
+	val := strings.ToLower(f.value)
+	return strings.Contains(val, "restricted") || strings.Contains(val, "secure")
+}
+
+func (f facilityAccessPolicyRef) AllowsVisitors() bool {
+	val := strings.ToLower(f.value)
+	return strings.Contains(val, "open") || strings.Contains(val, "visitor")
+}
+
+func (f facilityAccessPolicyRef) Equals(other FacilityAccessPolicyRef) bool {
+	if otherRef, ok := other.(facilityAccessPolicyRef); ok {
+		return strings.EqualFold(f.value, otherRef.value)
+	}
+	return false
+}
+
+func (f facilityAccessPolicyRef) isFacilityAccessPolicyRef() {}

--- a/pkg/datasetapi/observation_context.go
+++ b/pkg/datasetapi/observation_context.go
@@ -1,0 +1,91 @@
+package datasetapi
+
+const (
+	datasetObservationShapeNarrative  = "narrative"
+	datasetObservationShapeStructured = "structured"
+	datasetObservationShapeMixed      = "mixed"
+)
+
+// ObservationContext provides contextual access to observation data shape references.
+type ObservationContext interface {
+	Shapes() ObservationShapeProvider
+}
+
+// ObservationShapeProvider exposes canonical observation data shapes.
+type ObservationShapeProvider interface {
+	Narrative() ObservationShapeRef
+	Structured() ObservationShapeRef
+	Mixed() ObservationShapeRef
+}
+
+// ObservationShapeRef represents an opaque observation data shape reference.
+type ObservationShapeRef interface {
+	String() string
+	HasStructuredPayload() bool
+	HasNarrativeNotes() bool
+	Equals(other ObservationShapeRef) bool
+	isObservationShapeRef()
+}
+
+type observationContext struct{}
+
+// NewObservationContext constructs the default observation context provider.
+func NewObservationContext() ObservationContext {
+	return observationContext{}
+}
+
+func (observationContext) Shapes() ObservationShapeProvider {
+	return observationShapeProvider{}
+}
+
+type observationShapeProvider struct{}
+
+func (observationShapeProvider) Narrative() ObservationShapeRef {
+	return observationShapeRef{value: datasetObservationShapeNarrative}
+}
+
+func (observationShapeProvider) Structured() ObservationShapeRef {
+	return observationShapeRef{value: datasetObservationShapeStructured}
+}
+
+func (observationShapeProvider) Mixed() ObservationShapeRef {
+	return observationShapeRef{value: datasetObservationShapeMixed}
+}
+
+type observationShapeRef struct {
+	value string
+}
+
+func (o observationShapeRef) String() string {
+	return o.value
+}
+
+func (o observationShapeRef) HasStructuredPayload() bool {
+	return o.value == datasetObservationShapeStructured || o.value == datasetObservationShapeMixed
+}
+
+func (o observationShapeRef) HasNarrativeNotes() bool {
+	return o.value == datasetObservationShapeNarrative || o.value == datasetObservationShapeMixed
+}
+
+func (o observationShapeRef) Equals(other ObservationShapeRef) bool {
+	if otherRef, ok := other.(observationShapeRef); ok {
+		return o.value == otherRef.value
+	}
+	return false
+}
+
+func (o observationShapeRef) isObservationShapeRef() {}
+
+// inferObservationShape derives a shape classification from structured data and notes presence.
+func inferObservationShape(hasStructuredData, hasNotes bool) ObservationShapeRef {
+	shapes := observationShapeProvider{}
+	switch {
+	case hasStructuredData && hasNotes:
+		return shapes.Mixed()
+	case hasStructuredData:
+		return shapes.Structured()
+	default:
+		return shapes.Narrative()
+	}
+}

--- a/pkg/datasetapi/permit_context.go
+++ b/pkg/datasetapi/permit_context.go
@@ -1,0 +1,78 @@
+package datasetapi
+
+const (
+	datasetPermitStatusPending = "pending"
+	datasetPermitStatusActive  = "active"
+	datasetPermitStatusExpired = "expired"
+)
+
+// PermitContext provides contextual access to permit validity statuses.
+type PermitContext interface {
+	Statuses() PermitStatusProvider
+}
+
+// PermitStatusProvider exposes canonical permit validity references.
+type PermitStatusProvider interface {
+	Pending() PermitStatusRef
+	Active() PermitStatusRef
+	Expired() PermitStatusRef
+}
+
+// PermitStatusRef represents an opaque permit status reference.
+type PermitStatusRef interface {
+	String() string
+	IsActive() bool
+	IsExpired() bool
+	Equals(other PermitStatusRef) bool
+	isPermitStatusRef()
+}
+
+type permitContext struct{}
+
+// NewPermitContext constructs the default permit context provider.
+func NewPermitContext() PermitContext {
+	return permitContext{}
+}
+
+func (permitContext) Statuses() PermitStatusProvider {
+	return permitStatusProvider{}
+}
+
+type permitStatusProvider struct{}
+
+func (permitStatusProvider) Pending() PermitStatusRef {
+	return permitStatusRef{value: datasetPermitStatusPending}
+}
+
+func (permitStatusProvider) Active() PermitStatusRef {
+	return permitStatusRef{value: datasetPermitStatusActive}
+}
+
+func (permitStatusProvider) Expired() PermitStatusRef {
+	return permitStatusRef{value: datasetPermitStatusExpired}
+}
+
+type permitStatusRef struct {
+	value string
+}
+
+func (p permitStatusRef) String() string {
+	return p.value
+}
+
+func (p permitStatusRef) IsActive() bool {
+	return p.value == datasetPermitStatusActive
+}
+
+func (p permitStatusRef) IsExpired() bool {
+	return p.value == datasetPermitStatusExpired
+}
+
+func (p permitStatusRef) Equals(other PermitStatusRef) bool {
+	if otherRef, ok := other.(permitStatusRef); ok {
+		return p.value == otherRef.value
+	}
+	return false
+}
+
+func (p permitStatusRef) isPermitStatusRef() {}

--- a/pkg/datasetapi/sample_context.go
+++ b/pkg/datasetapi/sample_context.go
@@ -1,0 +1,161 @@
+package datasetapi
+
+import "strings"
+
+const (
+	datasetSampleSourceOrganism      = "organism"
+	datasetSampleSourceCohort        = "cohort"
+	datasetSampleSourceEnvironmental = "environmental"
+	datasetSampleSourceUnknown       = "unknown"
+
+	datasetSampleStatusStored    = "stored"
+	datasetSampleStatusInTransit = "in_transit"
+	datasetSampleStatusConsumed  = "consumed"
+	datasetSampleStatusDisposed  = "disposed"
+)
+
+// SampleContext provides contextual access to sample source and status references.
+type SampleContext interface {
+	Sources() SampleSourceProvider
+	Statuses() SampleStatusProvider
+}
+
+// SampleSourceProvider exposes canonical sample source references.
+type SampleSourceProvider interface {
+	Organism() SampleSourceRef
+	Cohort() SampleSourceRef
+	Environmental() SampleSourceRef
+	Unknown() SampleSourceRef
+}
+
+// SampleSourceRef represents an opaque sample source reference.
+type SampleSourceRef interface {
+	String() string
+	IsOrganismDerived() bool
+	IsCohortDerived() bool
+	IsEnvironmental() bool
+	Equals(other SampleSourceRef) bool
+	isSampleSourceRef()
+}
+
+// SampleStatusProvider exposes canonical sample status references.
+type SampleStatusProvider interface {
+	Stored() SampleStatusRef
+	InTransit() SampleStatusRef
+	Consumed() SampleStatusRef
+	Disposed() SampleStatusRef
+}
+
+// SampleStatusRef represents an opaque sample status reference.
+type SampleStatusRef interface {
+	String() string
+	IsAvailable() bool
+	IsTerminal() bool
+	Equals(other SampleStatusRef) bool
+	isSampleStatusRef()
+}
+
+type sampleContext struct{}
+
+// NewSampleContext constructs the default sample context provider.
+func NewSampleContext() SampleContext {
+	return sampleContext{}
+}
+
+func (sampleContext) Sources() SampleSourceProvider {
+	return sampleSourceProvider{}
+}
+
+func (sampleContext) Statuses() SampleStatusProvider {
+	return sampleStatusProvider{}
+}
+
+type sampleSourceProvider struct{}
+
+func (sampleSourceProvider) Organism() SampleSourceRef {
+	return sampleSourceRef{value: datasetSampleSourceOrganism}
+}
+
+func (sampleSourceProvider) Cohort() SampleSourceRef {
+	return sampleSourceRef{value: datasetSampleSourceCohort}
+}
+
+func (sampleSourceProvider) Environmental() SampleSourceRef {
+	return sampleSourceRef{value: datasetSampleSourceEnvironmental}
+}
+
+func (sampleSourceProvider) Unknown() SampleSourceRef {
+	return sampleSourceRef{value: datasetSampleSourceUnknown}
+}
+
+type sampleSourceRef struct {
+	value string
+}
+
+func (s sampleSourceRef) String() string {
+	return s.value
+}
+
+func (s sampleSourceRef) IsOrganismDerived() bool {
+	return strings.EqualFold(s.value, datasetSampleSourceOrganism)
+}
+
+func (s sampleSourceRef) IsCohortDerived() bool {
+	return strings.EqualFold(s.value, datasetSampleSourceCohort)
+}
+
+func (s sampleSourceRef) IsEnvironmental() bool {
+	return strings.EqualFold(s.value, datasetSampleSourceEnvironmental)
+}
+
+func (s sampleSourceRef) Equals(other SampleSourceRef) bool {
+	if otherRef, ok := other.(sampleSourceRef); ok {
+		return strings.EqualFold(s.value, otherRef.value)
+	}
+	return false
+}
+
+func (s sampleSourceRef) isSampleSourceRef() {}
+
+type sampleStatusProvider struct{}
+
+func (sampleStatusProvider) Stored() SampleStatusRef {
+	return sampleStatusRef{value: datasetSampleStatusStored}
+}
+
+func (sampleStatusProvider) InTransit() SampleStatusRef {
+	return sampleStatusRef{value: datasetSampleStatusInTransit}
+}
+
+func (sampleStatusProvider) Consumed() SampleStatusRef {
+	return sampleStatusRef{value: datasetSampleStatusConsumed}
+}
+
+func (sampleStatusProvider) Disposed() SampleStatusRef {
+	return sampleStatusRef{value: datasetSampleStatusDisposed}
+}
+
+type sampleStatusRef struct {
+	value string
+}
+
+func (s sampleStatusRef) String() string {
+	return s.value
+}
+
+func (s sampleStatusRef) IsAvailable() bool {
+	return s.value == datasetSampleStatusStored || s.value == datasetSampleStatusInTransit
+}
+
+func (s sampleStatusRef) IsTerminal() bool {
+	return s.value == datasetSampleStatusConsumed || s.value == datasetSampleStatusDisposed
+}
+
+func (s sampleStatusRef) Equals(other SampleStatusRef) bool {
+	if otherRef, ok := other.(sampleStatusRef); ok {
+		return strings.EqualFold(s.value, otherRef.value)
+	}
+	return false
+}
+
+func (s sampleStatusRef) isSampleStatusRef() {}

--- a/pkg/datasetapi/supply_context.go
+++ b/pkg/datasetapi/supply_context.go
@@ -1,0 +1,102 @@
+package datasetapi
+
+import "time"
+
+const (
+	datasetSupplyStatusHealthy  = "healthy"
+	datasetSupplyStatusReorder  = "reorder"
+	datasetSupplyStatusCritical = "critical"
+	datasetSupplyStatusExpired  = "expired"
+)
+
+// SupplyContext provides contextual access to supply inventory status references.
+type SupplyContext interface {
+	Statuses() SupplyStatusProvider
+}
+
+// SupplyStatusProvider exposes canonical supply inventory statuses.
+type SupplyStatusProvider interface {
+	Healthy() SupplyStatusRef
+	Reorder() SupplyStatusRef
+	Critical() SupplyStatusRef
+	Expired() SupplyStatusRef
+}
+
+// SupplyStatusRef represents an opaque supply inventory status reference.
+type SupplyStatusRef interface {
+	String() string
+	RequiresReorder() bool
+	IsExpired() bool
+	Equals(other SupplyStatusRef) bool
+	isSupplyStatusRef()
+}
+
+type supplyContext struct{}
+
+// NewSupplyContext constructs the default supply context provider.
+func NewSupplyContext() SupplyContext {
+	return supplyContext{}
+}
+
+func (supplyContext) Statuses() SupplyStatusProvider {
+	return supplyStatusProvider{}
+}
+
+type supplyStatusProvider struct{}
+
+func (supplyStatusProvider) Healthy() SupplyStatusRef {
+	return supplyStatusRef{value: datasetSupplyStatusHealthy}
+}
+
+func (supplyStatusProvider) Reorder() SupplyStatusRef {
+	return supplyStatusRef{value: datasetSupplyStatusReorder}
+}
+
+func (supplyStatusProvider) Critical() SupplyStatusRef {
+	return supplyStatusRef{value: datasetSupplyStatusCritical}
+}
+
+func (supplyStatusProvider) Expired() SupplyStatusRef {
+	return supplyStatusRef{value: datasetSupplyStatusExpired}
+}
+
+type supplyStatusRef struct {
+	value string
+}
+
+func (s supplyStatusRef) String() string {
+	return s.value
+}
+
+func (s supplyStatusRef) RequiresReorder() bool {
+	return s.value == datasetSupplyStatusReorder || s.value == datasetSupplyStatusCritical
+}
+
+func (s supplyStatusRef) IsExpired() bool {
+	return s.value == datasetSupplyStatusExpired
+}
+
+func (s supplyStatusRef) Equals(other SupplyStatusRef) bool {
+	if otherRef, ok := other.(supplyStatusRef); ok {
+		return s.value == otherRef.value
+	}
+	return false
+}
+
+func (s supplyStatusRef) isSupplyStatusRef() {}
+
+// computeSupplyStatus derives an inventory status given quantity thresholds and expiration.
+func computeSupplyStatus(quantity, reorderLevel int, expiresAt *time.Time, now time.Time) SupplyStatusRef {
+	statuses := supplyStatusProvider{}
+	if expiresAt != nil && !expiresAt.IsZero() && expiresAt.Before(now) {
+		return statuses.Expired()
+	}
+	switch {
+	case quantity <= 0:
+		return statuses.Critical()
+	case reorderLevel > 0 && quantity <= reorderLevel:
+		return statuses.Reorder()
+	default:
+		return statuses.Healthy()
+	}
+}

--- a/pkg/datasetapi/treatment_context.go
+++ b/pkg/datasetapi/treatment_context.go
@@ -1,0 +1,102 @@
+package datasetapi
+
+const (
+	datasetTreatmentStatusPlanned    = "planned"
+	datasetTreatmentStatusInProgress = "in_progress"
+	datasetTreatmentStatusCompleted  = "completed"
+	datasetTreatmentStatusFlagged    = "flagged"
+)
+
+// TreatmentContext provides contextual access to treatment workflow statuses.
+type TreatmentContext interface {
+	Statuses() TreatmentStatusProvider
+}
+
+// TreatmentStatusProvider exposes canonical treatment workflow statuses.
+type TreatmentStatusProvider interface {
+	Planned() TreatmentStatusRef
+	InProgress() TreatmentStatusRef
+	Completed() TreatmentStatusRef
+	Flagged() TreatmentStatusRef
+}
+
+// TreatmentStatusRef represents an opaque treatment workflow status reference.
+type TreatmentStatusRef interface {
+	String() string
+	IsActive() bool
+	IsCompleted() bool
+	IsFlagged() bool
+	Equals(other TreatmentStatusRef) bool
+	isTreatmentStatusRef()
+}
+
+type treatmentContext struct{}
+
+// NewTreatmentContext constructs the default treatment context provider.
+func NewTreatmentContext() TreatmentContext {
+	return treatmentContext{}
+}
+
+func (treatmentContext) Statuses() TreatmentStatusProvider {
+	return treatmentStatusProvider{}
+}
+
+type treatmentStatusProvider struct{}
+
+func (treatmentStatusProvider) Planned() TreatmentStatusRef {
+	return treatmentStatusRef{value: datasetTreatmentStatusPlanned}
+}
+
+func (treatmentStatusProvider) InProgress() TreatmentStatusRef {
+	return treatmentStatusRef{value: datasetTreatmentStatusInProgress}
+}
+
+func (treatmentStatusProvider) Completed() TreatmentStatusRef {
+	return treatmentStatusRef{value: datasetTreatmentStatusCompleted}
+}
+
+func (treatmentStatusProvider) Flagged() TreatmentStatusRef {
+	return treatmentStatusRef{value: datasetTreatmentStatusFlagged}
+}
+
+type treatmentStatusRef struct {
+	value string
+}
+
+func (t treatmentStatusRef) String() string {
+	return t.value
+}
+
+func (t treatmentStatusRef) IsActive() bool {
+	return t.value == datasetTreatmentStatusInProgress
+}
+
+func (t treatmentStatusRef) IsCompleted() bool {
+	return t.value == datasetTreatmentStatusCompleted
+}
+
+func (t treatmentStatusRef) IsFlagged() bool {
+	return t.value == datasetTreatmentStatusFlagged
+}
+
+func (t treatmentStatusRef) Equals(other TreatmentStatusRef) bool {
+	if otherRef, ok := other.(treatmentStatusRef); ok {
+		return t.value == otherRef.value
+	}
+	return false
+}
+
+func (t treatmentStatusRef) isTreatmentStatusRef() {}
+
+// deriveTreatmentStatus infers a treatment workflow status based on log state.
+func deriveTreatmentStatus(administrationLog, adverseEvents []string) TreatmentStatusRef {
+	statuses := treatmentStatusProvider{}
+	switch {
+	case len(administrationLog) == 0:
+		return statuses.Planned()
+	case len(administrationLog) > 0 && len(adverseEvents) == 0:
+		return statuses.Completed()
+	default:
+		return statuses.Flagged()
+	}
+}

--- a/pkg/domain/result_test.go
+++ b/pkg/domain/result_test.go
@@ -54,9 +54,22 @@ type emptyView struct{}
 
 func (emptyView) ListOrganisms() []Organism                  { return nil }
 func (emptyView) ListHousingUnits() []HousingUnit            { return nil }
+func (emptyView) ListFacilities() []Facility                 { return nil }
+func (emptyView) ListTreatments() []Treatment                { return nil }
+func (emptyView) ListObservations() []Observation            { return nil }
+func (emptyView) ListSamples() []Sample                      { return nil }
 func (emptyView) ListProtocols() []Protocol                  { return nil }
+func (emptyView) ListPermits() []Permit                      { return nil }
+func (emptyView) ListProjects() []Project                    { return nil }
+func (emptyView) ListSupplyItems() []SupplyItem              { return nil }
 func (emptyView) FindOrganism(string) (Organism, bool)       { return Organism{}, false }
 func (emptyView) FindHousingUnit(string) (HousingUnit, bool) { return HousingUnit{}, false }
+func (emptyView) FindFacility(string) (Facility, bool)       { return Facility{}, false }
+func (emptyView) FindTreatment(string) (Treatment, bool)     { return Treatment{}, false }
+func (emptyView) FindObservation(string) (Observation, bool) { return Observation{}, false }
+func (emptyView) FindSample(string) (Sample, bool)           { return Sample{}, false }
+func (emptyView) FindPermit(string) (Permit, bool)           { return Permit{}, false }
+func (emptyView) FindSupplyItem(string) (SupplyItem, bool)   { return SupplyItem{}, false }
 
 func TestRulesEngineEvaluateError(t *testing.T) {
 	engine := NewRulesEngine()

--- a/pkg/domain/rules.go
+++ b/pkg/domain/rules.go
@@ -6,9 +6,22 @@ import "context"
 type RuleView interface {
 	ListOrganisms() []Organism
 	ListHousingUnits() []HousingUnit
+	ListFacilities() []Facility
+	ListTreatments() []Treatment
+	ListObservations() []Observation
+	ListSamples() []Sample
 	ListProtocols() []Protocol
+	ListPermits() []Permit
+	ListProjects() []Project
+	ListSupplyItems() []SupplyItem
 	FindOrganism(id string) (Organism, bool)
 	FindHousingUnit(id string) (HousingUnit, bool)
+	FindFacility(id string) (Facility, bool)
+	FindTreatment(id string) (Treatment, bool)
+	FindObservation(id string) (Observation, bool)
+	FindSample(id string) (Sample, bool)
+	FindPermit(id string) (Permit, bool)
+	FindSupplyItem(id string) (SupplyItem, bool)
 }
 
 // Rule defines an evaluation executed within a transaction boundary.

--- a/pkg/pluginapi/architecture_ci_test.go
+++ b/pkg/pluginapi/architecture_ci_test.go
@@ -89,22 +89,23 @@ func TestArchitectureInvariantsEnforcement(t *testing.T) {
 		actions := NewActionContext()
 
 		// Entity behavioral testing
-		organism := entities.Organism()
-		housing := entities.Housing()
-		protocol := entities.Protocol()
-
-		coreEntities := []EntityTypeRef{organism, housing}
-		nonCoreEntities := []EntityTypeRef{protocol}
+		coreEntities := []EntityTypeRef{
+			entities.Organism(),
+			entities.Housing(),
+			entities.Facility(),
+			entities.Protocol(),
+			entities.Procedure(),
+			entities.Treatment(),
+			entities.Observation(),
+			entities.Sample(),
+			entities.Permit(),
+			entities.Project(),
+			entities.SupplyItem(),
+		}
 
 		for _, entity := range coreEntities {
 			if !entity.IsCore() {
 				t.Errorf("Entity %s should be core", entity.String())
-			}
-		}
-
-		for _, entity := range nonCoreEntities {
-			if entity.IsCore() {
-				t.Errorf("Entity %s should not be core", entity.String())
 			}
 		}
 

--- a/pkg/pluginapi/architecture_guard_test.go
+++ b/pkg/pluginapi/architecture_guard_test.go
@@ -135,15 +135,24 @@ func TestContextualInterfaceSemantics(t *testing.T) {
 	actionCtx := NewActionContext()
 
 	// Test entity semantics
-	organism := entityCtx.Organism()
-	housing := entityCtx.Housing()
-	protocol := entityCtx.Protocol()
-
-	if !organism.IsCore() || !housing.IsCore() {
-		t.Error("Organism and Housing should be core entities")
+	coreEntities := []EntityTypeRef{
+		entityCtx.Organism(),
+		entityCtx.Housing(),
+		entityCtx.Facility(),
+		entityCtx.Protocol(),
+		entityCtx.Procedure(),
+		entityCtx.Treatment(),
+		entityCtx.Observation(),
+		entityCtx.Sample(),
+		entityCtx.Permit(),
+		entityCtx.Project(),
+		entityCtx.SupplyItem(),
 	}
-	if protocol.IsCore() {
-		t.Error("Protocol should not be core entity")
+
+	for _, entity := range coreEntities {
+		if !entity.IsCore() {
+			t.Errorf("Entity %s should be core", entity.String())
+		}
 	}
 
 	// Test severity semantics

--- a/pkg/pluginapi/context_additional_test.go
+++ b/pkg/pluginapi/context_additional_test.go
@@ -1,0 +1,208 @@
+package pluginapi
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFacilityContext(t *testing.T) {
+	ctx := NewFacilityContext()
+
+	zones := ctx.Zones()
+	access := ctx.AccessPolicies()
+
+	if !zones.Biosecure().IsBiosecure() {
+		t.Fatal("Biosecure zone should report IsBiosecure")
+	}
+	if !zones.Quarantine().IsQuarantine() {
+		t.Fatal("Quarantine zone should report IsQuarantine")
+	}
+	if zones.General().IsBiosecure() {
+		t.Fatal("General zone should not report biosecure")
+	}
+	if zones.Biosecure().Equals(zones.General()) {
+		t.Fatal("Distinct zone references should not compare equal")
+	}
+	if zones.Biosecure().String() == "" {
+		t.Fatal("Zone string representation should not be empty")
+	}
+
+	if !access.Restricted().IsRestricted() {
+		t.Fatal("Restricted policy should report IsRestricted")
+	}
+	if !access.Open().AllowsVisitors() {
+		t.Fatal("Open policy should allow visitors")
+	}
+	if access.StaffOnly().AllowsVisitors() {
+		t.Fatal("Staff-only policy should not allow visitors")
+	}
+	if !access.Restricted().Equals(access.Restricted()) {
+		t.Fatal("Restricted access policies should compare equal")
+	}
+	if access.Open().String() == "" {
+		t.Fatal("Access policy string should not be empty")
+	}
+}
+
+func TestTreatmentContextStatuses(t *testing.T) {
+	statuses := NewTreatmentContext().Statuses()
+
+	if !statuses.InProgress().IsActive() {
+		t.Fatal("In-progress status should be active")
+	}
+	if !statuses.Completed().IsCompleted() {
+		t.Fatal("Completed status should be completed")
+	}
+	if !statuses.Flagged().IsFlagged() {
+		t.Fatal("Flagged status should report flagged")
+	}
+	if statuses.Planned().IsCompleted() {
+		t.Fatal("Planned status should not be completed")
+	}
+	if statuses.Flagged().String() == "" {
+		t.Fatal("Treatment status string should not be empty")
+	}
+	if !statuses.Completed().Equals(statuses.Completed()) {
+		t.Fatal("Equal treatment statuses should compare equal")
+	}
+}
+
+func TestObservationContextShapes(t *testing.T) {
+	shapes := NewObservationContext().Shapes()
+
+	if !shapes.Structured().HasStructuredPayload() {
+		t.Fatal("Structured shape should report structured payload")
+	}
+	if !shapes.Narrative().HasNarrativeNotes() {
+		t.Fatal("Narrative shape should report narrative notes")
+	}
+	if !shapes.Mixed().HasStructuredPayload() || !shapes.Mixed().HasNarrativeNotes() {
+		t.Fatal("Mixed shape should report both structured payload and narrative notes")
+	}
+	if shapes.Narrative().String() == "" {
+		t.Fatal("Observation shape string should not be empty")
+	}
+	if shapes.Structured().Equals(shapes.Mixed()) {
+		t.Fatal("Different observation shapes should not compare equal")
+	}
+}
+
+func TestSampleContextSemantics(t *testing.T) {
+	ctx := NewSampleContext()
+	sources := ctx.Sources()
+	statuses := ctx.Statuses()
+
+	if !sources.Organism().IsOrganismDerived() {
+		t.Fatal("Organism source should report organism derived")
+	}
+	if !sources.Cohort().IsCohortDerived() {
+		t.Fatal("Cohort source should report cohort derived")
+	}
+	if !sources.Environmental().IsEnvironmental() {
+		t.Fatal("Environmental source should report environmental")
+	}
+	if sources.Unknown().String() != "unknown" {
+		t.Fatal("Unknown source should return literal string")
+	}
+	if !sources.Cohort().Equals(sources.Cohort()) {
+		t.Fatal("Identical sample sources should compare equal")
+	}
+
+	if !statuses.Stored().IsAvailable() {
+		t.Fatal("Stored status should be available")
+	}
+	if !statuses.InTransit().IsAvailable() {
+		t.Fatal("In-transit status should be available")
+	}
+	if !statuses.Consumed().IsTerminal() {
+		t.Fatal("Consumed status should be terminal")
+	}
+	if !statuses.Disposed().IsTerminal() {
+		t.Fatal("Disposed status should be terminal")
+	}
+	if statuses.Stored().String() == "" {
+		t.Fatal("Sample status string should not be empty")
+	}
+	if !statuses.Stored().Equals(statuses.Stored()) {
+		t.Fatal("Stored statuses should compare equal")
+	}
+}
+
+func TestPermitContextStatuses(t *testing.T) {
+	statuses := NewPermitContext().Statuses()
+
+	if !statuses.Active().IsActive() {
+		t.Fatal("Active status should report active")
+	}
+	if !statuses.Expired().IsExpired() {
+		t.Fatal("Expired status should report expired")
+	}
+	if statuses.Pending().IsExpired() {
+		t.Fatal("Pending status should not be expired")
+	}
+	if statuses.Pending().String() == "" {
+		t.Fatal("Permit status string should not be empty")
+	}
+	if !statuses.Pending().Equals(statuses.Pending()) {
+		t.Fatal("Identical permit statuses should compare equal")
+	}
+}
+
+func TestSupplyContextStatuses(t *testing.T) {
+	statuses := NewSupplyContext().Statuses()
+	now := time.Now()
+	expires := now.Add(-time.Hour)
+
+	if statuses.Healthy().RequiresReorder() {
+		t.Fatal("Healthy status should not require reorder")
+	}
+	if !statuses.Reorder().RequiresReorder() {
+		t.Fatal("Reorder status should require reorder")
+	}
+	if statuses.Critical().IsExpired() {
+		t.Fatal("Critical status should not imply expired")
+	}
+	if !statuses.Expired().IsExpired() {
+		t.Fatal("Expired status should report expired")
+	}
+	if !statuses.Reorder().Equals(statuses.Reorder()) {
+		t.Fatal("Reorder references should be equal")
+	}
+	if statuses.Reorder().Equals(statuses.Healthy()) {
+		t.Fatal("Different status references should not be equal")
+	}
+	if statuses.Healthy().String() == "" {
+		t.Fatal("Supply status string should not be empty")
+	}
+
+	_ = expires
+}
+
+func TestContextEqualityHelpers(t *testing.T) {
+	entities := NewEntityContext()
+	if entities.Organism().Equals(entities.Housing()) {
+		t.Fatal("distinct entity refs should not compare equal")
+	}
+	if !entities.Organism().Equals(entities.Organism()) {
+		t.Fatal("identical entity refs should compare equal")
+	}
+	if !entities.Organism().IsCore() || !entities.Protocol().IsCore() {
+		t.Fatal("core entities should report IsCore")
+	}
+
+	actions := NewActionContext()
+	if actions.Create().Equals(actions.Update()) {
+		t.Fatal("different action refs should not compare equal")
+	}
+	if !actions.Create().Equals(actions.Create()) {
+		t.Fatal("identical action refs should compare equal")
+	}
+
+	severities := NewSeverityContext()
+	if severities.Warn().Equals(severities.Block()) {
+		t.Fatal("different severity refs should not compare equal")
+	}
+	if !severities.Warn().Equals(severities.Warn()) {
+		t.Fatal("identical severity refs should compare equal")
+	}
+}

--- a/pkg/pluginapi/context_marker_test.go
+++ b/pkg/pluginapi/context_marker_test.go
@@ -1,0 +1,117 @@
+package pluginapi
+
+import "testing"
+
+func TestContextMarkerMethodsAreCallable(t *testing.T) {
+	t.Run("ActionRef", func(t *testing.T) {
+		ref := NewActionContext().Create()
+		ref.isActionRef()
+		if ref.Equals(&actionRef{value: actionCreate}) {
+			t.Fatal("action equality should reject pointer types")
+		}
+	})
+
+	t.Run("EntityTypeRef", func(t *testing.T) {
+		ref := NewEntityContext().Organism()
+		ref.isEntityTypeRef()
+		if ref.Equals(&entityTypeRef{value: entityOrganism}) {
+			t.Fatal("entity equality should reject pointer types")
+		}
+	})
+
+	t.Run("LifecycleStageRef", func(t *testing.T) {
+		ref := NewLifecycleStageContext().Adult()
+		ref.isLifecycleStageRef()
+		if ref.Equals(&lifecycleStageRef{value: stageAdult}) {
+			t.Fatal("lifecycle equality should reject pointer types")
+		}
+	})
+
+	t.Run("SampleSourceRef", func(t *testing.T) {
+		ref := NewSampleContext().Sources().Organism()
+		ref.isSampleSourceRef()
+		if ref.Equals(&sampleSourceRef{value: sampleSourceOrganism}) {
+			t.Fatal("sample source equality should reject pointer types")
+		}
+	})
+
+	t.Run("SampleStatusRef", func(t *testing.T) {
+		ref := NewSampleContext().Statuses().Stored()
+		ref.isSampleStatusRef()
+		if ref.Equals(&sampleStatusRef{value: sampleStatusStored}) {
+			t.Fatal("sample status equality should reject pointer types")
+		}
+	})
+
+	t.Run("SeverityRef", func(t *testing.T) {
+		ref := NewSeverityContext().Warn()
+		ref.isSeverityRef()
+		if ref.Equals(&severityRef{value: severityWarn}) {
+			t.Fatal("severity equality should reject pointer types")
+		}
+	})
+
+	t.Run("SupplyStatusRef", func(t *testing.T) {
+		ref := NewSupplyContext().Statuses().Reorder()
+		ref.isSupplyStatusRef()
+		if ref.Equals(&supplyStatusRef{value: supplyStatusReorder}) {
+			t.Fatal("supply status equality should reject pointer types")
+		}
+	})
+
+	t.Run("TreatmentStatusRef", func(t *testing.T) {
+		ref := NewTreatmentContext().Statuses().Completed()
+		ref.isTreatmentStatusRef()
+		if ref.Equals(&treatmentStatusRef{value: treatmentStatusCompleted}) {
+			t.Fatal("treatment status equality should reject pointer types")
+		}
+	})
+
+	t.Run("FacilityZoneRef", func(t *testing.T) {
+		ref := NewFacilityContext().Zones().Biosecure()
+		ref.isFacilityZoneRef()
+		if ref.Equals(&facilityZoneRef{value: zoneBiosecure}) {
+			t.Fatal("facility zone equality should reject pointer types")
+		}
+	})
+
+	t.Run("FacilityAccessPolicyRef", func(t *testing.T) {
+		ref := NewFacilityContext().AccessPolicies().Restricted()
+		ref.isFacilityAccessPolicyRef()
+		if ref.Equals(&facilityAccessPolicyRef{value: accessRestricted}) {
+			t.Fatal("facility access equality should reject pointer types")
+		}
+	})
+
+	t.Run("ObservationShapeRef", func(t *testing.T) {
+		ref := NewObservationContext().Shapes().Structured()
+		ref.isObservationShapeRef()
+		if ref.Equals(&observationShapeRef{value: observationShapeStructured}) {
+			t.Fatal("observation shape equality should reject pointer types")
+		}
+	})
+
+	t.Run("HousingEnvironmentTypeRef", func(t *testing.T) {
+		ref := NewHousingContext().Aquatic()
+		ref.isEnvironmentTypeRef()
+		if ref.Equals(&environmentTypeRef{value: "aquatic"}) {
+			t.Fatal("environment equality should reject pointer types")
+		}
+	})
+
+	t.Run("ProtocolStatusRef", func(t *testing.T) {
+		ref := NewProtocolContext().Draft()
+		ref.isProtocolStatusRef()
+		if ref.Equals(&protocolStatusRef{value: "draft"}) {
+			t.Fatal("protocol status equality should reject pointer types")
+		}
+	})
+
+	t.Run("PermitStatusRef", func(t *testing.T) {
+		ref := NewPermitContext().Statuses().Pending()
+		ref.isPermitStatusRef()
+		if ref.Equals(&permitStatusRef{value: permitStatusPending}) {
+			t.Fatal("permit status equality should reject pointer types")
+		}
+	})
+}

--- a/pkg/pluginapi/contextual_accessor_enforcement_test.go
+++ b/pkg/pluginapi/contextual_accessor_enforcement_test.go
@@ -39,8 +39,26 @@ func validateViewInterfaceContextualAccessors(t *testing.T) {
 		"HousingUnitView": {
 			"GetEnvironmentType", "IsAquaticEnvironment", "IsHumidEnvironment", "SupportsSpecies",
 		},
+		"FacilityView": {
+			"GetZone", "GetAccessPolicy", "SupportsHousingUnit",
+		},
+		"TreatmentView": {
+			"GetCurrentStatus", "IsCompleted", "HasAdverseEvents",
+		},
+		"ObservationView": {
+			"GetDataShape", "HasStructuredPayload", "HasNarrativeNotes",
+		},
+		"SampleView": {
+			"GetSource", "GetStatus", "IsAvailable",
+		},
 		"ProtocolView": {
 			"GetCurrentStatus", "IsActiveProtocol", "IsTerminalStatus", "CanAcceptNewSubjects",
+		},
+		"PermitView": {
+			"GetStatus", "IsActive", "IsExpired",
+		},
+		"SupplyItemView": {
+			"GetInventoryStatus", "RequiresReorder", "IsExpired",
 		},
 	}
 
@@ -56,6 +74,18 @@ func validateViewInterfaceContextualAccessors(t *testing.T) {
 			interfaceType = reflect.TypeOf((*HousingUnitView)(nil)).Elem()
 		case "ProtocolView":
 			interfaceType = reflect.TypeOf((*ProtocolView)(nil)).Elem()
+		case "FacilityView":
+			interfaceType = reflect.TypeOf((*FacilityView)(nil)).Elem()
+		case "TreatmentView":
+			interfaceType = reflect.TypeOf((*TreatmentView)(nil)).Elem()
+		case "ObservationView":
+			interfaceType = reflect.TypeOf((*ObservationView)(nil)).Elem()
+		case "SampleView":
+			interfaceType = reflect.TypeOf((*SampleView)(nil)).Elem()
+		case "PermitView":
+			interfaceType = reflect.TypeOf((*PermitView)(nil)).Elem()
+		case "SupplyItemView":
+			interfaceType = reflect.TypeOf((*SupplyItemView)(nil)).Elem()
 		default:
 			t.Fatalf("Unknown interface: %s", interfaceName)
 		}
@@ -178,6 +208,14 @@ func validateContextualInterfacePattern(t *testing.T) {
 		reflect.TypeOf((*LifecycleStageRef)(nil)).Elem(),
 		reflect.TypeOf((*EnvironmentTypeRef)(nil)).Elem(),
 		reflect.TypeOf((*ProtocolStatusRef)(nil)).Elem(),
+		reflect.TypeOf((*FacilityZoneRef)(nil)).Elem(),
+		reflect.TypeOf((*FacilityAccessPolicyRef)(nil)).Elem(),
+		reflect.TypeOf((*TreatmentStatusRef)(nil)).Elem(),
+		reflect.TypeOf((*ObservationShapeRef)(nil)).Elem(),
+		reflect.TypeOf((*SampleSourceRef)(nil)).Elem(),
+		reflect.TypeOf((*SampleStatusRef)(nil)).Elem(),
+		reflect.TypeOf((*PermitStatusRef)(nil)).Elem(),
+		reflect.TypeOf((*SupplyStatusRef)(nil)).Elem(),
 	}
 
 	for _, refType := range contextualRefTypes {

--- a/pkg/pluginapi/contextual_interfaces_test.go
+++ b/pkg/pluginapi/contextual_interfaces_test.go
@@ -9,16 +9,36 @@ func TestEntityContext(t *testing.T) {
 
 	organism := ctx.Organism()
 	housing := ctx.Housing()
+	facility := ctx.Facility()
 	protocol := ctx.Protocol()
+	procedure := ctx.Procedure()
+	treatment := ctx.Treatment()
+	observation := ctx.Observation()
+	sample := ctx.Sample()
+	permit := ctx.Permit()
+	project := ctx.Project()
+	supply := ctx.SupplyItem()
 
 	if organism.Equals(housing) {
 		t.Error("Organism and Housing should not be equal")
 	}
-	if housing.Equals(protocol) {
-		t.Error("Housing and Protocol should not be equal")
+	if housing.Equals(facility) {
+		t.Error("Housing and Facility should not be equal")
 	}
-	if protocol.Equals(organism) {
-		t.Error("Protocol and Organism should not be equal")
+	if facility.Equals(protocol) {
+		t.Error("Facility and Protocol should not be equal")
+	}
+	if protocol.Equals(procedure) {
+		t.Error("Protocol and Procedure should not be equal")
+	}
+	if treatment.Equals(observation) {
+		t.Error("Treatment and Observation should not be equal")
+	}
+	if sample.Equals(permit) {
+		t.Error("Sample and Permit should not be equal")
+	}
+	if project.Equals(supply) {
+		t.Error("Project and SupplyItem should not be equal")
 	}
 
 	if organism.String() == "" {
@@ -36,8 +56,32 @@ func TestEntityContext(t *testing.T) {
 	if !housing.IsCore() {
 		t.Error("Housing should be core entity")
 	}
-	if protocol.IsCore() {
-		t.Error("Protocol should not be core entity")
+	if !facility.IsCore() {
+		t.Error("Facility should be core entity")
+	}
+	if !protocol.IsCore() {
+		t.Error("Protocol should be core entity")
+	}
+	if !procedure.IsCore() {
+		t.Error("Procedure should be core entity")
+	}
+	if !treatment.IsCore() {
+		t.Error("Treatment should be core entity")
+	}
+	if !observation.IsCore() {
+		t.Error("Observation should be core entity")
+	}
+	if !sample.IsCore() {
+		t.Error("Sample should be core entity")
+	}
+	if !permit.IsCore() {
+		t.Error("Permit should be core entity")
+	}
+	if !project.IsCore() {
+		t.Error("Project should be core entity")
+	}
+	if !supply.IsCore() {
+		t.Error("Supply item should be core entity")
 	}
 }
 

--- a/pkg/pluginapi/coverage_test.go
+++ b/pkg/pluginapi/coverage_test.go
@@ -1,0 +1,131 @@
+package pluginapi
+
+import (
+	"testing"
+)
+
+// TestActionRefChecker tests the isActionRef function
+func TestActionRefChecker(_ *testing.T) {
+	ctx := NewActionContext()
+	create := ctx.Create()
+
+	// Call the function to ensure it's covered
+	create.isActionRef()
+}
+
+// TestEntityTypeRefChecker tests the isEntityTypeRef function
+func TestEntityTypeRefChecker(_ *testing.T) {
+	ctx := NewEntityContext()
+	organism := ctx.Organism()
+
+	// Call the function to ensure it's covered
+	organism.isEntityTypeRef()
+}
+
+// TestFacilityZoneRefChecker tests the isFacilityZoneRef function
+func TestFacilityZoneRefChecker(_ *testing.T) {
+	ctx := NewFacilityContext()
+	biosecure := ctx.Zones().Biosecure()
+
+	// Call the function to ensure it's covered
+	biosecure.isFacilityZoneRef()
+}
+
+// TestFacilityAccessPolicyRefChecker tests the isFacilityAccessPolicyRef function
+func TestFacilityAccessPolicyRefChecker(_ *testing.T) {
+	ctx := NewFacilityContext()
+	restricted := ctx.AccessPolicies().Restricted()
+
+	// Call the function to ensure it's covered
+	restricted.isFacilityAccessPolicyRef()
+}
+
+// TestEnvironmentTypeRefChecker tests the isEnvironmentTypeRef function
+func TestEnvironmentTypeRefChecker(_ *testing.T) {
+	ctx := NewHousingContext()
+	aquatic := ctx.Aquatic()
+
+	// Call the function to ensure it's covered
+	aquatic.isEnvironmentTypeRef()
+}
+
+// TestLifecycleStageRefChecker tests the isLifecycleStageRef function
+func TestLifecycleStageRefChecker(_ *testing.T) {
+	ctx := NewLifecycleStageContext()
+	adult := ctx.Adult()
+
+	// Call the function to ensure it's covered
+	adult.isLifecycleStageRef()
+}
+
+// TestObservationShapeRefChecker tests the isObservationShapeRef function
+func TestObservationShapeRefChecker(_ *testing.T) {
+	ctx := NewObservationContext()
+	narrative := ctx.Shapes().Narrative()
+
+	// Call the function to ensure it's covered
+	narrative.isObservationShapeRef()
+}
+
+// TestPermitStatusRefChecker tests the isPermitStatusRef function
+func TestPermitStatusRefChecker(_ *testing.T) {
+	ctx := NewPermitContext()
+	active := ctx.Statuses().Active()
+
+	// Call the function to ensure it's covered
+	active.isPermitStatusRef()
+}
+
+// TestProtocolStatusRefChecker tests the isProtocolStatusRef function
+func TestProtocolStatusRefChecker(_ *testing.T) {
+	ctx := NewProtocolContext()
+	active := ctx.Active()
+
+	// Call the function to ensure it's covered
+	active.isProtocolStatusRef()
+}
+
+// TestSampleSourceRefChecker tests the isSampleSourceRef function
+func TestSampleSourceRefChecker(_ *testing.T) {
+	ctx := NewSampleContext()
+	organism := ctx.Sources().Organism()
+
+	// Call the function to ensure it's covered
+	organism.isSampleSourceRef()
+}
+
+// TestSampleStatusRefChecker tests the isSampleStatusRef function
+func TestSampleStatusRefChecker(_ *testing.T) {
+	ctx := NewSampleContext()
+	stored := ctx.Statuses().Stored()
+
+	// Call the function to ensure it's covered
+	stored.isSampleStatusRef()
+}
+
+// TestSeverityRefChecker tests the isSeverityRef function
+func TestSeverityRefChecker(_ *testing.T) {
+	ctx := NewSeverityContext()
+	warn := ctx.Warn()
+
+	// Call the function to ensure it's covered
+	warn.isSeverityRef()
+}
+
+// TestSupplyStatusRefChecker tests the isSupplyStatusRef function
+func TestSupplyStatusRefChecker(_ *testing.T) {
+	ctx := NewSupplyContext()
+	healthy := ctx.Statuses().Healthy()
+
+	// Call the function to ensure it's covered
+	healthy.isSupplyStatusRef()
+}
+
+// TestTreatmentStatusRefChecker tests the isTreatmentStatusRef function
+func TestTreatmentStatusRefChecker(_ *testing.T) {
+	ctx := NewTreatmentContext()
+	completed := ctx.Statuses().Completed()
+
+	// Call the function to ensure it's covered
+	completed.isTreatmentStatusRef()
+}

--- a/pkg/pluginapi/domain_aliases.go
+++ b/pkg/pluginapi/domain_aliases.go
@@ -42,10 +42,16 @@ const (
 	entityOrganism    EntityType = "organism"
 	entityCohort      EntityType = "cohort"
 	entityHousingUnit EntityType = "housing_unit"
+	entityFacility    EntityType = "facility"
 	entityBreeding    EntityType = "breeding_unit"
 	entityProcedure   EntityType = "procedure"
+	entityTreatment   EntityType = "treatment"
+	entityObservation EntityType = "observation"
+	entitySample      EntityType = "sample"
 	entityProtocol    EntityType = "protocol"
 	entityProject     EntityType = "project"
+	entityPermit      EntityType = "permit"
+	entitySupplyItem  EntityType = "supply_item"
 )
 
 // Action indicates the type of modification performed.

--- a/pkg/pluginapi/entity_context.go
+++ b/pkg/pluginapi/entity_context.go
@@ -8,8 +8,24 @@ type EntityContext interface {
 	Organism() EntityTypeRef
 	// Housing returns an opaque reference to a housing unit entity type.
 	Housing() EntityTypeRef
+	// Facility returns an opaque reference to a facility entity type.
+	Facility() EntityTypeRef
 	// Protocol returns an opaque reference to a protocol entity type.
 	Protocol() EntityTypeRef
+	// Procedure returns an opaque reference to a procedure entity type.
+	Procedure() EntityTypeRef
+	// Treatment returns an opaque reference to a treatment entity type.
+	Treatment() EntityTypeRef
+	// Observation returns an opaque reference to an observation entity type.
+	Observation() EntityTypeRef
+	// Sample returns an opaque reference to a sample entity type.
+	Sample() EntityTypeRef
+	// Permit returns an opaque reference to a permit entity type.
+	Permit() EntityTypeRef
+	// Project returns an opaque reference to a project entity type.
+	Project() EntityTypeRef
+	// SupplyItem returns an opaque reference to a supply item entity type.
+	SupplyItem() EntityTypeRef
 }
 
 // EntityTypeRef represents an opaque reference to an entity type.
@@ -38,7 +54,22 @@ func (e entityTypeRef) String() string {
 }
 
 func (e entityTypeRef) IsCore() bool {
-	return e.value == entityOrganism || e.value == entityHousingUnit
+	switch e.value {
+	case entityOrganism,
+		entityHousingUnit,
+		entityFacility,
+		entityProcedure,
+		entityTreatment,
+		entityObservation,
+		entitySample,
+		entityProtocol,
+		entityPermit,
+		entityProject,
+		entitySupplyItem:
+		return true
+	default:
+		return false
+	}
 }
 
 func (e entityTypeRef) Equals(other EntityTypeRef) bool {
@@ -62,9 +93,21 @@ func newEntityTypeRef(entityType EntityType) EntityTypeRef {
 // entityContext is the default implementation of EntityContext.
 type entityContext struct{}
 
-func (entityContext) Organism() EntityTypeRef { return newEntityTypeRef(entityOrganism) }
-func (entityContext) Housing() EntityTypeRef  { return newEntityTypeRef(entityHousingUnit) }
-func (entityContext) Protocol() EntityTypeRef { return newEntityTypeRef(entityProtocol) }
+func (entityContext) Organism() EntityTypeRef  { return newEntityTypeRef(entityOrganism) }
+func (entityContext) Housing() EntityTypeRef   { return newEntityTypeRef(entityHousingUnit) }
+func (entityContext) Facility() EntityTypeRef  { return newEntityTypeRef(entityFacility) }
+func (entityContext) Protocol() EntityTypeRef  { return newEntityTypeRef(entityProtocol) }
+func (entityContext) Procedure() EntityTypeRef { return newEntityTypeRef(entityProcedure) }
+func (entityContext) Treatment() EntityTypeRef { return newEntityTypeRef(entityTreatment) }
+func (entityContext) Observation() EntityTypeRef {
+	return newEntityTypeRef(entityObservation)
+}
+func (entityContext) Sample() EntityTypeRef  { return newEntityTypeRef(entitySample) }
+func (entityContext) Permit() EntityTypeRef  { return newEntityTypeRef(entityPermit) }
+func (entityContext) Project() EntityTypeRef { return newEntityTypeRef(entityProject) }
+func (entityContext) SupplyItem() EntityTypeRef {
+	return newEntityTypeRef(entitySupplyItem)
+}
 
 // NewEntityContext creates a new entity context for accessing entity type references.
 func NewEntityContext() EntityContext {

--- a/pkg/pluginapi/example_contextual_test.go
+++ b/pkg/pluginapi/example_contextual_test.go
@@ -97,7 +97,7 @@ func Example_contextualInterfacesBenefits() {
 	// Output:
 	// Organism is core entity: true
 	// Housing is core entity: true
-	// Protocol is core entity: false
+	// Protocol is core entity: true
 	// Warn is blocking: false
 	// Block is blocking: true
 }

--- a/pkg/pluginapi/facility_context.go
+++ b/pkg/pluginapi/facility_context.go
@@ -1,0 +1,148 @@
+package pluginapi
+
+import "strings"
+
+const (
+	zoneBiosecure  = "biosecure"
+	zoneQuarantine = "quarantine"
+	zoneGeneral    = "general"
+
+	accessRestricted = "restricted"
+	accessStaffOnly  = "staff_only"
+	accessOpen       = "open"
+)
+
+// FacilityContext provides contextual access to facility zoning and access policies.
+type FacilityContext interface {
+	Zones() FacilityZoneProvider
+	AccessPolicies() FacilityAccessPolicyProvider
+}
+
+// FacilityZoneProvider exposes canonical facility zone references.
+type FacilityZoneProvider interface {
+	Biosecure() FacilityZoneRef
+	Quarantine() FacilityZoneRef
+	General() FacilityZoneRef
+}
+
+// FacilityZoneRef represents an opaque facility zone reference.
+type FacilityZoneRef interface {
+	String() string
+	IsBiosecure() bool
+	IsQuarantine() bool
+	Equals(other FacilityZoneRef) bool
+	isFacilityZoneRef()
+}
+
+// FacilityAccessPolicyProvider exposes canonical facility access policies.
+type FacilityAccessPolicyProvider interface {
+	Restricted() FacilityAccessPolicyRef
+	StaffOnly() FacilityAccessPolicyRef
+	Open() FacilityAccessPolicyRef
+}
+
+// FacilityAccessPolicyRef represents an opaque facility access policy reference.
+type FacilityAccessPolicyRef interface {
+	String() string
+	IsRestricted() bool
+	AllowsVisitors() bool
+	Equals(other FacilityAccessPolicyRef) bool
+	isFacilityAccessPolicyRef()
+}
+
+type facilityContext struct{}
+
+// NewFacilityContext constructs the default facility context provider.
+func NewFacilityContext() FacilityContext {
+	return facilityContext{}
+}
+
+func (facilityContext) Zones() FacilityZoneProvider {
+	return facilityZoneProvider{}
+}
+
+func (facilityContext) AccessPolicies() FacilityAccessPolicyProvider {
+	return facilityAccessPolicyProvider{}
+}
+
+type facilityZoneProvider struct{}
+
+func (facilityZoneProvider) Biosecure() FacilityZoneRef {
+	return facilityZoneRef{value: zoneBiosecure}
+}
+
+func (facilityZoneProvider) Quarantine() FacilityZoneRef {
+	return facilityZoneRef{value: zoneQuarantine}
+}
+
+func (facilityZoneProvider) General() FacilityZoneRef {
+	return facilityZoneRef{value: zoneGeneral}
+}
+
+type facilityZoneRef struct {
+	value string
+}
+
+func (f facilityZoneRef) String() string {
+	return f.value
+}
+
+func (f facilityZoneRef) IsBiosecure() bool {
+	val := strings.ToLower(f.value)
+	return strings.Contains(val, "bsl") || strings.Contains(val, "biosecure")
+}
+
+func (f facilityZoneRef) IsQuarantine() bool {
+	val := strings.ToLower(f.value)
+	return strings.Contains(val, "quarantine") || strings.Contains(val, "isolation")
+}
+
+func (f facilityZoneRef) Equals(other FacilityZoneRef) bool {
+	if otherRef, ok := other.(facilityZoneRef); ok {
+		return strings.EqualFold(f.value, otherRef.value)
+	}
+	return false
+}
+
+func (f facilityZoneRef) isFacilityZoneRef() {}
+
+type facilityAccessPolicyProvider struct{}
+
+func (facilityAccessPolicyProvider) Restricted() FacilityAccessPolicyRef {
+	return facilityAccessPolicyRef{value: accessRestricted}
+}
+
+func (facilityAccessPolicyProvider) StaffOnly() FacilityAccessPolicyRef {
+	return facilityAccessPolicyRef{value: accessStaffOnly}
+}
+
+func (facilityAccessPolicyProvider) Open() FacilityAccessPolicyRef {
+	return facilityAccessPolicyRef{value: accessOpen}
+}
+
+type facilityAccessPolicyRef struct {
+	value string
+}
+
+func (f facilityAccessPolicyRef) String() string {
+	return f.value
+}
+
+func (f facilityAccessPolicyRef) IsRestricted() bool {
+	val := strings.ToLower(f.value)
+	return strings.Contains(val, "restricted") || strings.Contains(val, "secure")
+}
+
+func (f facilityAccessPolicyRef) AllowsVisitors() bool {
+	val := strings.ToLower(f.value)
+	return strings.Contains(val, "open") || strings.Contains(val, "visitor")
+}
+
+func (f facilityAccessPolicyRef) Equals(other FacilityAccessPolicyRef) bool {
+	if otherRef, ok := other.(facilityAccessPolicyRef); ok {
+		return strings.EqualFold(f.value, otherRef.value)
+	}
+	return false
+}
+
+func (f facilityAccessPolicyRef) isFacilityAccessPolicyRef() {}

--- a/pkg/pluginapi/observation_context.go
+++ b/pkg/pluginapi/observation_context.go
@@ -1,0 +1,78 @@
+package pluginapi
+
+const (
+	observationShapeNarrative  = "narrative"
+	observationShapeStructured = "structured"
+	observationShapeMixed      = "mixed"
+)
+
+// ObservationContext provides contextual access to observation data shape references.
+type ObservationContext interface {
+	Shapes() ObservationShapeProvider
+}
+
+// ObservationShapeProvider exposes canonical observation data shapes.
+type ObservationShapeProvider interface {
+	Narrative() ObservationShapeRef
+	Structured() ObservationShapeRef
+	Mixed() ObservationShapeRef
+}
+
+// ObservationShapeRef represents an opaque observation data shape reference.
+type ObservationShapeRef interface {
+	String() string
+	HasStructuredPayload() bool
+	HasNarrativeNotes() bool
+	Equals(other ObservationShapeRef) bool
+	isObservationShapeRef()
+}
+
+type observationContext struct{}
+
+// NewObservationContext constructs the default observation context provider.
+func NewObservationContext() ObservationContext {
+	return observationContext{}
+}
+
+func (observationContext) Shapes() ObservationShapeProvider {
+	return observationShapeProvider{}
+}
+
+type observationShapeProvider struct{}
+
+func (observationShapeProvider) Narrative() ObservationShapeRef {
+	return observationShapeRef{value: observationShapeNarrative}
+}
+
+func (observationShapeProvider) Structured() ObservationShapeRef {
+	return observationShapeRef{value: observationShapeStructured}
+}
+
+func (observationShapeProvider) Mixed() ObservationShapeRef {
+	return observationShapeRef{value: observationShapeMixed}
+}
+
+type observationShapeRef struct {
+	value string
+}
+
+func (o observationShapeRef) String() string {
+	return o.value
+}
+
+func (o observationShapeRef) HasStructuredPayload() bool {
+	return o.value == observationShapeStructured || o.value == observationShapeMixed
+}
+
+func (o observationShapeRef) HasNarrativeNotes() bool {
+	return o.value == observationShapeNarrative || o.value == observationShapeMixed
+}
+
+func (o observationShapeRef) Equals(other ObservationShapeRef) bool {
+	if otherRef, ok := other.(observationShapeRef); ok {
+		return o.value == otherRef.value
+	}
+	return false
+}
+
+func (o observationShapeRef) isObservationShapeRef() {}

--- a/pkg/pluginapi/permit_context.go
+++ b/pkg/pluginapi/permit_context.go
@@ -1,0 +1,78 @@
+package pluginapi
+
+const (
+	permitStatusPending = "pending"
+	permitStatusActive  = "active"
+	permitStatusExpired = "expired"
+)
+
+// PermitContext provides contextual access to permit status references.
+type PermitContext interface {
+	Statuses() PermitStatusProvider
+}
+
+// PermitStatusProvider exposes canonical permit validity references.
+type PermitStatusProvider interface {
+	Pending() PermitStatusRef
+	Active() PermitStatusRef
+	Expired() PermitStatusRef
+}
+
+// PermitStatusRef represents an opaque permit status value.
+type PermitStatusRef interface {
+	String() string
+	IsActive() bool
+	IsExpired() bool
+	Equals(other PermitStatusRef) bool
+	isPermitStatusRef()
+}
+
+type permitContext struct{}
+
+// NewPermitContext constructs the default permit context provider.
+func NewPermitContext() PermitContext {
+	return permitContext{}
+}
+
+func (permitContext) Statuses() PermitStatusProvider {
+	return permitStatusProvider{}
+}
+
+type permitStatusProvider struct{}
+
+func (permitStatusProvider) Pending() PermitStatusRef {
+	return permitStatusRef{value: permitStatusPending}
+}
+
+func (permitStatusProvider) Active() PermitStatusRef {
+	return permitStatusRef{value: permitStatusActive}
+}
+
+func (permitStatusProvider) Expired() PermitStatusRef {
+	return permitStatusRef{value: permitStatusExpired}
+}
+
+type permitStatusRef struct {
+	value string
+}
+
+func (p permitStatusRef) String() string {
+	return p.value
+}
+
+func (p permitStatusRef) IsActive() bool {
+	return p.value == permitStatusActive
+}
+
+func (p permitStatusRef) IsExpired() bool {
+	return p.value == permitStatusExpired
+}
+
+func (p permitStatusRef) Equals(other PermitStatusRef) bool {
+	if otherRef, ok := other.(permitStatusRef); ok {
+		return p.value == otherRef.value
+	}
+	return false
+}
+
+func (p permitStatusRef) isPermitStatusRef() {}

--- a/pkg/pluginapi/rules.go
+++ b/pkg/pluginapi/rules.go
@@ -12,7 +12,20 @@ type Rule interface {
 type RuleView interface {
 	ListOrganisms() []OrganismView
 	ListHousingUnits() []HousingUnitView
+	ListFacilities() []FacilityView
+	ListTreatments() []TreatmentView
+	ListObservations() []ObservationView
+	ListSamples() []SampleView
 	ListProtocols() []ProtocolView
+	ListPermits() []PermitView
+	ListProjects() []ProjectView
+	ListSupplyItems() []SupplyItemView
 	FindOrganism(id string) (OrganismView, bool)
 	FindHousingUnit(id string) (HousingUnitView, bool)
+	FindFacility(id string) (FacilityView, bool)
+	FindTreatment(id string) (TreatmentView, bool)
+	FindObservation(id string) (ObservationView, bool)
+	FindSample(id string) (SampleView, bool)
+	FindPermit(id string) (PermitView, bool)
+	FindSupplyItem(id string) (SupplyItemView, bool)
 }

--- a/pkg/pluginapi/sample_context.go
+++ b/pkg/pluginapi/sample_context.go
@@ -1,0 +1,161 @@
+package pluginapi
+
+import "strings"
+
+const (
+	sampleSourceOrganism      = "organism"
+	sampleSourceCohort        = "cohort"
+	sampleSourceEnvironmental = "environmental"
+	sampleSourceUnknown       = "unknown"
+
+	sampleStatusStored    = "stored"
+	sampleStatusInTransit = "in_transit"
+	sampleStatusConsumed  = "consumed"
+	sampleStatusDisposed  = "disposed"
+)
+
+// SampleContext provides contextual access to sample source and status values.
+type SampleContext interface {
+	Sources() SampleSourceProvider
+	Statuses() SampleStatusProvider
+}
+
+// SampleSourceProvider exposes canonical sample source references.
+type SampleSourceProvider interface {
+	Organism() SampleSourceRef
+	Cohort() SampleSourceRef
+	Environmental() SampleSourceRef
+	Unknown() SampleSourceRef
+}
+
+// SampleSourceRef represents an opaque sample source reference.
+type SampleSourceRef interface {
+	String() string
+	IsOrganismDerived() bool
+	IsCohortDerived() bool
+	IsEnvironmental() bool
+	Equals(other SampleSourceRef) bool
+	isSampleSourceRef()
+}
+
+// SampleStatusProvider exposes canonical sample status references.
+type SampleStatusProvider interface {
+	Stored() SampleStatusRef
+	InTransit() SampleStatusRef
+	Consumed() SampleStatusRef
+	Disposed() SampleStatusRef
+}
+
+// SampleStatusRef represents an opaque sample status reference.
+type SampleStatusRef interface {
+	String() string
+	IsAvailable() bool
+	IsTerminal() bool
+	Equals(other SampleStatusRef) bool
+	isSampleStatusRef()
+}
+
+type sampleContext struct{}
+
+// NewSampleContext constructs the default sample context provider.
+func NewSampleContext() SampleContext {
+	return sampleContext{}
+}
+
+func (sampleContext) Sources() SampleSourceProvider {
+	return sampleSourceProvider{}
+}
+
+func (sampleContext) Statuses() SampleStatusProvider {
+	return sampleStatusProvider{}
+}
+
+type sampleSourceProvider struct{}
+
+func (sampleSourceProvider) Organism() SampleSourceRef {
+	return sampleSourceRef{value: sampleSourceOrganism}
+}
+
+func (sampleSourceProvider) Cohort() SampleSourceRef {
+	return sampleSourceRef{value: sampleSourceCohort}
+}
+
+func (sampleSourceProvider) Environmental() SampleSourceRef {
+	return sampleSourceRef{value: sampleSourceEnvironmental}
+}
+
+func (sampleSourceProvider) Unknown() SampleSourceRef {
+	return sampleSourceRef{value: sampleSourceUnknown}
+}
+
+type sampleSourceRef struct {
+	value string
+}
+
+func (s sampleSourceRef) String() string {
+	return s.value
+}
+
+func (s sampleSourceRef) IsOrganismDerived() bool {
+	return strings.EqualFold(s.value, sampleSourceOrganism)
+}
+
+func (s sampleSourceRef) IsCohortDerived() bool {
+	return strings.EqualFold(s.value, sampleSourceCohort)
+}
+
+func (s sampleSourceRef) IsEnvironmental() bool {
+	return strings.EqualFold(s.value, sampleSourceEnvironmental)
+}
+
+func (s sampleSourceRef) Equals(other SampleSourceRef) bool {
+	if otherRef, ok := other.(sampleSourceRef); ok {
+		return strings.EqualFold(s.value, otherRef.value)
+	}
+	return false
+}
+
+func (s sampleSourceRef) isSampleSourceRef() {}
+
+type sampleStatusProvider struct{}
+
+func (sampleStatusProvider) Stored() SampleStatusRef {
+	return sampleStatusRef{value: sampleStatusStored}
+}
+
+func (sampleStatusProvider) InTransit() SampleStatusRef {
+	return sampleStatusRef{value: sampleStatusInTransit}
+}
+
+func (sampleStatusProvider) Consumed() SampleStatusRef {
+	return sampleStatusRef{value: sampleStatusConsumed}
+}
+
+func (sampleStatusProvider) Disposed() SampleStatusRef {
+	return sampleStatusRef{value: sampleStatusDisposed}
+}
+
+type sampleStatusRef struct {
+	value string
+}
+
+func (s sampleStatusRef) String() string {
+	return s.value
+}
+
+func (s sampleStatusRef) IsAvailable() bool {
+	return s.value == sampleStatusStored || s.value == sampleStatusInTransit
+}
+
+func (s sampleStatusRef) IsTerminal() bool {
+	return s.value == sampleStatusConsumed || s.value == sampleStatusDisposed
+}
+
+func (s sampleStatusRef) Equals(other SampleStatusRef) bool {
+	if otherRef, ok := other.(sampleStatusRef); ok {
+		return strings.EqualFold(s.value, otherRef.value)
+	}
+	return false
+}
+
+func (s sampleStatusRef) isSampleStatusRef() {}

--- a/pkg/pluginapi/supply_context.go
+++ b/pkg/pluginapi/supply_context.go
@@ -1,0 +1,84 @@
+package pluginapi
+
+const (
+	supplyStatusHealthy  = "healthy"
+	supplyStatusReorder  = "reorder"
+	supplyStatusCritical = "critical"
+	supplyStatusExpired  = "expired"
+)
+
+// SupplyContext provides contextual access to supply inventory status references.
+type SupplyContext interface {
+	Statuses() SupplyStatusProvider
+}
+
+// SupplyStatusProvider exposes canonical supply inventory statuses.
+type SupplyStatusProvider interface {
+	Healthy() SupplyStatusRef
+	Reorder() SupplyStatusRef
+	Critical() SupplyStatusRef
+	Expired() SupplyStatusRef
+}
+
+// SupplyStatusRef represents an opaque supply inventory status.
+type SupplyStatusRef interface {
+	String() string
+	RequiresReorder() bool
+	IsExpired() bool
+	Equals(other SupplyStatusRef) bool
+	isSupplyStatusRef()
+}
+
+type supplyContext struct{}
+
+// NewSupplyContext constructs the default supply context provider.
+func NewSupplyContext() SupplyContext {
+	return supplyContext{}
+}
+
+func (supplyContext) Statuses() SupplyStatusProvider {
+	return supplyStatusProvider{}
+}
+
+type supplyStatusProvider struct{}
+
+func (supplyStatusProvider) Healthy() SupplyStatusRef {
+	return supplyStatusRef{value: supplyStatusHealthy}
+}
+
+func (supplyStatusProvider) Reorder() SupplyStatusRef {
+	return supplyStatusRef{value: supplyStatusReorder}
+}
+
+func (supplyStatusProvider) Critical() SupplyStatusRef {
+	return supplyStatusRef{value: supplyStatusCritical}
+}
+
+func (supplyStatusProvider) Expired() SupplyStatusRef {
+	return supplyStatusRef{value: supplyStatusExpired}
+}
+
+type supplyStatusRef struct {
+	value string
+}
+
+func (s supplyStatusRef) String() string {
+	return s.value
+}
+
+func (s supplyStatusRef) RequiresReorder() bool {
+	return s.value == supplyStatusReorder || s.value == supplyStatusCritical
+}
+
+func (s supplyStatusRef) IsExpired() bool {
+	return s.value == supplyStatusExpired
+}
+
+func (s supplyStatusRef) Equals(other SupplyStatusRef) bool {
+	if otherRef, ok := other.(supplyStatusRef); ok {
+		return s.value == otherRef.value
+	}
+	return false
+}
+
+func (s supplyStatusRef) isSupplyStatusRef() {}

--- a/pkg/pluginapi/treatment_context.go
+++ b/pkg/pluginapi/treatment_context.go
@@ -1,0 +1,89 @@
+package pluginapi
+
+const (
+	treatmentStatusPlanned    = "planned"
+	treatmentStatusInProgress = "in_progress"
+	treatmentStatusCompleted  = "completed"
+	treatmentStatusFlagged    = "flagged"
+)
+
+// TreatmentContext provides contextual access to treatment workflow statuses.
+type TreatmentContext interface {
+	Statuses() TreatmentStatusProvider
+}
+
+// TreatmentStatusProvider exposes canonical treatment workflow statuses.
+type TreatmentStatusProvider interface {
+	Planned() TreatmentStatusRef
+	InProgress() TreatmentStatusRef
+	Completed() TreatmentStatusRef
+	Flagged() TreatmentStatusRef
+}
+
+// TreatmentStatusRef represents an opaque treatment workflow status.
+type TreatmentStatusRef interface {
+	String() string
+	IsActive() bool
+	IsCompleted() bool
+	IsFlagged() bool
+	Equals(other TreatmentStatusRef) bool
+	isTreatmentStatusRef()
+}
+
+type treatmentContext struct{}
+
+// NewTreatmentContext constructs the default treatment context provider.
+func NewTreatmentContext() TreatmentContext {
+	return treatmentContext{}
+}
+
+func (treatmentContext) Statuses() TreatmentStatusProvider {
+	return treatmentStatusProvider{}
+}
+
+type treatmentStatusProvider struct{}
+
+func (treatmentStatusProvider) Planned() TreatmentStatusRef {
+	return treatmentStatusRef{value: treatmentStatusPlanned}
+}
+
+func (treatmentStatusProvider) InProgress() TreatmentStatusRef {
+	return treatmentStatusRef{value: treatmentStatusInProgress}
+}
+
+func (treatmentStatusProvider) Completed() TreatmentStatusRef {
+	return treatmentStatusRef{value: treatmentStatusCompleted}
+}
+
+func (treatmentStatusProvider) Flagged() TreatmentStatusRef {
+	return treatmentStatusRef{value: treatmentStatusFlagged}
+}
+
+type treatmentStatusRef struct {
+	value string
+}
+
+func (t treatmentStatusRef) String() string {
+	return t.value
+}
+
+func (t treatmentStatusRef) IsActive() bool {
+	return t.value == treatmentStatusInProgress
+}
+
+func (t treatmentStatusRef) IsCompleted() bool {
+	return t.value == treatmentStatusCompleted
+}
+
+func (t treatmentStatusRef) IsFlagged() bool {
+	return t.value == treatmentStatusFlagged
+}
+
+func (t treatmentStatusRef) Equals(other TreatmentStatusRef) bool {
+	if otherRef, ok := other.(treatmentStatusRef); ok {
+		return t.value == otherRef.value
+	}
+	return false
+}
+
+func (t treatmentStatusRef) isTreatmentStatusRef() {}

--- a/pkg/pluginapi/views.go
+++ b/pkg/pluginapi/views.go
@@ -44,6 +44,77 @@ type HousingUnitView interface {
 	SupportsSpecies(species string) bool
 }
 
+// FacilityView is a read-only projection of a facility record.
+type FacilityView interface {
+	BaseView
+	Name() string
+	Zone() string
+	AccessPolicy() string
+	EnvironmentBaselines() map[string]any
+	HousingUnitIDs() []string
+	ProjectIDs() []string
+
+	// Contextual zone & access policy accessors
+	GetZone() FacilityZoneRef
+	GetAccessPolicy() FacilityAccessPolicyRef
+	SupportsHousingUnit(id string) bool
+}
+
+// TreatmentView is a read-only projection of a treatment record.
+type TreatmentView interface {
+	BaseView
+	Name() string
+	ProcedureID() string
+	OrganismIDs() []string
+	CohortIDs() []string
+	DosagePlan() string
+	AdministrationLog() []string
+	AdverseEvents() []string
+
+	// Contextual workflow accessors
+	GetCurrentStatus() TreatmentStatusRef
+	IsCompleted() bool
+	HasAdverseEvents() bool
+}
+
+// ObservationView is a read-only projection of an observation record.
+type ObservationView interface {
+	BaseView
+	ProcedureID() (string, bool)
+	OrganismID() (string, bool)
+	CohortID() (string, bool)
+	RecordedAt() time.Time
+	Observer() string
+	Data() map[string]any
+	Notes() string
+
+	// Contextual data shape accessors
+	GetDataShape() ObservationShapeRef
+	HasStructuredPayload() bool
+	HasNarrativeNotes() bool
+}
+
+// SampleView is a read-only projection of a sample record.
+type SampleView interface {
+	BaseView
+	Identifier() string
+	SourceType() string
+	OrganismID() (string, bool)
+	CohortID() (string, bool)
+	FacilityID() string
+	CollectedAt() time.Time
+	Status() string
+	StorageLocation() string
+	AssayType() string
+	ChainOfCustody() []map[string]any
+	Attributes() map[string]any
+
+	// Contextual sample accessors
+	GetSource() SampleSourceRef
+	GetStatus() SampleStatusRef
+	IsAvailable() bool
+}
+
 // ProtocolView is a read-only projection of a protocol record.
 type ProtocolView interface {
 	BaseView
@@ -57,4 +128,52 @@ type ProtocolView interface {
 	IsActiveProtocol() bool
 	IsTerminalStatus() bool
 	CanAcceptNewSubjects() bool
+}
+
+// PermitView is a read-only projection of a permit record.
+type PermitView interface {
+	BaseView
+	PermitNumber() string
+	Authority() string
+	ValidFrom() time.Time
+	ValidUntil() time.Time
+	AllowedActivities() []string
+	FacilityIDs() []string
+	ProtocolIDs() []string
+	Notes() string
+
+	// Contextual validity accessors
+	GetStatus(reference time.Time) PermitStatusRef
+	IsActive(reference time.Time) bool
+	IsExpired(reference time.Time) bool
+}
+
+// ProjectView is a read-only projection of a project record.
+type ProjectView interface {
+	BaseView
+	Code() string
+	Title() string
+	Description() string
+	FacilityIDs() []string
+}
+
+// SupplyItemView is a read-only projection of a supply item record.
+type SupplyItemView interface {
+	BaseView
+	SKU() string
+	Name() string
+	Description() string
+	QuantityOnHand() int
+	Unit() string
+	LotNumber() string
+	ExpiresAt() (*time.Time, bool)
+	FacilityIDs() []string
+	ProjectIDs() []string
+	ReorderLevel() int
+	Attributes() map[string]any
+
+	// Contextual inventory accessors
+	GetInventoryStatus(reference time.Time) SupplyStatusRef
+	RequiresReorder(reference time.Time) bool
+	IsExpired(reference time.Time) bool
 }

--- a/plugins/frog/plugin_rule_skip_test.go
+++ b/plugins/frog/plugin_rule_skip_test.go
@@ -15,11 +15,36 @@ type fakeRuleViewNoHousing struct {
 
 func (v fakeRuleViewNoHousing) ListOrganisms() []pluginapi.OrganismView       { return v.orgs }
 func (v fakeRuleViewNoHousing) ListHousingUnits() []pluginapi.HousingUnitView { return v.housing }
+func (fakeRuleViewNoHousing) ListFacilities() []pluginapi.FacilityView        { return nil }
+func (fakeRuleViewNoHousing) ListTreatments() []pluginapi.TreatmentView       { return nil }
+func (fakeRuleViewNoHousing) ListObservations() []pluginapi.ObservationView   { return nil }
+func (fakeRuleViewNoHousing) ListSamples() []pluginapi.SampleView             { return nil }
 func (v fakeRuleViewNoHousing) ListProtocols() []pluginapi.ProtocolView       { return nil }
+func (fakeRuleViewNoHousing) ListPermits() []pluginapi.PermitView             { return nil }
+func (fakeRuleViewNoHousing) ListProjects() []pluginapi.ProjectView           { return nil }
+func (fakeRuleViewNoHousing) ListSupplyItems() []pluginapi.SupplyItemView     { return nil }
 func (v fakeRuleViewNoHousing) FindOrganism(_ string) (pluginapi.OrganismView, bool) {
 	return nil, false
 }
 func (v fakeRuleViewNoHousing) FindHousingUnit(_ string) (pluginapi.HousingUnitView, bool) {
+	return nil, false
+}
+func (fakeRuleViewNoHousing) FindFacility(string) (pluginapi.FacilityView, bool) {
+	return nil, false
+}
+func (fakeRuleViewNoHousing) FindTreatment(string) (pluginapi.TreatmentView, bool) {
+	return nil, false
+}
+func (fakeRuleViewNoHousing) FindObservation(string) (pluginapi.ObservationView, bool) {
+	return nil, false
+}
+func (fakeRuleViewNoHousing) FindSample(string) (pluginapi.SampleView, bool) {
+	return nil, false
+}
+func (fakeRuleViewNoHousing) FindPermit(string) (pluginapi.PermitView, bool) {
+	return nil, false
+}
+func (fakeRuleViewNoHousing) FindSupplyItem(string) (pluginapi.SupplyItemView, bool) {
 	return nil, false
 }
 func strPtr(s string) *string { return &s }

--- a/plugins/frog/plugin_rule_test.go
+++ b/plugins/frog/plugin_rule_test.go
@@ -33,7 +33,14 @@ type fakeView struct {
 
 func (v fakeView) ListOrganisms() []pluginapi.OrganismView       { return v.organisms }
 func (v fakeView) ListHousingUnits() []pluginapi.HousingUnitView { return v.housing }
+func (fakeView) ListFacilities() []pluginapi.FacilityView        { return nil }
+func (fakeView) ListTreatments() []pluginapi.TreatmentView       { return nil }
+func (fakeView) ListObservations() []pluginapi.ObservationView   { return nil }
+func (fakeView) ListSamples() []pluginapi.SampleView             { return nil }
 func (v fakeView) ListProtocols() []pluginapi.ProtocolView       { return nil }
+func (fakeView) ListPermits() []pluginapi.PermitView             { return nil }
+func (fakeView) ListProjects() []pluginapi.ProjectView           { return nil }
+func (fakeView) ListSupplyItems() []pluginapi.SupplyItemView     { return nil }
 
 func (v fakeView) FindHousingUnit(id string) (pluginapi.HousingUnitView, bool) {
 	for _, h := range v.housing {
@@ -50,6 +57,30 @@ func (v fakeView) FindOrganism(id string) (pluginapi.OrganismView, bool) {
 			return o, true
 		}
 	}
+	return nil, false
+}
+
+func (fakeView) FindFacility(string) (pluginapi.FacilityView, bool) {
+	return nil, false
+}
+
+func (fakeView) FindTreatment(string) (pluginapi.TreatmentView, bool) {
+	return nil, false
+}
+
+func (fakeView) FindObservation(string) (pluginapi.ObservationView, bool) {
+	return nil, false
+}
+
+func (fakeView) FindSample(string) (pluginapi.SampleView, bool) {
+	return nil, false
+}
+
+func (fakeView) FindPermit(string) (pluginapi.PermitView, bool) {
+	return nil, false
+}
+
+func (fakeView) FindSupplyItem(string) (pluginapi.SupplyItemView, bool) {
 	return nil, false
 }
 

--- a/plugins/frog/plugin_test.go
+++ b/plugins/frog/plugin_test.go
@@ -54,7 +54,14 @@ func (s *stubView) ListHousingUnits() []datasetapi.HousingUnit {
 	return units
 }
 
-func (s *stubView) ListProtocols() []datasetapi.Protocol { return nil }
+func (s *stubView) ListProtocols() []datasetapi.Protocol       { return nil }
+func (s *stubView) ListFacilities() []datasetapi.Facility      { return nil }
+func (s *stubView) ListTreatments() []datasetapi.Treatment     { return nil }
+func (s *stubView) ListObservations() []datasetapi.Observation { return nil }
+func (s *stubView) ListSamples() []datasetapi.Sample           { return nil }
+func (s *stubView) ListPermits() []datasetapi.Permit           { return nil }
+func (s *stubView) ListProjects() []datasetapi.Project         { return nil }
+func (s *stubView) ListSupplyItems() []datasetapi.SupplyItem   { return nil }
 
 func (s *stubView) FindOrganism(id string) (datasetapi.Organism, bool) {
 	for _, org := range s.organisms {
@@ -70,6 +77,13 @@ func (s *stubView) FindHousingUnit(id string) (datasetapi.HousingUnit, bool) {
 	return unit, ok
 }
 
+func (s *stubView) FindFacility(string) (datasetapi.Facility, bool)       { return nil, false }
+func (s *stubView) FindTreatment(string) (datasetapi.Treatment, bool)     { return nil, false }
+func (s *stubView) FindObservation(string) (datasetapi.Observation, bool) { return nil, false }
+func (s *stubView) FindSample(string) (datasetapi.Sample, bool)           { return nil, false }
+func (s *stubView) FindPermit(string) (datasetapi.Permit, bool)           { return nil, false }
+func (s *stubView) FindSupplyItem(string) (datasetapi.SupplyItem, bool)   { return nil, false }
+
 type stubStore struct {
 	view datasetapi.TransactionView
 }
@@ -83,12 +97,20 @@ func (stubStore) ListOrganisms() []datasetapi.Organism           { return nil }
 func (stubStore) GetHousingUnit(string) (datasetapi.HousingUnit, bool) {
 	return nil, false
 }
-func (stubStore) ListHousingUnits() []datasetapi.HousingUnit   { return nil }
-func (stubStore) ListCohorts() []datasetapi.Cohort             { return nil }
-func (stubStore) ListProtocols() []datasetapi.Protocol         { return nil }
-func (stubStore) ListProjects() []datasetapi.Project           { return nil }
-func (stubStore) ListBreedingUnits() []datasetapi.BreedingUnit { return nil }
-func (stubStore) ListProcedures() []datasetapi.Procedure       { return nil }
+func (stubStore) ListHousingUnits() []datasetapi.HousingUnit     { return nil }
+func (stubStore) GetFacility(string) (datasetapi.Facility, bool) { return nil, false }
+func (stubStore) ListFacilities() []datasetapi.Facility          { return nil }
+func (stubStore) ListCohorts() []datasetapi.Cohort               { return nil }
+func (stubStore) ListTreatments() []datasetapi.Treatment         { return nil }
+func (stubStore) ListObservations() []datasetapi.Observation     { return nil }
+func (stubStore) ListSamples() []datasetapi.Sample               { return nil }
+func (stubStore) ListProtocols() []datasetapi.Protocol           { return nil }
+func (stubStore) GetPermit(string) (datasetapi.Permit, bool)     { return nil, false }
+func (stubStore) ListPermits() []datasetapi.Permit               { return nil }
+func (stubStore) ListProjects() []datasetapi.Project             { return nil }
+func (stubStore) ListBreedingUnits() []datasetapi.BreedingUnit   { return nil }
+func (stubStore) ListProcedures() []datasetapi.Procedure         { return nil }
+func (stubStore) ListSupplyItems() []datasetapi.SupplyItem       { return nil }
 
 func TestPluginRegistration(t *testing.T) {
 	plugin := New()

--- a/scripts/validate_plugin_patterns_test.go
+++ b/scripts/validate_plugin_patterns_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMainWithValidPlugin(t *testing.T) {
+	originalArgs := os.Args
+	t.Cleanup(func() { os.Args = originalArgs })
+
+	pluginDir := filepath.Join("..", "plugins", "frog")
+	os.Args = []string{"validate_plugin_patterns", pluginDir}
+
+	main()
+}


### PR DESCRIPTION
## What  
<!-- Describe the change. -->
Add rule adapters and contextual view types so `plugins/datasets` can consume the new entities: update `internal/core/plugin_rule_adapter.go`, `pkg/pluginapi/views.go`, and `pkg/datasetapi/facade.go` plus their snapshot tests to expose `ADR-0010`-compliant accessor methods.

## Why  
<!-- What's the motivation. -->

Working on #66 

## How  
<!-- Bullet list or description of key changes. -->

* Add 7 new entity types to datasetapi and pluginapi:
  * Facility
  * Treatment
  * Observation
  * Sample
  * Permit
  * Project
  * SupplyItem
* Implement contextual accessor pattern for all new entities
* Extend TransactionView, PersistentStore and RuleView interfaces
* Update domain rules interface
* Update tests

## Notes  
<!-- Breaking changes or follow-ups (if any). -->

## Checklist  

- [x] I have used conventional commits (conventionalcommits.com)
- [ ] I have updated the documentation
- [ ] I have updated the relevant RFC and its linked resources
- [x] I have added tests
- [x] I ran manual tests