### PR TITLE
feat: enforce facility-linked relationships

### DIFF
--- a/internal/core/housing_extra_test.go
+++ b/internal/core/housing_extra_test.go
@@ -12,10 +12,21 @@ import (
 func TestHousingUnit_UpdateAndBranches(t *testing.T) {
 	eng := NewDefaultRulesEngine()
 	store := NewMemoryStore(eng)
+	var facility domain.Facility
+	if _, err := store.RunInTransaction(context.Background(), func(tx domain.Transaction) error {
+		f, err := tx.CreateFacility(domain.Facility{Name: "Facility-A"})
+		if err != nil {
+			return err
+		}
+		facility = f
+		return nil
+	}); err != nil {
+		t.Fatalf("create facility: %v", err)
+	}
 	// Create valid housing unit
 	var created domain.HousingUnit
 	if _, err := store.RunInTransaction(context.Background(), func(tx domain.Transaction) error {
-		h, err := tx.CreateHousingUnit(domain.HousingUnit{Name: "HU-A", Capacity: 2})
+		h, err := tx.CreateHousingUnit(domain.HousingUnit{Name: "HU-A", FacilityID: facility.ID, Capacity: 2})
 		if err != nil {
 			return err
 		}
@@ -77,7 +88,7 @@ func TestHousingUnit_UpdateAndBranches(t *testing.T) {
 	}
 	// Invalid capacity on create
 	if _, err := store.RunInTransaction(context.Background(), func(tx domain.Transaction) error {
-		if _, cErr := tx.CreateHousingUnit(domain.HousingUnit{Name: "HU-B", Capacity: 0}); cErr == nil {
+		if _, cErr := tx.CreateHousingUnit(domain.HousingUnit{Name: "HU-B", FacilityID: facility.ID, Capacity: 0}); cErr == nil {
 			t.Fatalf("expected create capacity error")
 		}
 		return nil

--- a/internal/core/more_core_test.go
+++ b/internal/core/more_core_test.go
@@ -12,7 +12,11 @@ func TestStore_UpdateHousingUnit_InvalidCapacity(t *testing.T) {
 	eng := NewDefaultRulesEngine()
 	store := NewMemoryStore(eng)
 	_, err := store.RunInTransaction(context.Background(), func(tx domain.Transaction) error {
-		h, err := tx.CreateHousingUnit(domain.HousingUnit{Capacity: 1, Name: "A"})
+		f, err := tx.CreateFacility(domain.Facility{Name: "F"})
+		if err != nil {
+			return err
+		}
+		h, err := tx.CreateHousingUnit(domain.HousingUnit{Capacity: 1, Name: "A", FacilityID: f.ID})
 		if err != nil {
 			return err
 		}

--- a/internal/core/rules_extra_test.go
+++ b/internal/core/rules_extra_test.go
@@ -31,7 +31,8 @@ func TestHousingCapacityRuleViolation(t *testing.T) {
 	rule := NewHousingCapacityRule()
 	mem := NewMemoryStore(NewRulesEngine())
 	_, _ = mem.RunInTransaction(context.Background(), func(tx domain.Transaction) error {
-		h, _ := tx.CreateHousingUnit(domain.HousingUnit{Name: "H", Capacity: 1})
+		f, _ := tx.CreateFacility(domain.Facility{Name: "F"})
+		h, _ := tx.CreateHousingUnit(domain.HousingUnit{Name: "H", FacilityID: f.ID, Capacity: 1})
 		_, _ = tx.CreateOrganism(domain.Organism{Name: "A", Species: "frog", HousingID: &h.ID})
 		_, _ = tx.CreateOrganism(domain.Organism{Name: "B", Species: "frog", HousingID: &h.ID})
 		return nil

--- a/internal/core/service.go
+++ b/internal/core/service.go
@@ -131,6 +131,24 @@ func (s *Service) CreateProject(ctx context.Context, project domain.Project) (do
 	return created, res, err
 }
 
+// UpdateProject mutates a project.
+func (s *Service) UpdateProject(ctx context.Context, id string, mutator func(*domain.Project) error) (domain.Project, domain.Result, error) {
+	var updated domain.Project
+	res, err := s.run(ctx, "update_project", func(tx domain.Transaction) error {
+		var innerErr error
+		updated, innerErr = tx.UpdateProject(id, mutator)
+		return innerErr
+	})
+	return updated, res, err
+}
+
+// DeleteProject removes a project.
+func (s *Service) DeleteProject(ctx context.Context, id string) (domain.Result, error) {
+	return s.run(ctx, "delete_project", func(tx domain.Transaction) error {
+		return tx.DeleteProject(id)
+	})
+}
+
 // CreateProtocol persists a new protocol.
 func (s *Service) CreateProtocol(ctx context.Context, protocol domain.Protocol) (domain.Protocol, domain.Result, error) {
 	var created domain.Protocol
@@ -140,6 +158,24 @@ func (s *Service) CreateProtocol(ctx context.Context, protocol domain.Protocol) 
 		return innerErr
 	})
 	return created, res, err
+}
+
+// UpdateProtocol mutates a protocol.
+func (s *Service) UpdateProtocol(ctx context.Context, id string, mutator func(*domain.Protocol) error) (domain.Protocol, domain.Result, error) {
+	var updated domain.Protocol
+	res, err := s.run(ctx, "update_protocol", func(tx domain.Transaction) error {
+		var innerErr error
+		updated, innerErr = tx.UpdateProtocol(id, mutator)
+		return innerErr
+	})
+	return updated, res, err
+}
+
+// DeleteProtocol removes a protocol.
+func (s *Service) DeleteProtocol(ctx context.Context, id string) (domain.Result, error) {
+	return s.run(ctx, "delete_protocol", func(tx domain.Transaction) error {
+		return tx.DeleteProtocol(id)
+	})
 }
 
 // CreateFacility persists facility metadata.
@@ -180,6 +216,24 @@ func (s *Service) CreateHousingUnit(ctx context.Context, housing domain.HousingU
 		return innerErr
 	})
 	return created, res, err
+}
+
+// UpdateHousingUnit mutates a housing unit.
+func (s *Service) UpdateHousingUnit(ctx context.Context, id string, mutator func(*domain.HousingUnit) error) (domain.HousingUnit, domain.Result, error) {
+	var updated domain.HousingUnit
+	res, err := s.run(ctx, "update_housing_unit", func(tx domain.Transaction) error {
+		var innerErr error
+		updated, innerErr = tx.UpdateHousingUnit(id, mutator)
+		return innerErr
+	})
+	return updated, res, err
+}
+
+// DeleteHousingUnit removes a housing unit.
+func (s *Service) DeleteHousingUnit(ctx context.Context, id string) (domain.Result, error) {
+	return s.run(ctx, "delete_housing_unit", func(tx domain.Transaction) error {
+		return tx.DeleteHousingUnit(id)
+	})
 }
 
 // CreateCohort persists a new cohort.

--- a/internal/core/service_extra_test.go
+++ b/internal/core/service_extra_test.go
@@ -30,7 +30,11 @@ func TestAssignOrganismHousing(t *testing.T) {
 		t.Fatalf("expected not found error")
 	}
 	// create housing then assign
-	h, _, err := svc.CreateHousingUnit(ctx, domain.HousingUnit{Name: "H", Capacity: 10})
+	facility, _, err := svc.CreateFacility(ctx, domain.Facility{Name: "F"})
+	if err != nil {
+		t.Fatalf("create facility: %v", err)
+	}
+	h, _, err := svc.CreateHousingUnit(ctx, domain.HousingUnit{Name: "H", FacilityID: facility.ID, Capacity: 10})
 	if err != nil {
 		t.Fatalf("create housing: %v", err)
 	}

--- a/internal/infra/persistence/memory/state_additional_test.go
+++ b/internal/infra/persistence/memory/state_additional_test.go
@@ -15,12 +15,16 @@ func TestSnapshotAllEntities(t *testing.T) {
 	var housing domain.HousingUnit
 	var organism domain.Organism
 	if _, err := store.RunInTransaction(ctx, func(tx domain.Transaction) error {
+		facility, err := tx.CreateFacility(domain.Facility{Name: "Lab"})
+		if err != nil {
+			return err
+		}
 		// Create project
-		if _, err := tx.CreateProject(domain.Project{Code: "P1", Title: "Project"}); err != nil {
+		if _, err := tx.CreateProject(domain.Project{Code: "P1", Title: "Project", FacilityIDs: []string{facility.ID}}); err != nil {
 			return err
 		}
 		// Create housing
-		h, err := tx.CreateHousingUnit(domain.HousingUnit{Name: "H1", FacilityID: "Lab", Capacity: 2})
+		h, err := tx.CreateHousingUnit(domain.HousingUnit{Name: "H1", FacilityID: facility.ID, Capacity: 2})
 		if err != nil {
 			return err
 		}
@@ -81,5 +85,219 @@ func TestSnapshotAllEntities(t *testing.T) {
 	snapOrg.Attributes["color"] = "blue"
 	if store.ListOrganisms()[0].Attributes["color"] != "green" {
 		t.Fatalf("expected deep copy isolation")
+	}
+}
+
+func TestImportStateAppliesRelationshipMigrations(t *testing.T) {
+	store := NewStore(nil)
+	now := time.Now().UTC()
+	const facilityKey = "fac-1"
+
+	organisms := map[string]domain.Organism{
+		"org-1": {Base: domain.Base{ID: "org-1"}, Name: "Org", Species: "Spec"},
+	}
+	cohorts := map[string]domain.Cohort{
+		"cohort-1": {Base: domain.Base{ID: "cohort-1"}, Name: "Cohort"},
+	}
+	protocols := map[string]domain.Protocol{
+		"prot-1": {Base: domain.Base{ID: "prot-1"}, Code: "PR", Title: "Protocol", MaxSubjects: 10, Status: "active"},
+	}
+	procedures := map[string]domain.Procedure{
+		"proc-1": {Base: domain.Base{ID: "proc-1"}, Name: "Proc", Status: "scheduled", ScheduledAt: now, ProtocolID: "prot-1", OrganismIDs: []string{"org-1"}},
+	}
+
+	snapshot := Snapshot{
+		Organisms: organisms,
+		Cohorts:   cohorts,
+		Housing: map[string]domain.HousingUnit{
+			"house-1":       {Base: domain.Base{ID: "house-1"}, Name: "Housing", FacilityID: facilityKey, Capacity: 2},
+			"house-invalid": {Base: domain.Base{ID: "house-invalid"}, Name: "Invalid", FacilityID: "missing", Capacity: 1},
+		},
+		Facilities: map[string]domain.Facility{
+			facilityKey: {Base: domain.Base{ID: facilityKey}, Name: "Facility"},
+		},
+		Procedures: procedures,
+		Treatments: map[string]domain.Treatment{
+			"treat-1":   {Base: domain.Base{ID: "treat-1"}, Name: "Treat", ProcedureID: "proc-1", OrganismIDs: []string{"org-1", "missing", "org-1"}},
+			"treat-bad": {Base: domain.Base{ID: "treat-bad"}, Name: "Bad", ProcedureID: "missing"},
+		},
+		Observations: map[string]domain.Observation{
+			"obs-1": {Base: domain.Base{ID: "obs-1"}, ProcedureID: ptr("proc-1"), Observer: "Tech", RecordedAt: now},
+			"obs-2": {Base: domain.Base{ID: "obs-2"}, ProcedureID: ptr("missing"), Observer: "Tech", RecordedAt: now},
+		},
+		Samples: map[string]domain.Sample{
+			"sample-1": {Base: domain.Base{ID: "sample-1"}, Identifier: "S1", SourceType: "blood", FacilityID: facilityKey, OrganismID: ptr("org-1"), CollectedAt: now, Status: "stored", StorageLocation: "freezer"},
+			"sample-2": {Base: domain.Base{ID: "sample-2"}, Identifier: "S2", SourceType: "blood", FacilityID: "missing", CollectedAt: now, Status: "stored", StorageLocation: "freezer"},
+		},
+		Protocols: protocols,
+		Permits: map[string]domain.Permit{
+			"permit-1": {Base: domain.Base{ID: "permit-1"}, PermitNumber: "P1", Authority: "Gov", ValidFrom: now, ValidUntil: now.AddDate(1, 0, 0), FacilityIDs: []string{facilityKey, "missing", facilityKey}, ProtocolIDs: []string{"prot-1", "missing"}},
+		},
+		Projects: map[string]domain.Project{
+			"proj-1": {Base: domain.Base{ID: "proj-1"}, Code: "P1", Title: "Project", FacilityIDs: []string{facilityKey, facilityKey, "missing"}},
+		},
+		Supplies: map[string]domain.SupplyItem{
+			"supply-1": {Base: domain.Base{ID: "supply-1"}, SKU: "SKU", Name: "Gloves", QuantityOnHand: 5, Unit: "box", FacilityIDs: []string{facilityKey, "missing"}, ProjectIDs: []string{"proj-1", "missing", "proj-1"}},
+		},
+	}
+
+	store.ImportState(snapshot)
+
+	if units := store.ListHousingUnits(); len(units) != 1 || units[0].ID != "house-1" {
+		t.Fatalf("expected only valid housing to remain, got %+v", units)
+	}
+
+	facility, ok := store.GetFacility(facilityKey)
+	if !ok {
+		t.Fatalf("expected facility present")
+	}
+	if len(facility.HousingUnitIDs) != 1 || facility.HousingUnitIDs[0] != "house-1" {
+		t.Fatalf("expected facility housing ids to be migrated, got %+v", facility.HousingUnitIDs)
+	}
+	if len(facility.ProjectIDs) != 1 || facility.ProjectIDs[0] != "proj-1" {
+		t.Fatalf("expected facility project ids to be migrated, got %+v", facility.ProjectIDs)
+	}
+
+	if projects := store.ListProjects(); len(projects) != 1 || len(projects[0].FacilityIDs) != 1 || projects[0].FacilityIDs[0] != facilityKey {
+		t.Fatalf("expected project facility ids filtered, got %+v", projects)
+	}
+
+	treatments := store.ListTreatments()
+	if len(treatments) != 1 || len(treatments[0].OrganismIDs) != 1 || treatments[0].OrganismIDs[0] != "org-1" {
+		t.Fatalf("expected valid treatment with deduped organism ids, got %+v", treatments)
+	}
+
+	observations := store.ListObservations()
+	if len(observations) != 1 || observations[0].Data == nil {
+		t.Fatalf("expected valid observation with data map initialised, got %+v", observations)
+	}
+
+	samples := store.ListSamples()
+	if len(samples) != 1 || samples[0].FacilityID != facilityKey || samples[0].OrganismID == nil || *samples[0].OrganismID != "org-1" {
+		t.Fatalf("expected only valid sample, got %+v", samples)
+	}
+
+	permits := store.ListPermits()
+	if len(permits) != 1 || len(permits[0].FacilityIDs) != 1 || permits[0].FacilityIDs[0] != facilityKey || len(permits[0].ProtocolIDs) != 1 || permits[0].ProtocolIDs[0] != "prot-1" {
+		t.Fatalf("expected permit lists filtered, got %+v", permits)
+	}
+
+	supplies := store.ListSupplyItems()
+	if len(supplies) != 1 || len(supplies[0].FacilityIDs) != 1 || supplies[0].FacilityIDs[0] != facilityKey || len(supplies[0].ProjectIDs) != 1 || supplies[0].ProjectIDs[0] != "proj-1" {
+		t.Fatalf("expected supply references filtered, got %+v", supplies)
+	}
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}
+
+func TestMigrateSnapshotCleansDataVariants(t *testing.T) {
+	const facilityID = "fac-clean"
+	now := time.Now().UTC()
+	snapshot := Snapshot{
+		Organisms: map[string]domain.Organism{
+			"org-keep": {Base: domain.Base{ID: "org-keep"}, Name: "Org", Species: "Spec"},
+		},
+		Cohorts: map[string]domain.Cohort{
+			"cohort-keep": {Base: domain.Base{ID: "cohort-keep"}, Name: "Cohort"},
+		},
+		Facilities: map[string]domain.Facility{
+			facilityID: {Base: domain.Base{ID: facilityID}},
+		},
+		Housing: map[string]domain.HousingUnit{
+			"housing-valid":  {Base: domain.Base{ID: "housing-valid"}, Name: "HV", FacilityID: facilityID, Capacity: 0},
+			"housing-remove": {Base: domain.Base{ID: "housing-remove"}, Name: "HR", FacilityID: "missing", Capacity: 2},
+		},
+		Procedures: map[string]domain.Procedure{
+			"proc-keep": {Base: domain.Base{ID: "proc-keep"}, Name: "Proc", Status: "scheduled", ScheduledAt: now, ProtocolID: "prot-keep"},
+		},
+		Treatments: map[string]domain.Treatment{
+			"treatment-valid":  {Base: domain.Base{ID: "treatment-valid"}, Name: "Treat", ProcedureID: "proc-keep", OrganismIDs: []string{"org-keep", "org-keep", "missing"}, CohortIDs: []string{"cohort-keep", "missing"}},
+			"treatment-remove": {Base: domain.Base{ID: "treatment-remove"}, Name: "TreatBad", ProcedureID: "missing"},
+		},
+		Observations: map[string]domain.Observation{
+			"observation-valid": {Base: domain.Base{ID: "observation-valid"}, ProcedureID: ptr("proc-keep"), Observer: "Tech", RecordedAt: now},
+			"observation-drop":  {Base: domain.Base{ID: "observation-drop"}, ProcedureID: ptr("missing"), Observer: "Tech", RecordedAt: now},
+		},
+		Samples: map[string]domain.Sample{
+			"sample-valid":            {Base: domain.Base{ID: "sample-valid"}, Identifier: "S", SourceType: "blood", FacilityID: facilityID, OrganismID: ptr("org-keep"), CollectedAt: now, Status: "stored", StorageLocation: "room"},
+			"sample-drop":             {Base: domain.Base{ID: "sample-drop"}, Identifier: "S2", SourceType: "blood", FacilityID: facilityID, OrganismID: ptr("missing"), CollectedAt: now, Status: "stored", StorageLocation: "room"},
+			"sample-missing-facility": {Base: domain.Base{ID: "sample-missing-facility"}, Identifier: "S3", SourceType: "blood", FacilityID: "missing", CollectedAt: now, Status: "stored", StorageLocation: "room"},
+		},
+		Protocols: map[string]domain.Protocol{
+			"prot-keep": {Base: domain.Base{ID: "prot-keep"}, Code: "PR", Title: "Protocol", MaxSubjects: 5, Status: "active"},
+		},
+		Permits: map[string]domain.Permit{
+			"permit-valid": {Base: domain.Base{ID: "permit-valid"}, PermitNumber: "P", Authority: "Gov", ValidFrom: now, ValidUntil: now.Add(time.Hour), FacilityIDs: []string{facilityID, facilityID, "missing"}, ProtocolIDs: []string{"prot-keep", "missing"}},
+		},
+		Projects: map[string]domain.Project{
+			"project-valid": {Base: domain.Base{ID: "project-valid"}, Code: "PRJ", Title: "Project", FacilityIDs: []string{facilityID, facilityID, "missing"}},
+		},
+		Supplies: map[string]domain.SupplyItem{
+			"supply-valid": {Base: domain.Base{ID: "supply-valid"}, SKU: "SKU", Name: "Supply", FacilityIDs: []string{facilityID, facilityID, "missing"}, ProjectIDs: []string{"project-valid", "missing"}},
+		},
+	}
+
+	migrated := migrateSnapshot(snapshot)
+
+	if len(migrated.Housing) != 1 {
+		t.Fatalf("expected one housing unit to remain, got %+v", migrated.Housing)
+	}
+	if got := migrated.Housing["housing-valid"].Capacity; got != 1 {
+		t.Fatalf("expected capacity to default to 1, got %d", got)
+	}
+
+	if len(migrated.Treatments) != 1 || len(migrated.Treatments["treatment-valid"].OrganismIDs) != 1 || migrated.Treatments["treatment-valid"].OrganismIDs[0] != "org-keep" {
+		t.Fatalf("unexpected treatments after migration: %+v", migrated.Treatments)
+	}
+	if len(migrated.Treatments["treatment-valid"].CohortIDs) != 1 || migrated.Treatments["treatment-valid"].CohortIDs[0] != "cohort-keep" {
+		t.Fatalf("expected cohort IDs to be deduped")
+	}
+
+	if len(migrated.Observations) != 1 {
+		t.Fatalf("expected single observation, got %+v", migrated.Observations)
+	}
+	if migrated.Observations["observation-valid"].Data == nil {
+		t.Fatalf("expected observation data map to be initialised")
+	}
+
+	if len(migrated.Samples) != 1 {
+		t.Fatalf("expected single valid sample, got %+v", migrated.Samples)
+	}
+	if migrated.Samples["sample-valid"].Attributes == nil {
+		t.Fatalf("expected sample attributes map to be initialised")
+	}
+
+	if len(migrated.Permits) != 1 || len(migrated.Permits["permit-valid"].FacilityIDs) != 1 || migrated.Permits["permit-valid"].FacilityIDs[0] != facilityID {
+		t.Fatalf("expected permit facility IDs filtered, got %+v", migrated.Permits["permit-valid"].FacilityIDs)
+	}
+	if len(migrated.Permits["permit-valid"].ProtocolIDs) != 1 || migrated.Permits["permit-valid"].ProtocolIDs[0] != "prot-keep" {
+		t.Fatalf("expected permit protocol IDs filtered")
+	}
+
+	if len(migrated.Projects["project-valid"].FacilityIDs) != 1 || migrated.Projects["project-valid"].FacilityIDs[0] != facilityID {
+		t.Fatalf("expected project facility IDs filtered")
+	}
+
+	if migrated.Supplies["supply-valid"].Attributes == nil {
+		t.Fatalf("expected supply attributes map initialised")
+	}
+	if len(migrated.Supplies["supply-valid"].FacilityIDs) != 1 || migrated.Supplies["supply-valid"].FacilityIDs[0] != facilityID {
+		t.Fatalf("expected supply facility IDs filtered")
+	}
+	if len(migrated.Supplies["supply-valid"].ProjectIDs) != 1 || migrated.Supplies["supply-valid"].ProjectIDs[0] != "project-valid" {
+		t.Fatalf("expected supply project IDs filtered")
+	}
+
+	facility := migrated.Facilities[facilityID]
+	if facility.EnvironmentBaselines == nil {
+		t.Fatalf("expected facility baselines map initialised")
+	}
+	if len(facility.HousingUnitIDs) != 1 || facility.HousingUnitIDs[0] != "housing-valid" {
+		t.Fatalf("expected facility housing IDs populated, got %+v", facility.HousingUnitIDs)
+	}
+	if len(facility.ProjectIDs) != 1 || facility.ProjectIDs[0] != "project-valid" {
+		t.Fatalf("expected facility project IDs populated, got %+v", facility.ProjectIDs)
 	}
 }

--- a/internal/infra/persistence/memory/store_test.go
+++ b/internal/infra/persistence/memory/store_test.go
@@ -79,7 +79,11 @@ func TestUpdateHousingUnitErrors(t *testing.T) {
 		if _, err := tx.UpdateHousingUnit("missing", func(*domain.HousingUnit) error { return nil }); err == nil {
 			t.Fatalf("expected missing housing error")
 		}
-		h, err := tx.CreateHousingUnit(domain.HousingUnit{Name: "Unit", Capacity: 2})
+		f, err := tx.CreateFacility(domain.Facility{Name: "Facility"})
+		if err != nil {
+			return err
+		}
+		h, err := tx.CreateHousingUnit(domain.HousingUnit{Name: "Unit", FacilityID: f.ID, Capacity: 2})
 		if err != nil {
 			return err
 		}

--- a/internal/infra/persistence/sqlite/memstore.go
+++ b/internal/infra/persistence/sqlite/memstore.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 )
@@ -213,6 +214,200 @@ func memoryStateFromSnapshot(s Snapshot) memoryState {
 	return st
 }
 
+func migrateSnapshot(snapshot Snapshot) Snapshot {
+	if snapshot.Organisms == nil {
+		snapshot.Organisms = map[string]Organism{}
+	}
+	if snapshot.Cohorts == nil {
+		snapshot.Cohorts = map[string]Cohort{}
+	}
+	if snapshot.Housing == nil {
+		snapshot.Housing = map[string]HousingUnit{}
+	}
+	if snapshot.Facilities == nil {
+		snapshot.Facilities = map[string]Facility{}
+	}
+	if snapshot.Breeding == nil {
+		snapshot.Breeding = map[string]BreedingUnit{}
+	}
+	if snapshot.Procedures == nil {
+		snapshot.Procedures = map[string]Procedure{}
+	}
+	if snapshot.Treatments == nil {
+		snapshot.Treatments = map[string]Treatment{}
+	}
+	if snapshot.Observations == nil {
+		snapshot.Observations = map[string]Observation{}
+	}
+	if snapshot.Samples == nil {
+		snapshot.Samples = map[string]Sample{}
+	}
+	if snapshot.Protocols == nil {
+		snapshot.Protocols = map[string]Protocol{}
+	}
+	if snapshot.Permits == nil {
+		snapshot.Permits = map[string]Permit{}
+	}
+	if snapshot.Projects == nil {
+		snapshot.Projects = map[string]Project{}
+	}
+	if snapshot.Supplies == nil {
+		snapshot.Supplies = map[string]SupplyItem{}
+	}
+
+	facilityExists := func(id string) bool {
+		_, ok := snapshot.Facilities[id]
+		return ok
+	}
+	projectExists := func(id string) bool {
+		_, ok := snapshot.Projects[id]
+		return ok
+	}
+	organismExists := func(id string) bool {
+		_, ok := snapshot.Organisms[id]
+		return ok
+	}
+	cohortExists := func(id string) bool {
+		_, ok := snapshot.Cohorts[id]
+		return ok
+	}
+	procedureExists := func(id string) bool {
+		_, ok := snapshot.Procedures[id]
+		return ok
+	}
+	protocolExists := func(id string) bool {
+		_, ok := snapshot.Protocols[id]
+		return ok
+	}
+
+	for id, housing := range snapshot.Housing {
+		if housing.FacilityID == "" || !facilityExists(housing.FacilityID) {
+			delete(snapshot.Housing, id)
+			continue
+		}
+		if housing.Capacity <= 0 {
+			housing.Capacity = 1
+		}
+		snapshot.Housing[id] = housing
+	}
+
+	for id, treatment := range snapshot.Treatments {
+		if treatment.ProcedureID == "" || !procedureExists(treatment.ProcedureID) {
+			delete(snapshot.Treatments, id)
+			continue
+		}
+		if filtered, changed := filterIDs(treatment.OrganismIDs, organismExists); changed {
+			treatment.OrganismIDs = filtered
+		}
+		if filtered, changed := filterIDs(treatment.CohortIDs, cohortExists); changed {
+			treatment.CohortIDs = filtered
+		}
+		snapshot.Treatments[id] = treatment
+	}
+
+	for id, observation := range snapshot.Observations {
+		if observation.Data == nil {
+			observation.Data = map[string]any{}
+		}
+		if observation.ProcedureID != nil && !procedureExists(*observation.ProcedureID) {
+			observation.ProcedureID = nil
+		}
+		if observation.OrganismID != nil && !organismExists(*observation.OrganismID) {
+			observation.OrganismID = nil
+		}
+		if observation.CohortID != nil && !cohortExists(*observation.CohortID) {
+			observation.CohortID = nil
+		}
+		if observation.ProcedureID == nil && observation.OrganismID == nil && observation.CohortID == nil {
+			delete(snapshot.Observations, id)
+			continue
+		}
+		snapshot.Observations[id] = observation
+	}
+
+	for id, sample := range snapshot.Samples {
+		if sample.Attributes == nil {
+			sample.Attributes = map[string]any{}
+		}
+		if sample.FacilityID == "" || !facilityExists(sample.FacilityID) {
+			delete(snapshot.Samples, id)
+			continue
+		}
+		if sample.OrganismID != nil && !organismExists(*sample.OrganismID) {
+			sample.OrganismID = nil
+		}
+		if sample.CohortID != nil && !cohortExists(*sample.CohortID) {
+			sample.CohortID = nil
+		}
+		if sample.OrganismID == nil && sample.CohortID == nil {
+			delete(snapshot.Samples, id)
+			continue
+		}
+		snapshot.Samples[id] = sample
+	}
+
+	for id, permit := range snapshot.Permits {
+		if filtered, changed := filterIDs(permit.FacilityIDs, facilityExists); changed {
+			permit.FacilityIDs = filtered
+		}
+		if filtered, changed := filterIDs(permit.ProtocolIDs, protocolExists); changed {
+			permit.ProtocolIDs = filtered
+		}
+		snapshot.Permits[id] = permit
+	}
+
+	for id, project := range snapshot.Projects {
+		if filtered, changed := filterIDs(project.FacilityIDs, facilityExists); changed {
+			project.FacilityIDs = filtered
+		}
+		snapshot.Projects[id] = project
+	}
+
+	for id, item := range snapshot.Supplies {
+		if item.Attributes == nil {
+			item.Attributes = map[string]any{}
+		}
+		if filtered, changed := filterIDs(item.FacilityIDs, facilityExists); changed {
+			item.FacilityIDs = filtered
+		}
+		if filtered, changed := filterIDs(item.ProjectIDs, projectExists); changed {
+			item.ProjectIDs = filtered
+		}
+		snapshot.Supplies[id] = item
+	}
+
+	for id, facility := range snapshot.Facilities {
+		if facility.EnvironmentBaselines == nil {
+			facility.EnvironmentBaselines = map[string]any{}
+		}
+		snapshot.Facilities[id] = facility
+	}
+
+	for id, facility := range snapshot.Facilities {
+		var housingIDs []string
+		for _, housing := range snapshot.Housing {
+			if housing.FacilityID == id {
+				housingIDs = append(housingIDs, housing.ID)
+			}
+		}
+		sort.Strings(housingIDs)
+		facility.HousingUnitIDs = housingIDs
+
+		var projectIDs []string
+		for _, project := range snapshot.Projects {
+			if containsString(project.FacilityIDs, id) {
+				projectIDs = append(projectIDs, project.ID)
+			}
+		}
+		sort.Strings(projectIDs)
+		facility.ProjectIDs = projectIDs
+
+		snapshot.Facilities[id] = facility
+	}
+
+	return snapshot
+}
+
 func (s memoryState) clone() memoryState { return memoryStateFromSnapshot(snapshotFromMemoryState(s)) }
 
 func cloneOrganism(o Organism) Organism {
@@ -239,7 +434,11 @@ func cloneProcedure(p Procedure) Procedure {
 	return cp
 }
 func cloneProtocol(p Protocol) Protocol { return p }
-func cloneProject(p Project) Project    { return p }
+func cloneProject(p Project) Project {
+	cp := p
+	cp.FacilityIDs = append([]string(nil), p.FacilityIDs...)
+	return cp
+}
 
 func cloneFacility(f Facility) Facility {
 	cp := f
@@ -294,6 +493,99 @@ func clonePermit(p Permit) Permit {
 	return cp
 }
 
+func appendIfMissing(values []string, id string) ([]string, bool) {
+	for _, existing := range values {
+		if existing == id {
+			return values, false
+		}
+	}
+	return append(values, id), true
+}
+
+func removeIfPresent(values []string, id string) ([]string, bool) {
+	for idx, existing := range values {
+		if existing == id {
+			out := make([]string, 0, len(values)-1)
+			out = append(out, values[:idx]...)
+			out = append(out, values[idx+1:]...)
+			return out, true
+		}
+	}
+	return values, false
+}
+
+func containsString(values []string, id string) bool {
+	for _, existing := range values {
+		if existing == id {
+			return true
+		}
+	}
+	return false
+}
+
+func dedupeStrings(values []string) []string {
+	if len(values) <= 1 {
+		return append([]string(nil), values...)
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
+
+func filterIDs(values []string, exists func(string) bool) ([]string, bool) {
+	if len(values) == 0 {
+		return nil, false
+	}
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	changed := false
+	for _, v := range values {
+		if _, ok := seen[v]; ok {
+			changed = true
+			continue
+		}
+		seen[v] = struct{}{}
+		if !exists(v) {
+			changed = true
+			continue
+		}
+		out = append(out, v)
+	}
+	if !changed && len(out) == len(values) {
+		return values, false
+	}
+	return out, true
+}
+
+func facilityHousingIDs(state memoryState, facilityID string) []string {
+	var ids []string
+	for _, housing := range state.housing {
+		if housing.FacilityID == facilityID {
+			ids = append(ids, housing.ID)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func facilityProjectIDs(state memoryState, facilityID string) []string {
+	var ids []string
+	for _, project := range state.projects {
+		if containsString(project.FacilityIDs, facilityID) {
+			ids = append(ids, project.ID)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
 func cloneSupplyItem(s SupplyItem) SupplyItem {
 	cp := s
 	if s.ExpiresAt != nil {
@@ -339,7 +631,7 @@ func (s *memStore) ExportState() Snapshot {
 func (s *memStore) ImportState(snapshot Snapshot) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.state = memoryStateFromSnapshot(snapshot)
+	s.state = memoryStateFromSnapshot(migrateSnapshot(snapshot))
 }
 func (s *memStore) RulesEngine() *RulesEngine { s.mu.RLock(); defer s.mu.RUnlock(); return s.engine }
 func (s *memStore) NowFunc() func() time.Time { s.mu.RLock(); defer s.mu.RUnlock(); return s.nowFn }
@@ -533,6 +825,21 @@ func (tx *transaction) FindFacility(id string) (Facility, bool) {
 	}
 	return cloneFacility(f), true
 }
+
+func (tx *transaction) mutateFacility(id string, mutate func(*Facility) bool) error {
+	facility, ok := tx.state.facilities[id]
+	if !ok {
+		return fmt.Errorf("facility %q not found", id)
+	}
+	before := cloneFacility(facility)
+	if !mutate(&facility) {
+		return nil
+	}
+	facility.UpdatedAt = tx.now
+	tx.state.facilities[id] = cloneFacility(facility)
+	tx.recordChange(Change{Entity: domain.EntityFacility, Action: domain.ActionUpdate, Before: before, After: cloneFacility(facility)})
+	return nil
+}
 func (tx *transaction) FindTreatment(id string) (Treatment, bool) {
 	t, ok := tx.state.treatments[id]
 	if !ok {
@@ -604,6 +911,11 @@ func (tx *transaction) DeleteOrganism(id string) error {
 	if !ok {
 		return fmt.Errorf("organism %q not found", id)
 	}
+	for _, sample := range tx.state.samples {
+		if sample.OrganismID != nil && *sample.OrganismID == id {
+			return fmt.Errorf("organism %q still referenced by sample %q", id, sample.ID)
+		}
+	}
 	delete(tx.state.organisms, id)
 	tx.recordChange(Change{Entity: domain.EntityOrganism, Action: domain.ActionDelete, Before: cloneOrganism(current)})
 	return nil
@@ -641,6 +953,11 @@ func (tx *transaction) DeleteCohort(id string) error {
 	if !ok {
 		return fmt.Errorf("cohort %q not found", id)
 	}
+	for _, sample := range tx.state.samples {
+		if sample.CohortID != nil && *sample.CohortID == id {
+			return fmt.Errorf("cohort %q still referenced by sample %q", id, sample.ID)
+		}
+	}
 	delete(tx.state.cohorts, id)
 	tx.recordChange(Change{Entity: domain.EntityCohort, Action: domain.ActionDelete, Before: cloneCohort(current)})
 	return nil
@@ -652,6 +969,12 @@ func (tx *transaction) CreateHousingUnit(h HousingUnit) (HousingUnit, error) {
 	if _, exists := tx.state.housing[h.ID]; exists {
 		return HousingUnit{}, fmt.Errorf("housing unit %q already exists", h.ID)
 	}
+	if h.FacilityID == "" {
+		return HousingUnit{}, errors.New("housing unit requires facility id")
+	}
+	if _, ok := tx.state.facilities[h.FacilityID]; !ok {
+		return HousingUnit{}, fmt.Errorf("facility %q not found", h.FacilityID)
+	}
 	if h.Capacity <= 0 {
 		return HousingUnit{}, errors.New("housing capacity must be positive")
 	}
@@ -659,6 +982,15 @@ func (tx *transaction) CreateHousingUnit(h HousingUnit) (HousingUnit, error) {
 	h.UpdatedAt = tx.now
 	tx.state.housing[h.ID] = cloneHousing(h)
 	tx.recordChange(Change{Entity: domain.EntityHousingUnit, Action: domain.ActionCreate, After: cloneHousing(h)})
+	if err := tx.mutateFacility(h.FacilityID, func(f *Facility) bool {
+		ids, changed := appendIfMissing(f.HousingUnitIDs, h.ID)
+		if changed {
+			f.HousingUnitIDs = ids
+		}
+		return changed
+	}); err != nil {
+		return HousingUnit{}, err
+	}
 	return cloneHousing(h), nil
 }
 func (tx *transaction) UpdateHousingUnit(id string, mutator func(*HousingUnit) error) (HousingUnit, error) {
@@ -666,9 +998,16 @@ func (tx *transaction) UpdateHousingUnit(id string, mutator func(*HousingUnit) e
 	if !ok {
 		return HousingUnit{}, fmt.Errorf("housing unit %q not found", id)
 	}
+	prevFacility := current.FacilityID
 	before := cloneHousing(current)
 	if err := mutator(&current); err != nil {
 		return HousingUnit{}, err
+	}
+	if current.FacilityID == "" {
+		return HousingUnit{}, errors.New("housing unit requires facility id")
+	}
+	if _, ok := tx.state.facilities[current.FacilityID]; !ok {
+		return HousingUnit{}, fmt.Errorf("facility %q not found", current.FacilityID)
 	}
 	if current.Capacity <= 0 {
 		return HousingUnit{}, errors.New("housing capacity must be positive")
@@ -677,12 +1016,41 @@ func (tx *transaction) UpdateHousingUnit(id string, mutator func(*HousingUnit) e
 	current.UpdatedAt = tx.now
 	tx.state.housing[id] = cloneHousing(current)
 	tx.recordChange(Change{Entity: domain.EntityHousingUnit, Action: domain.ActionUpdate, Before: before, After: cloneHousing(current)})
+	if prevFacility != current.FacilityID {
+		if err := tx.mutateFacility(prevFacility, func(f *Facility) bool {
+			ids, changed := removeIfPresent(f.HousingUnitIDs, id)
+			if changed {
+				f.HousingUnitIDs = ids
+			}
+			return changed
+		}); err != nil {
+			return HousingUnit{}, err
+		}
+	}
+	if err := tx.mutateFacility(current.FacilityID, func(f *Facility) bool {
+		ids, changed := appendIfMissing(f.HousingUnitIDs, id)
+		if changed {
+			f.HousingUnitIDs = ids
+		}
+		return changed
+	}); err != nil {
+		return HousingUnit{}, err
+	}
 	return cloneHousing(current), nil
 }
 func (tx *transaction) DeleteHousingUnit(id string) error {
 	current, ok := tx.state.housing[id]
 	if !ok {
 		return fmt.Errorf("housing unit %q not found", id)
+	}
+	if err := tx.mutateFacility(current.FacilityID, func(f *Facility) bool {
+		ids, changed := removeIfPresent(f.HousingUnitIDs, id)
+		if changed {
+			f.HousingUnitIDs = ids
+		}
+		return changed
+	}); err != nil {
+		return err
 	}
 	delete(tx.state.housing, id)
 	tx.recordChange(Change{Entity: domain.EntityHousingUnit, Action: domain.ActionDelete, Before: cloneHousing(current)})
@@ -697,6 +1065,8 @@ func (tx *transaction) CreateFacility(f Facility) (Facility, error) {
 	}
 	f.CreatedAt = tx.now
 	f.UpdatedAt = tx.now
+	f.HousingUnitIDs = nil
+	f.ProjectIDs = nil
 	if f.EnvironmentBaselines == nil {
 		f.EnvironmentBaselines = map[string]any{}
 	}
@@ -716,6 +1086,8 @@ func (tx *transaction) UpdateFacility(id string, mutator func(*Facility) error) 
 	if current.EnvironmentBaselines == nil {
 		current.EnvironmentBaselines = map[string]any{}
 	}
+	current.HousingUnitIDs = facilityHousingIDs(tx.state, id)
+	current.ProjectIDs = facilityProjectIDs(tx.state, id)
 	current.ID = id
 	current.UpdatedAt = tx.now
 	tx.state.facilities[id] = cloneFacility(current)
@@ -726,6 +1098,34 @@ func (tx *transaction) DeleteFacility(id string) error {
 	current, ok := tx.state.facilities[id]
 	if !ok {
 		return fmt.Errorf("facility %q not found", id)
+	}
+	if len(current.HousingUnitIDs) > 0 {
+		return fmt.Errorf("facility %q has %d housing units; remove them before delete", id, len(current.HousingUnitIDs))
+	}
+	for _, housing := range tx.state.housing {
+		if housing.FacilityID == id {
+			return fmt.Errorf("facility %q still referenced by housing unit %q", id, housing.ID)
+		}
+	}
+	for _, sample := range tx.state.samples {
+		if sample.FacilityID == id {
+			return fmt.Errorf("facility %q still referenced by sample %q", id, sample.ID)
+		}
+	}
+	for _, project := range tx.state.projects {
+		if containsString(project.FacilityIDs, id) {
+			return fmt.Errorf("facility %q still referenced by project %q", id, project.ID)
+		}
+	}
+	for _, permit := range tx.state.permits {
+		if containsString(permit.FacilityIDs, id) {
+			return fmt.Errorf("facility %q still referenced by permit %q", id, permit.ID)
+		}
+	}
+	for _, item := range tx.state.supplies {
+		if containsString(item.FacilityIDs, id) {
+			return fmt.Errorf("facility %q still referenced by supply item %q", id, item.ID)
+		}
 	}
 	delete(tx.state.facilities, id)
 	tx.recordChange(Change{Entity: domain.EntityFacility, Action: domain.ActionDelete, Before: cloneFacility(current)})
@@ -801,6 +1201,16 @@ func (tx *transaction) DeleteProcedure(id string) error {
 	if !ok {
 		return fmt.Errorf("procedure %q not found", id)
 	}
+	for _, treatment := range tx.state.treatments {
+		if treatment.ProcedureID == id {
+			return fmt.Errorf("procedure %q still referenced by treatment %q", id, treatment.ID)
+		}
+	}
+	for _, observation := range tx.state.observations {
+		if observation.ProcedureID != nil && *observation.ProcedureID == id {
+			return fmt.Errorf("procedure %q still referenced by observation %q", id, observation.ID)
+		}
+	}
 	delete(tx.state.procedures, id)
 	tx.recordChange(Change{Entity: domain.EntityProcedure, Action: domain.ActionDelete, Before: cloneProcedure(current)})
 	return nil
@@ -811,6 +1221,24 @@ func (tx *transaction) CreateTreatment(t Treatment) (Treatment, error) {
 	}
 	if _, exists := tx.state.treatments[t.ID]; exists {
 		return Treatment{}, fmt.Errorf("treatment %q already exists", t.ID)
+	}
+	if t.ProcedureID == "" {
+		return Treatment{}, errors.New("treatment requires procedure id")
+	}
+	if _, ok := tx.state.procedures[t.ProcedureID]; !ok {
+		return Treatment{}, fmt.Errorf("procedure %q not found", t.ProcedureID)
+	}
+	t.OrganismIDs = dedupeStrings(t.OrganismIDs)
+	for _, organismID := range t.OrganismIDs {
+		if _, ok := tx.state.organisms[organismID]; !ok {
+			return Treatment{}, fmt.Errorf("organism %q not found for treatment", organismID)
+		}
+	}
+	t.CohortIDs = dedupeStrings(t.CohortIDs)
+	for _, cohortID := range t.CohortIDs {
+		if _, ok := tx.state.cohorts[cohortID]; !ok {
+			return Treatment{}, fmt.Errorf("cohort %q not found for treatment", cohortID)
+		}
 	}
 	t.CreatedAt = tx.now
 	t.UpdatedAt = tx.now
@@ -826,6 +1254,24 @@ func (tx *transaction) UpdateTreatment(id string, mutator func(*Treatment) error
 	before := cloneTreatment(current)
 	if err := mutator(&current); err != nil {
 		return Treatment{}, err
+	}
+	if current.ProcedureID == "" {
+		return Treatment{}, errors.New("treatment requires procedure id")
+	}
+	if _, ok := tx.state.procedures[current.ProcedureID]; !ok {
+		return Treatment{}, fmt.Errorf("procedure %q not found", current.ProcedureID)
+	}
+	current.OrganismIDs = dedupeStrings(current.OrganismIDs)
+	for _, organismID := range current.OrganismIDs {
+		if _, ok := tx.state.organisms[organismID]; !ok {
+			return Treatment{}, fmt.Errorf("organism %q not found for treatment", organismID)
+		}
+	}
+	current.CohortIDs = dedupeStrings(current.CohortIDs)
+	for _, cohortID := range current.CohortIDs {
+		if _, ok := tx.state.cohorts[cohortID]; !ok {
+			return Treatment{}, fmt.Errorf("cohort %q not found for treatment", cohortID)
+		}
 	}
 	current.ID = id
 	current.UpdatedAt = tx.now
@@ -849,6 +1295,24 @@ func (tx *transaction) CreateObservation(o Observation) (Observation, error) {
 	if _, exists := tx.state.observations[o.ID]; exists {
 		return Observation{}, fmt.Errorf("observation %q already exists", o.ID)
 	}
+	if o.ProcedureID == nil && o.OrganismID == nil && o.CohortID == nil {
+		return Observation{}, errors.New("observation requires procedure, organism, or cohort reference")
+	}
+	if o.ProcedureID != nil {
+		if _, ok := tx.state.procedures[*o.ProcedureID]; !ok {
+			return Observation{}, fmt.Errorf("procedure %q not found for observation", *o.ProcedureID)
+		}
+	}
+	if o.OrganismID != nil {
+		if _, ok := tx.state.organisms[*o.OrganismID]; !ok {
+			return Observation{}, fmt.Errorf("organism %q not found for observation", *o.OrganismID)
+		}
+	}
+	if o.CohortID != nil {
+		if _, ok := tx.state.cohorts[*o.CohortID]; !ok {
+			return Observation{}, fmt.Errorf("cohort %q not found for observation", *o.CohortID)
+		}
+	}
 	o.CreatedAt = tx.now
 	o.UpdatedAt = tx.now
 	if o.Data == nil {
@@ -866,6 +1330,24 @@ func (tx *transaction) UpdateObservation(id string, mutator func(*Observation) e
 	before := cloneObservation(current)
 	if err := mutator(&current); err != nil {
 		return Observation{}, err
+	}
+	if current.ProcedureID == nil && current.OrganismID == nil && current.CohortID == nil {
+		return Observation{}, errors.New("observation requires procedure, organism, or cohort reference")
+	}
+	if current.ProcedureID != nil {
+		if _, ok := tx.state.procedures[*current.ProcedureID]; !ok {
+			return Observation{}, fmt.Errorf("procedure %q not found for observation", *current.ProcedureID)
+		}
+	}
+	if current.OrganismID != nil {
+		if _, ok := tx.state.organisms[*current.OrganismID]; !ok {
+			return Observation{}, fmt.Errorf("organism %q not found for observation", *current.OrganismID)
+		}
+	}
+	if current.CohortID != nil {
+		if _, ok := tx.state.cohorts[*current.CohortID]; !ok {
+			return Observation{}, fmt.Errorf("cohort %q not found for observation", *current.CohortID)
+		}
 	}
 	if current.Data == nil {
 		current.Data = map[string]any{}
@@ -892,6 +1374,25 @@ func (tx *transaction) CreateSample(s Sample) (Sample, error) {
 	if _, exists := tx.state.samples[s.ID]; exists {
 		return Sample{}, fmt.Errorf("sample %q already exists", s.ID)
 	}
+	if s.FacilityID == "" {
+		return Sample{}, errors.New("sample requires facility id")
+	}
+	if _, ok := tx.state.facilities[s.FacilityID]; !ok {
+		return Sample{}, fmt.Errorf("facility %q not found for sample", s.FacilityID)
+	}
+	if s.OrganismID == nil && s.CohortID == nil {
+		return Sample{}, errors.New("sample requires organism or cohort reference")
+	}
+	if s.OrganismID != nil {
+		if _, ok := tx.state.organisms[*s.OrganismID]; !ok {
+			return Sample{}, fmt.Errorf("organism %q not found for sample", *s.OrganismID)
+		}
+	}
+	if s.CohortID != nil {
+		if _, ok := tx.state.cohorts[*s.CohortID]; !ok {
+			return Sample{}, fmt.Errorf("cohort %q not found for sample", *s.CohortID)
+		}
+	}
 	s.CreatedAt = tx.now
 	s.UpdatedAt = tx.now
 	if s.Attributes == nil {
@@ -909,6 +1410,25 @@ func (tx *transaction) UpdateSample(id string, mutator func(*Sample) error) (Sam
 	before := cloneSample(current)
 	if err := mutator(&current); err != nil {
 		return Sample{}, err
+	}
+	if current.FacilityID == "" {
+		return Sample{}, errors.New("sample requires facility id")
+	}
+	if _, ok := tx.state.facilities[current.FacilityID]; !ok {
+		return Sample{}, fmt.Errorf("facility %q not found for sample", current.FacilityID)
+	}
+	if current.OrganismID == nil && current.CohortID == nil {
+		return Sample{}, errors.New("sample requires organism or cohort reference")
+	}
+	if current.OrganismID != nil {
+		if _, ok := tx.state.organisms[*current.OrganismID]; !ok {
+			return Sample{}, fmt.Errorf("organism %q not found for sample", *current.OrganismID)
+		}
+	}
+	if current.CohortID != nil {
+		if _, ok := tx.state.cohorts[*current.CohortID]; !ok {
+			return Sample{}, fmt.Errorf("cohort %q not found for sample", *current.CohortID)
+		}
 	}
 	if current.Attributes == nil {
 		current.Attributes = map[string]any{}
@@ -961,6 +1481,11 @@ func (tx *transaction) DeleteProtocol(id string) error {
 	if !ok {
 		return fmt.Errorf("protocol %q not found", id)
 	}
+	for _, permit := range tx.state.permits {
+		if containsString(permit.ProtocolIDs, id) {
+			return fmt.Errorf("protocol %q still referenced by permit %q", id, permit.ID)
+		}
+	}
 	delete(tx.state.protocols, id)
 	tx.recordChange(Change{Entity: domain.EntityProtocol, Action: domain.ActionDelete, Before: cloneProtocol(current)})
 	return nil
@@ -971,6 +1496,18 @@ func (tx *transaction) CreatePermit(p Permit) (Permit, error) {
 	}
 	if _, exists := tx.state.permits[p.ID]; exists {
 		return Permit{}, fmt.Errorf("permit %q already exists", p.ID)
+	}
+	p.FacilityIDs = dedupeStrings(p.FacilityIDs)
+	for _, facilityID := range p.FacilityIDs {
+		if _, ok := tx.state.facilities[facilityID]; !ok {
+			return Permit{}, fmt.Errorf("facility %q not found for permit", facilityID)
+		}
+	}
+	p.ProtocolIDs = dedupeStrings(p.ProtocolIDs)
+	for _, protocolID := range p.ProtocolIDs {
+		if _, ok := tx.state.protocols[protocolID]; !ok {
+			return Permit{}, fmt.Errorf("protocol %q not found for permit", protocolID)
+		}
 	}
 	p.CreatedAt = tx.now
 	p.UpdatedAt = tx.now
@@ -986,6 +1523,18 @@ func (tx *transaction) UpdatePermit(id string, mutator func(*Permit) error) (Per
 	before := clonePermit(current)
 	if err := mutator(&current); err != nil {
 		return Permit{}, err
+	}
+	current.FacilityIDs = dedupeStrings(current.FacilityIDs)
+	for _, facilityID := range current.FacilityIDs {
+		if _, ok := tx.state.facilities[facilityID]; !ok {
+			return Permit{}, fmt.Errorf("facility %q not found for permit", facilityID)
+		}
+	}
+	current.ProtocolIDs = dedupeStrings(current.ProtocolIDs)
+	for _, protocolID := range current.ProtocolIDs {
+		if _, ok := tx.state.protocols[protocolID]; !ok {
+			return Permit{}, fmt.Errorf("protocol %q not found for permit", protocolID)
+		}
 	}
 	current.ID = id
 	current.UpdatedAt = tx.now
@@ -1009,6 +1558,12 @@ func (tx *transaction) CreateProject(p Project) (Project, error) {
 	if _, exists := tx.state.projects[p.ID]; exists {
 		return Project{}, fmt.Errorf("project %q already exists", p.ID)
 	}
+	p.FacilityIDs = dedupeStrings(p.FacilityIDs)
+	for _, facilityID := range p.FacilityIDs {
+		if _, ok := tx.state.facilities[facilityID]; !ok {
+			return Project{}, fmt.Errorf("facility %q not found for project", facilityID)
+		}
+	}
 	p.CreatedAt = tx.now
 	p.UpdatedAt = tx.now
 	tx.state.projects[p.ID] = cloneProject(p)
@@ -1024,6 +1579,12 @@ func (tx *transaction) UpdateProject(id string, mutator func(*Project) error) (P
 	if err := mutator(&current); err != nil {
 		return Project{}, err
 	}
+	current.FacilityIDs = dedupeStrings(current.FacilityIDs)
+	for _, facilityID := range current.FacilityIDs {
+		if _, ok := tx.state.facilities[facilityID]; !ok {
+			return Project{}, fmt.Errorf("facility %q not found for project", facilityID)
+		}
+	}
 	current.ID = id
 	current.UpdatedAt = tx.now
 	tx.state.projects[id] = cloneProject(current)
@@ -1035,6 +1596,11 @@ func (tx *transaction) DeleteProject(id string) error {
 	if !ok {
 		return fmt.Errorf("project %q not found", id)
 	}
+	for _, supply := range tx.state.supplies {
+		if containsString(supply.ProjectIDs, id) {
+			return fmt.Errorf("project %q still referenced by supply item %q", id, supply.ID)
+		}
+	}
 	delete(tx.state.projects, id)
 	tx.recordChange(Change{Entity: domain.EntityProject, Action: domain.ActionDelete, Before: cloneProject(current)})
 	return nil
@@ -1045,6 +1611,18 @@ func (tx *transaction) CreateSupplyItem(s SupplyItem) (SupplyItem, error) {
 	}
 	if _, exists := tx.state.supplies[s.ID]; exists {
 		return SupplyItem{}, fmt.Errorf("supply item %q already exists", s.ID)
+	}
+	s.FacilityIDs = dedupeStrings(s.FacilityIDs)
+	for _, facilityID := range s.FacilityIDs {
+		if _, ok := tx.state.facilities[facilityID]; !ok {
+			return SupplyItem{}, fmt.Errorf("facility %q not found for supply item", facilityID)
+		}
+	}
+	s.ProjectIDs = dedupeStrings(s.ProjectIDs)
+	for _, projectID := range s.ProjectIDs {
+		if _, ok := tx.state.projects[projectID]; !ok {
+			return SupplyItem{}, fmt.Errorf("project %q not found for supply item", projectID)
+		}
 	}
 	s.CreatedAt = tx.now
 	s.UpdatedAt = tx.now
@@ -1063,6 +1641,18 @@ func (tx *transaction) UpdateSupplyItem(id string, mutator func(*SupplyItem) err
 	before := cloneSupplyItem(current)
 	if err := mutator(&current); err != nil {
 		return SupplyItem{}, err
+	}
+	current.FacilityIDs = dedupeStrings(current.FacilityIDs)
+	for _, facilityID := range current.FacilityIDs {
+		if _, ok := tx.state.facilities[facilityID]; !ok {
+			return SupplyItem{}, fmt.Errorf("facility %q not found for supply item", facilityID)
+		}
+	}
+	current.ProjectIDs = dedupeStrings(current.ProjectIDs)
+	for _, projectID := range current.ProjectIDs {
+		if _, ok := tx.state.projects[projectID]; !ok {
+			return SupplyItem{}, fmt.Errorf("project %q not found for supply item", projectID)
+		}
 	}
 	if current.Attributes == nil {
 		current.Attributes = map[string]any{}

--- a/internal/infra/persistence/sqlite/memstore_test.go
+++ b/internal/infra/persistence/sqlite/memstore_test.go
@@ -121,3 +121,79 @@ func TestMemStoreViewSnapshotReduced(t *testing.T) {
 		t.Fatalf("view: %v", err)
 	}
 }
+
+func TestMigrateSnapshotRelationships(t *testing.T) {
+	store := newMemStore(nil)
+	now := time.Now().UTC()
+
+	organisms := map[string]domain.Organism{
+		"org-1": {Base: domain.Base{ID: "org-1"}, Name: "Org", Species: "Spec"},
+	}
+	cohorts := map[string]domain.Cohort{
+		"cohort-1": {Base: domain.Base{ID: "cohort-1"}, Name: "Cohort"},
+	}
+	protocols := map[string]domain.Protocol{
+		"prot-1": {Base: domain.Base{ID: "prot-1"}, Code: "PR", Title: "Protocol", MaxSubjects: 10, Status: "active"},
+	}
+	procedures := map[string]domain.Procedure{
+		"proc-1": {Base: domain.Base{ID: "proc-1"}, Name: "Proc", Status: "scheduled", ScheduledAt: now, ProtocolID: "prot-1", OrganismIDs: []string{"org-1"}},
+	}
+
+	snapshot := Snapshot{
+		Organisms: organisms,
+		Cohorts:   cohorts,
+		Housing: map[string]domain.HousingUnit{
+			"house-1": {Base: domain.Base{ID: "house-1"}, Name: "Housing", FacilityID: "fac-1", Capacity: 2},
+		},
+		Facilities: map[string]domain.Facility{
+			"fac-1": {Base: domain.Base{ID: "fac-1"}, Name: "Facility"},
+		},
+		Procedures: procedures,
+		Treatments: map[string]domain.Treatment{
+			"treat-1": {Base: domain.Base{ID: "treat-1"}, Name: "Treat", ProcedureID: "proc-1", OrganismIDs: []string{"org-1", "org-1"}, CohortIDs: []string{"missing"}},
+		},
+		Observations: map[string]domain.Observation{
+			"obs-1": {Base: domain.Base{ID: "obs-1"}, ProcedureID: ptr("proc-1"), Observer: "Tech", RecordedAt: now},
+		},
+		Samples: map[string]domain.Sample{
+			"sample-1": {Base: domain.Base{ID: "sample-1"}, Identifier: "S1", SourceType: "blood", FacilityID: "fac-1", OrganismID: ptr("org-1"), CollectedAt: now, Status: "stored", StorageLocation: "freezer"},
+		},
+		Protocols: protocols,
+		Permits: map[string]domain.Permit{
+			"permit-1": {Base: domain.Base{ID: "permit-1"}, PermitNumber: "P1", Authority: "Gov", ValidFrom: now, ValidUntil: now.AddDate(1, 0, 0), FacilityIDs: []string{"fac-1", "fac-1"}, ProtocolIDs: []string{"prot-1"}},
+		},
+		Projects: map[string]domain.Project{
+			"proj-1": {Base: domain.Base{ID: "proj-1"}, Code: "P1", Title: "Project", FacilityIDs: []string{"fac-1", "fac-1"}},
+		},
+		Supplies: map[string]domain.SupplyItem{
+			"supply-1": {Base: domain.Base{ID: "supply-1"}, SKU: "SKU", Name: "Gloves", QuantityOnHand: 5, Unit: "box", FacilityIDs: []string{"fac-1"}, ProjectIDs: []string{"proj-1", "proj-1"}},
+		},
+	}
+
+	store.ImportState(snapshot)
+
+	facility, ok := store.GetFacility("fac-1")
+	if !ok {
+		t.Fatalf("expected facility present")
+	}
+	if len(facility.HousingUnitIDs) != 1 || facility.HousingUnitIDs[0] != "house-1" {
+		t.Fatalf("expected facility housing ids migrated, got %+v", facility.HousingUnitIDs)
+	}
+	if len(facility.ProjectIDs) != 1 || facility.ProjectIDs[0] != "proj-1" {
+		t.Fatalf("expected facility project ids migrated, got %+v", facility.ProjectIDs)
+	}
+
+	if treatments := store.ListTreatments(); len(treatments) != 1 || len(treatments[0].OrganismIDs) != 1 || treatments[0].OrganismIDs[0] != "org-1" {
+		t.Fatalf("expected deduped treatment organism ids, got %+v", treatments)
+	}
+
+	if permits := store.ListPermits(); len(permits) != 1 || len(permits[0].FacilityIDs) != 1 || permits[0].FacilityIDs[0] != "fac-1" {
+		t.Fatalf("expected permit facility ids filtered, got %+v", permits)
+	}
+
+	if supplies := store.ListSupplyItems(); len(supplies) != 1 || len(supplies[0].ProjectIDs) != 1 || supplies[0].ProjectIDs[0] != "proj-1" {
+		t.Fatalf("expected supply project ids filtered, got %+v", supplies)
+	}
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/internal/integration/relationship_test.go
+++ b/internal/integration/relationship_test.go
@@ -1,0 +1,355 @@
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	core "colonycore/internal/core"
+	domain "colonycore/pkg/domain"
+)
+
+func TestIntegrationEntityRelationships(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	coreVariants := []struct {
+		name string
+		open func(t *testing.T) domain.PersistentStore
+	}{
+		{
+			name: "memory-store",
+			open: func(_ *testing.T) domain.PersistentStore {
+				return core.NewMemoryStore(core.NewDefaultRulesEngine())
+			},
+		},
+		{
+			name: "sqlite-store",
+			open: func(t *testing.T) domain.PersistentStore {
+				path := t.TempDir() + "/relationships.db"
+				store, err := core.NewSQLiteStore(path, core.NewDefaultRulesEngine())
+				if err != nil {
+					t.Fatalf("new sqlite store: %v", err)
+				}
+				return store
+			},
+		},
+	}
+
+	for _, variant := range coreVariants {
+		t.Run(variant.name, func(t *testing.T) {
+			store := variant.open(t)
+			svc := core.NewService(store)
+
+			facility, res, err := svc.CreateFacility(ctx, domain.Facility{
+				Name:         "Facility A",
+				Zone:         "zone-a",
+				AccessPolicy: "standard",
+			})
+			if err != nil {
+				t.Fatalf("create facility: %v", err)
+			}
+			if res.HasBlocking() {
+				t.Fatalf("unexpected facility violations: %+v", res.Violations)
+			}
+
+			if _, _, err := svc.CreateHousingUnit(ctx, domain.HousingUnit{
+				Name:       "Invalid Housing",
+				FacilityID: "missing-facility",
+				Capacity:   1,
+			}); err == nil {
+				t.Fatalf("expected housing creation to fail for missing facility")
+			}
+
+			housing, res, err := svc.CreateHousingUnit(ctx, domain.HousingUnit{
+				Name:        "Housing-1",
+				FacilityID:  facility.ID,
+				Capacity:    2,
+				Environment: "dry",
+			})
+			if err != nil {
+				t.Fatalf("create housing: %v", err)
+			}
+			if res.HasBlocking() {
+				t.Fatalf("unexpected housing violations: %+v", res.Violations)
+			}
+
+			if _, err := svc.DeleteFacility(ctx, facility.ID); err == nil {
+				t.Fatalf("expected facility delete to fail while housing exists")
+			}
+
+			project, res, err := svc.CreateProject(ctx, domain.Project{
+				Code:        "PROJ-1",
+				Title:       "Project 1",
+				Description: "linked to facility",
+				FacilityIDs: []string{facility.ID},
+			})
+			if err != nil {
+				t.Fatalf("create project: %v", err)
+			}
+			if res.HasBlocking() {
+				t.Fatalf("unexpected project violations: %+v", res.Violations)
+			}
+
+			protocol, res, err := svc.CreateProtocol(ctx, domain.Protocol{
+				Code:        "PR-1",
+				Title:       "Protocol 1",
+				Description: "baseline protocol",
+				MaxSubjects: 10,
+				Status:      "active",
+			})
+			if err != nil {
+				t.Fatalf("create protocol: %v", err)
+			}
+			if res.HasBlocking() {
+				t.Fatalf("unexpected protocol violations: %+v", res.Violations)
+			}
+
+			organism, res, err := svc.CreateOrganism(ctx, domain.Organism{
+				Name:    "Specimen-1",
+				Species: "Testus example",
+			})
+			if err != nil {
+				t.Fatalf("create organism: %v", err)
+			}
+			if res.HasBlocking() {
+				t.Fatalf("unexpected organism violations: %+v", res.Violations)
+			}
+
+			procedure, res, err := svc.CreateProcedure(ctx, domain.Procedure{
+				Name:        "Procedure-1",
+				Status:      "scheduled",
+				ScheduledAt: now,
+				ProtocolID:  protocol.ID,
+				OrganismIDs: []string{organism.ID},
+			})
+			if err != nil {
+				t.Fatalf("create procedure: %v", err)
+			}
+			if res.HasBlocking() {
+				t.Fatalf("unexpected procedure violations: %+v", res.Violations)
+			}
+
+			if _, _, err := svc.CreateTreatment(ctx, domain.Treatment{
+				Name:        "InvalidTreatment",
+				ProcedureID: "missing-procedure",
+			}); err == nil {
+				t.Fatalf("expected treatment creation to fail for missing procedure")
+			}
+
+			treatment, res, err := svc.CreateTreatment(ctx, domain.Treatment{
+				Name:        "Treatment-1",
+				ProcedureID: procedure.ID,
+				OrganismIDs: []string{organism.ID, organism.ID},
+				DosagePlan:  "Plan A",
+			})
+			if err != nil {
+				t.Fatalf("create treatment: %v", err)
+			}
+			if res.HasBlocking() {
+				t.Fatalf("unexpected treatment violations: %+v", res.Violations)
+			}
+
+			if _, _, err := svc.CreateObservation(ctx, domain.Observation{
+				Observer:   "Tech",
+				RecordedAt: now,
+				Notes:      "missing context",
+			}); err == nil {
+				t.Fatalf("expected observation creation to fail without context")
+			}
+
+			procedureID := procedure.ID
+			observation, res, err := svc.CreateObservation(ctx, domain.Observation{
+				ProcedureID: &procedureID,
+				Observer:    "Tech",
+				RecordedAt:  now,
+				Data:        map[string]any{"weight": 12.5},
+				Notes:       "baseline observation",
+			})
+			if err != nil {
+				t.Fatalf("create observation: %v", err)
+			}
+			if res.HasBlocking() {
+				t.Fatalf("unexpected observation violations: %+v", res.Violations)
+			}
+
+			if _, err := svc.DeleteProcedure(ctx, procedure.ID); err == nil {
+				t.Fatalf("expected procedure delete to fail while attachments exist")
+			}
+
+			organismID := organism.ID
+			if _, _, err := svc.CreateSample(ctx, domain.Sample{
+				Identifier:      "S-Invalid",
+				SourceType:      "blood",
+				FacilityID:      "missing-facility",
+				OrganismID:      &organismID,
+				CollectedAt:     now,
+				Status:          "stored",
+				StorageLocation: "freezer-a",
+			}); err == nil {
+				t.Fatalf("expected sample creation to fail for missing facility")
+			}
+
+			if _, _, err := svc.CreateSample(ctx, domain.Sample{
+				Identifier:      "S-NoLink",
+				SourceType:      "blood",
+				FacilityID:      facility.ID,
+				CollectedAt:     now,
+				Status:          "stored",
+				StorageLocation: "freezer-a",
+			}); err == nil {
+				t.Fatalf("expected sample creation to fail without organism or cohort")
+			}
+
+			validSample, res, err := svc.CreateSample(ctx, domain.Sample{
+				Identifier:      "S-1",
+				SourceType:      "blood",
+				FacilityID:      facility.ID,
+				OrganismID:      &organismID,
+				CollectedAt:     now,
+				Status:          "stored",
+				StorageLocation: "freezer-a",
+			})
+			if err != nil {
+				t.Fatalf("create sample: %v", err)
+			}
+			if res.HasBlocking() {
+				t.Fatalf("unexpected sample violations: %+v", res.Violations)
+			}
+
+			if _, _, err := svc.CreatePermit(ctx, domain.Permit{
+				PermitNumber: "PERM-ERR",
+				Authority:    "Gov",
+				ValidFrom:    now,
+				ValidUntil:   now.AddDate(1, 0, 0),
+				FacilityIDs:  []string{facility.ID},
+				ProtocolIDs:  []string{"missing-protocol"},
+			}); err == nil {
+				t.Fatalf("expected permit creation to fail for missing protocol")
+			}
+
+			permit, res, err := svc.CreatePermit(ctx, domain.Permit{
+				PermitNumber:      "PERM-1",
+				Authority:         "Gov",
+				ValidFrom:         now,
+				ValidUntil:        now.AddDate(1, 0, 0),
+				AllowedActivities: []string{"activity"},
+				FacilityIDs:       []string{facility.ID, facility.ID},
+				ProtocolIDs:       []string{protocol.ID},
+			})
+			if err != nil {
+				t.Fatalf("create permit: %v", err)
+			}
+			if res.HasBlocking() {
+				t.Fatalf("unexpected permit violations: %+v", res.Violations)
+			}
+
+			if _, _, err := svc.CreateSupplyItem(ctx, domain.SupplyItem{
+				SKU:            "SKU-ERR",
+				Name:           "Gloves",
+				Description:    "invalid project reference",
+				QuantityOnHand: 5,
+				Unit:           "box",
+				FacilityIDs:    []string{facility.ID},
+				ProjectIDs:     []string{"missing-project"},
+			}); err == nil {
+				t.Fatalf("expected supply item creation to fail for missing project")
+			}
+
+			supply, res, err := svc.CreateSupplyItem(ctx, domain.SupplyItem{
+				SKU:            "SKU-1",
+				Name:           "Gloves",
+				Description:    "valid supply",
+				QuantityOnHand: 25,
+				Unit:           "box",
+				FacilityIDs:    []string{facility.ID},
+				ProjectIDs:     []string{project.ID},
+				ReorderLevel:   5,
+			})
+			if err != nil {
+				t.Fatalf("create supply: %v", err)
+			}
+			if res.HasBlocking() {
+				t.Fatalf("unexpected supply violations: %+v", res.Violations)
+			}
+
+			if _, err := svc.DeleteProject(ctx, project.ID); err == nil {
+				t.Fatalf("expected project delete to fail while supply exists")
+			}
+
+			if res, err := svc.DeleteSupplyItem(ctx, supply.ID); err != nil {
+				t.Fatalf("delete supply: %v", err)
+			} else if res.HasBlocking() {
+				t.Fatalf("unexpected supply delete violations: %+v", res.Violations)
+			}
+
+			if res, err := svc.DeleteProject(ctx, project.ID); err != nil {
+				t.Fatalf("delete project: %v", err)
+			} else if res.HasBlocking() {
+				t.Fatalf("unexpected project delete violations: %+v", res.Violations)
+			}
+
+			if _, err := svc.DeleteOrganism(ctx, organism.ID); err == nil {
+				t.Fatalf("expected organism delete to fail while sample exists")
+			}
+
+			if res, err := svc.DeleteSample(ctx, validSample.ID); err != nil {
+				t.Fatalf("delete sample: %v", err)
+			} else if res.HasBlocking() {
+				t.Fatalf("unexpected sample delete violations: %+v", res.Violations)
+			}
+
+			if res, err := svc.DeleteOrganism(ctx, organism.ID); err != nil {
+				t.Fatalf("delete organism: %v", err)
+			} else if res.HasBlocking() {
+				t.Fatalf("unexpected organism delete violations: %+v", res.Violations)
+			}
+
+			if res, err := svc.DeleteObservation(ctx, observation.ID); err != nil {
+				t.Fatalf("delete observation: %v", err)
+			} else if res.HasBlocking() {
+				t.Fatalf("unexpected observation delete violations: %+v", res.Violations)
+			}
+
+			if res, err := svc.DeleteTreatment(ctx, treatment.ID); err != nil {
+				t.Fatalf("delete treatment: %v", err)
+			} else if res.HasBlocking() {
+				t.Fatalf("unexpected treatment delete violations: %+v", res.Violations)
+			}
+
+			if res, err := svc.DeleteProcedure(ctx, procedure.ID); err != nil {
+				t.Fatalf("delete procedure: %v", err)
+			} else if res.HasBlocking() {
+				t.Fatalf("unexpected procedure delete violations: %+v", res.Violations)
+			}
+
+			if _, err := svc.DeleteProtocol(ctx, protocol.ID); err == nil {
+				t.Fatalf("expected protocol delete to fail while permit exists")
+			}
+
+			if res, err := svc.DeletePermit(ctx, permit.ID); err != nil {
+				t.Fatalf("delete permit: %v", err)
+			} else if res.HasBlocking() {
+				t.Fatalf("unexpected permit delete violations: %+v", res.Violations)
+			}
+
+			if res, err := svc.DeleteProtocol(ctx, protocol.ID); err != nil {
+				t.Fatalf("delete protocol: %v", err)
+			} else if res.HasBlocking() {
+				t.Fatalf("unexpected protocol delete violations: %+v", res.Violations)
+			}
+
+			if res, err := svc.DeleteHousingUnit(ctx, housing.ID); err != nil {
+				t.Fatalf("delete housing: %v", err)
+			} else if res.HasBlocking() {
+				t.Fatalf("unexpected housing delete violations: %+v", res.Violations)
+			}
+
+			if res, err := svc.DeleteFacility(ctx, facility.ID); err != nil {
+				t.Fatalf("delete facility: %v", err)
+			} else if res.HasBlocking() {
+				t.Fatalf("unexpected facility delete violations: %+v", res.Violations)
+			}
+		})
+	}
+}

--- a/internal/integration/smoke_test.go
+++ b/internal/integration/smoke_test.go
@@ -74,8 +74,12 @@ func TestIntegrationSmoke(t *testing.T) {
 		t.Run(cv.name, func(t *testing.T) {
 			store := cv.open(t)
 			svc := core.NewService(store)
+			facility, _, err := svc.CreateFacility(ctx, domain.Facility{Name: "Lab"})
+			if err != nil {
+				t.Fatalf("create facility: %v", err)
+			}
 			// Write one housing unit and one organism referencing it.
-			created, res, err := svc.CreateHousingUnit(ctx, domain.HousingUnit{Name: "Tank", FacilityID: "Lab", Capacity: 1})
+			created, res, err := svc.CreateHousingUnit(ctx, domain.HousingUnit{Name: "Tank", FacilityID: facility.ID, Capacity: 1})
 			if err != nil {
 				t.Fatalf("create housing: %v", err)
 			}

--- a/pkg/datasetapi/facade_accessors_extra_test.go
+++ b/pkg/datasetapi/facade_accessors_extra_test.go
@@ -1,0 +1,102 @@
+package datasetapi
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSupplyItemAccessors(t *testing.T) {
+	now := time.Now().UTC()
+	expires := now.Add(24 * time.Hour)
+
+	data := SupplyItemData{
+		Base:           BaseData{ID: "supply", CreatedAt: now, UpdatedAt: now},
+		SKU:            "SKU-1",
+		Name:           "Supply",
+		Description:    "desc",
+		QuantityOnHand: 2,
+		Unit:           "box",
+		LotNumber:      "LOT",
+		ExpiresAt:      &expires,
+		FacilityIDs:    []string{"fac"},
+		ProjectIDs:     []string{"proj"},
+		ReorderLevel:   5,
+		Attributes:     map[string]any{"color": "blue"},
+	}
+
+	item := NewSupplyItem(data)
+
+	if ids := item.FacilityIDs(); len(ids) != 1 || ids[0] != "fac" {
+		t.Fatalf("facility ids mismatch: %+v", ids)
+	}
+	ids := item.ProjectIDs()
+	if len(ids) != 1 || ids[0] != "proj" {
+		t.Fatalf("project ids mismatch: %+v", ids)
+	}
+	if lvl := item.ReorderLevel(); lvl != 5 {
+		t.Fatalf("expected reorder level 5, got %d", lvl)
+	}
+	if attr := item.Attributes(); attr["color"] != "blue" {
+		t.Fatalf("expected attribute clone, got %+v", attr)
+	} else {
+		attr["color"] = "red"
+	}
+	if attr := item.Attributes(); attr["color"] != "blue" {
+		t.Fatalf("expected attributes to be cloned, got %+v", attr)
+	}
+
+	if exp, ok := item.ExpiresAt(); !ok || exp == nil || !exp.Equal(expires) {
+		t.Fatalf("expected expires at %v, got %v ok=%v", expires, exp, ok)
+	}
+	status := item.GetInventoryStatus(now)
+	if !status.RequiresReorder() {
+		t.Fatalf("expected inventory status to require reorder")
+	}
+	if !item.RequiresReorder(now) {
+		t.Fatalf("expected RequiresReorder to be true")
+	}
+	if item.IsExpired(now) {
+		t.Fatalf("expected supply not to be expired at current time")
+	}
+	if !item.IsExpired(expires.Add(48 * time.Hour)) {
+		t.Fatalf("expected supply to be expired after expiration time")
+	}
+}
+
+func TestPermitAccessors(t *testing.T) {
+	now := time.Now().UTC()
+	until := now.Add(48 * time.Hour)
+
+	data := PermitData{
+		Base:              BaseData{ID: "permit", CreatedAt: now, UpdatedAt: now},
+		PermitNumber:      "PERM-1",
+		Authority:         "Gov",
+		ValidFrom:         now,
+		ValidUntil:        until,
+		AllowedActivities: []string{"collect"},
+		FacilityIDs:       []string{"fac"},
+		ProtocolIDs:       []string{"prot"},
+		Notes:             "note",
+	}
+
+	permit := NewPermit(data)
+
+	if ids := permit.FacilityIDs(); len(ids) != 1 || ids[0] != "fac" {
+		t.Fatalf("facility ids mismatch: %+v", ids)
+	}
+	if ids := permit.ProtocolIDs(); len(ids) != 1 || ids[0] != "prot" {
+		t.Fatalf("protocol ids mismatch: %+v", ids)
+	}
+	if vf := permit.ValidFrom(); !vf.Equal(now) {
+		t.Fatalf("expected valid from %v, got %v", now, vf)
+	}
+	if vu := permit.ValidUntil(); !vu.Equal(until) {
+		t.Fatalf("expected valid until %v, got %v", until, vu)
+	}
+	if permit.IsExpired(now) {
+		t.Fatalf("expected permit active at current time")
+	}
+	if !permit.IsExpired(until.Add(24 * time.Hour)) {
+		t.Fatalf("expected permit expired after valid until")
+	}
+}


### PR DESCRIPTION
## What  
<!-- Describe the change. -->

Introduce migrations and integration tests ensuring HousingUnits reference Facility IDs (and enforce cascade checks), Procedures can attach Treatments/Observations, Samples relate to Organisms/Cohorts, Protocols link to Permits, and SupplyItems tie into Projects/Facilities.

## Why  
<!-- What's the motivation. -->

Working on #66 

## How  
<!-- Bullet list or description of key changes. -->

* Require facilities for housing/samples/supplies
* Migrate legacy snapshots
* Add service wrappers
* Add integration and datastore tests covering relationship cascades, facade accessors, and dedupe paths

## Notes  
<!-- Breaking changes or follow-ups (if any). -->

## Checklist  

- [x] I have used conventional commits (conventionalcommits.com)
- [ ] I have updated the documentation
- [ ] I have updated the relevant RFC and its linked resources
- [x] I have added tests
- [x] I ran manual tests